### PR TITLE
Optimize process listing for Unix without /proc (OS X)

### DIFF
--- a/attach/attachdialog.cpp
+++ b/attach/attachdialog.cpp
@@ -73,7 +73,7 @@ AttachDialog::AttachDialog(QWidget *parent, Qt::WindowFlags f)
   m_timer->start(1000);
 
   // set process list syncronously the first time
-  m_model->setProcesses(processList());
+  m_model->setProcesses(processList(m_model->processes()));
   selectionChanged();
 }
 
@@ -92,7 +92,7 @@ void AttachDialog::updateProcesses()
   QFutureWatcher<ProcDataList>* watcher = new QFutureWatcher<ProcDataList>(this);
   connect(watcher, SIGNAL(finished()),
           this, SLOT(updateProcessesFinished()));
-  watcher->setFuture(QtConcurrent::run(processList));
+  watcher->setFuture(QtConcurrent::run(processList, m_model->processes()));
 }
 
 void AttachDialog::updateProcessesFinished()

--- a/attach/attachdialog.h
+++ b/attach/attachdialog.h
@@ -26,6 +26,7 @@
 
 #include <QDialog>
 
+#include "processlist.h"
 #include "ui_attachdialog.h"
 
 namespace GammaRay {

--- a/attach/processlist.h
+++ b/attach/processlist.h
@@ -58,6 +58,6 @@ struct ProcData
 
 typedef QList<ProcData> ProcDataList;
 
-extern ProcDataList processList();
+extern ProcDataList processList(const ProcDataList& previous);
 
 #endif // PROCESSLIST_H

--- a/attach/processmodel.cpp
+++ b/attach/processmodel.cpp
@@ -189,3 +189,7 @@ int ProcessModel::rowCount(const QModelIndex &parent) const
   return parent.isValid() ? 0 : m_data.count();
 }
 
+ProcDataList ProcessModel::processes() const
+{
+  return m_data;
+}

--- a/attach/processmodel.h
+++ b/attach/processmodel.h
@@ -42,6 +42,8 @@ class ProcessModel : public QAbstractTableModel
     ProcData dataForRow(int row) const;
     QModelIndex indexForPid(const QString &pid) const;
 
+    ProcDataList processes() const;
+
     void clear();
 
     enum Columns {


### PR DESCRIPTION
Do not rerun lsof for known processes.
Instead look up "isQtApp" property in previous process listing if process was already examined.
Reduces recurrent process listings (but no the first) from about 50 seconds to about 20 milliseconds for me.
