### PR TITLE
Split up gammaray_probe

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(tools)
-
 include_directories(
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/3rdparty
@@ -179,20 +177,25 @@ qt4_wrap_ui(gammaray_srcs
 qt4_add_resources(gammaray_srcs ${CMAKE_SOURCE_DIR}/resources/gammaray.qrc)
 
 add_definitions(-DMAKE_GAMMARAY_LIB)
-add_library(gammaray_probe SHARED ${gammaray_srcs})
+
+# core lib
+add_library(gammaray_core SHARED
+  ${gammaray_srcs}
+)
 
 if(Qt5Core_FOUND)
-  target_link_libraries(gammaray_probe Qt5::Widgets)
+  target_link_libraries(gammaray_core Qt5::Widgets)
 else()
-  target_link_libraries(gammaray_probe
+  target_link_libraries(gammaray_core
     ${QT_QTCORE_LIBRARIES}
     ${QT_QTGUI_LIBRARIES}
   )
 endif()
 
 if(NOT WIN32)
-  target_link_libraries(gammaray_probe dl)
+  target_link_libraries(gammaray_core dl)
 endif()
-set_target_properties(gammaray_probe PROPERTIES PREFIX "")
+install(TARGETS gammaray_core ${INSTALL_TARGETS_DEFAULT_ARGS})
 
-install(TARGETS gammaray_probe ${INSTALL_TARGETS_DEFAULT_ARGS})
+add_subdirectory(hooking)
+add_subdirectory(tools)

--- a/core/connectionmodel.cpp
+++ b/core/connectionmodel.cpp
@@ -121,7 +121,7 @@ void ConnectionModel::connectionAddedMainThread(QObject *sender, const char *sig
   c.receiver = receiver;
   c.method = QMetaObject::normalizedSignature(method);
   c.type = type;
-  c.location = Probe::connectLocation(signal);
+  c.location = SignalSlotsLocationStore::extractLocation(signal);
 
   // check if that's actually a valid connection
   if (checkMethodForObject(sender, c.signal, true) &&

--- a/core/hooking/CMakeLists.txt
+++ b/core/hooking/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Enable RPATH, make gammaray_probe find gammaray_core (same directory)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+include_directories(
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+set(gammaray_probe_srcs
+  abstractfunctionoverwriter.cpp
+  functionoverwriterfactory.cpp
+  winfunctionoverwriter.cpp
+  unixfunctionoverwriter.cpp
+  probecreator.cpp
+  hooks.cpp
+)
+
+# probe lib
+qt4_automoc(${gammaray_probe_srcs})
+add_library(gammaray_probe SHARED ${gammaray_probe_srcs})
+target_link_libraries(gammaray_probe
+  gammaray_core
+)
+set_target_properties(gammaray_probe PROPERTIES PREFIX "")
+install(TARGETS gammaray_probe ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/core/hooking/hooks.cpp
+++ b/core/hooking/hooks.cpp
@@ -1,0 +1,205 @@
+/*
+  hooks.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2012 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "probe.h"
+#include "functionoverwriterfactory.h"
+#include "probecreator.h"
+
+#include <QCoreApplication>
+
+#ifndef Q_OS_WIN
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif
+
+#include <stdio.h>
+#include <cassert>
+
+#ifdef Q_OS_MAC
+#include <dlfcn.h>
+#include <inttypes.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/errno.h>
+#endif
+
+#define IF_DEBUG(x)
+
+using namespace GammaRay;
+
+bool functionsOverwritten = false;
+
+extern "C" Q_DECL_EXPORT void qt_startup_hook()
+{
+  Probe::startupHookReceived();
+
+  new ProbeCreator(ProbeCreator::CreateOnly);
+#if !defined Q_OS_WIN && !defined Q_OS_MAC
+  if (!functionsOverwritten) {
+    static void(*next_qt_startup_hook)() = (void (*)()) dlsym(RTLD_NEXT, "qt_startup_hook");
+    next_qt_startup_hook();
+  }
+#endif
+}
+
+extern "C" Q_DECL_EXPORT void qt_addObject(QObject *obj)
+{
+  if (!Probe::isInitialized()) {
+    IF_DEBUG(cout
+             << "objectAdded Before: "
+             << hex << obj
+             << (fromCtor ? " (from ctor)" : "") << endl;)
+    ProbeCreator::trackObject(obj);
+  } else {
+    Probe::objectAdded(obj, true);
+  }
+
+#if !defined Q_OS_WIN && !defined Q_OS_MAC
+  if (!functionsOverwritten) {
+    static void (*next_qt_addObject)(QObject *obj) =
+      (void (*)(QObject *obj)) dlsym(RTLD_NEXT, "qt_addObject");
+    next_qt_addObject(obj);
+  }
+#endif
+}
+
+extern "C" Q_DECL_EXPORT void qt_removeObject(QObject *obj)
+{
+  if (!Probe::isInitialized()) {
+    ProbeCreator::untrackObject(obj);
+  } else {
+    Probe::objectRemoved(obj);
+  }
+
+#if !defined Q_OS_WIN && !defined Q_OS_MAC
+  if (!functionsOverwritten) {
+    static void (*next_qt_removeObject)(QObject *obj) =
+      (void (*)(QObject *obj)) dlsym(RTLD_NEXT, "qt_removeObject");
+    next_qt_removeObject(obj);
+  }
+#endif
+}
+
+#ifndef GAMMARAY_UNKNOWN_CXX_MANGLED_NAMES
+#ifndef Q_OS_WIN
+Q_DECL_EXPORT const char *qFlagLocation(const char *method)
+#else
+Q_DECL_EXPORT const char *myFlagLocation(const char *method)
+#endif
+{
+  SignalSlotsLocationStore::flagLocation(method);
+
+#ifndef Q_OS_WIN
+  static const char *(*next_qFlagLocation)(const char *method) =
+    (const char * (*)(const char *method)) dlsym(RTLD_NEXT, "_Z13qFlagLocationPKc");
+
+  Q_ASSERT_X(next_qFlagLocation, "",
+             "Recompile with GAMMARAY_UNKNOWN_CXX_MANGLED_NAMES enabled, "
+             "your compiler uses an unsupported C++ name mangling scheme");
+  return next_qFlagLocation(method);
+#else
+  return method;
+#endif
+}
+#endif
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+void overwriteQtFunctions()
+{
+  functionsOverwritten = true;
+  AbstractFunctionOverwriter *overwriter = FunctionOverwriterFactory::createFunctionOverwriter();
+
+  overwriter->overwriteFunction(QLatin1String("qt_startup_hook"), (void*)qt_startup_hook);
+  overwriter->overwriteFunction(QLatin1String("qt_addObject"), (void*)qt_addObject);
+  overwriter->overwriteFunction(QLatin1String("qt_removeObject"), (void*)qt_removeObject);
+#if defined(Q_OS_WIN)
+#ifdef ARCH_64
+#ifdef __MINGW32__
+  overwriter->overwriteFunction(
+    QLatin1String("_Z13qFlagLocationPKc"), (void*)myFlagLocation);
+#else
+  overwriter->overwriteFunction(
+    QLatin1String("?qFlagLocation@@YAPEBDPEBD@Z"), (void*)myFlagLocation);
+#endif
+#else
+# ifdef __MINGW32__
+  overwriter->overwriteFunction(
+    QLatin1String("_Z13qFlagLocationPKc"), (void*)myFlagLocation);
+# else
+  overwriter->overwriteFunction(
+    QLatin1String("?qFlagLocation@@YAPBDPBD@Z"), (void*)myFlagLocation);
+# endif
+#endif
+#endif
+}
+#endif
+
+#ifdef Q_OS_WIN
+extern "C" Q_DECL_EXPORT void gammaray_probe_inject();
+
+extern "C" BOOL WINAPI DllMain(HINSTANCE/*hInstance*/, DWORD dwReason, LPVOID/*lpvReserved*/)
+{
+  switch(dwReason) {
+  case DLL_PROCESS_ATTACH:
+  {
+    overwriteQtFunctions();
+
+    gammaray_probe_inject();
+    break;
+  }
+  case DLL_PROCESS_DETACH:
+  {
+      //Unloading does not work, because we overwrite existing code
+      exit(-1);
+      break;
+  }
+  };
+  return TRUE;
+}
+#endif
+
+extern "C" Q_DECL_EXPORT void gammaray_probe_inject()
+{
+  if (!qApp) {
+    return;
+  }
+  printf("gammaray_probe_inject()\n");
+  // make it possible to re-attach
+  new ProbeCreator(ProbeCreator::CreateAndFindExisting);
+}
+
+#ifdef Q_OS_MAC
+// we need a way to execute some code upon load, so let's abuse
+// static initialization
+class HitMeBabyOneMoreTime
+{
+  public:
+    HitMeBabyOneMoreTime()
+    {
+      overwriteQtFunctions();
+    }
+
+};
+static HitMeBabyOneMoreTime britney;
+#endif

--- a/core/hooking/probecreator.cpp
+++ b/core/hooking/probecreator.cpp
@@ -1,0 +1,111 @@
+/*
+  probecreator.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2012 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Kevin Funk <kevin.funk@kdab.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "probecreator.h"
+
+#include "probe.h"
+
+#include <QApplication>
+#include <QMetaObject>
+#include <QVector>
+#include <QThread>
+
+#include <iostream>
+
+#define IF_DEBUG(x)
+
+using namespace GammaRay;
+using namespace std;
+
+Q_GLOBAL_STATIC(QVector<QObject*>, s_addedBeforeProbeInsertion)
+
+ProbeCreator::ProbeCreator(Type type)
+  : m_type(type)
+{
+  //push object into the main thread, as windows creates a
+  //different thread where this runs in
+  moveToThread(QApplication::instance()->thread());
+  // delay to foreground thread
+  QMetaObject::invokeMethod(this, "createProbe", Qt::QueuedConnection);
+}
+
+void ProbeCreator::trackObject(QObject* object)
+{
+  QWriteLocker lock(Probe::objectLock());
+
+  // need to pay attention if the Probe asked to filter certain objects
+  // e.g. during the construction of the Probe itself
+  if (Probe::filteredThread() == object->thread())
+    return;
+
+  s_addedBeforeProbeInsertion()->push_back(object);
+}
+
+void ProbeCreator::untrackObject(QObject* obj)
+{
+  QWriteLocker lock(Probe::objectLock());
+
+  if (!s_addedBeforeProbeInsertion())
+    return;
+
+  for (QVector<QObject*>::iterator it = s_addedBeforeProbeInsertion()->begin();
+      it != s_addedBeforeProbeInsertion()->end();) {
+    if (*it == obj) {
+      it = s_addedBeforeProbeInsertion()->erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void ProbeCreator::createProbe()
+{
+  QWriteLocker lock(Probe::objectLock());
+  // make sure we are in the ui thread
+  Q_ASSERT(QThread::currentThread() == qApp->thread());
+
+  if (!qApp || Probe::isInitialized()) {
+    // never create it twice
+    return;
+  }
+
+  const bool success = Probe::createProbe();
+  Q_ASSERT(success);
+
+  Q_ASSERT(Probe::instance());
+  QMetaObject::invokeMethod(Probe::instance(), "delayedInit", Qt::QueuedConnection);
+
+  // add objects to the probe that were tracked before its creation
+  foreach (QObject *obj, *(s_addedBeforeProbeInsertion())) {
+    Probe::objectAdded(obj);
+  }
+  s_addedBeforeProbeInsertion()->clear();
+
+  if (m_type == CreateAndFindExisting) {
+    Probe::findExistingObjects();
+  }
+
+  deleteLater();
+}
+
+#include "probecreator.moc"

--- a/core/hooking/probecreator.h
+++ b/core/hooking/probecreator.h
@@ -1,0 +1,56 @@
+/*
+  probecreator.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2012 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Kevin Funk <kevin.funk@kdab.com>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROBECREATOR_H
+#define GAMMARAY_PROBECREATOR_H
+
+#include <QObject>
+
+namespace GammaRay {
+
+/**
+ * Creates Probe instance in main thread and deletes self afterwards.
+ */
+class ProbeCreator : public QObject
+{
+  Q_OBJECT
+  public:
+    enum Type {
+      CreateOnly,
+      CreateAndFindExisting
+    };
+    explicit ProbeCreator(Type t);
+
+    static void trackObject(QObject* object);
+    static void untrackObject(QObject* object);
+
+  private slots:
+    void createProbe();
+
+  private:
+    Type m_type;
+};
+
+}
+
+#endif // GAMMARAY_PROBECREATOR_H

--- a/core/probe.h
+++ b/core/probe.h
@@ -32,38 +32,19 @@
 #include <QReadWriteLock>
 #include <QSet>
 
+class QThread;
 class QPoint;
 class QTimer;
 
 namespace GammaRay {
 
+class ProbeCreator;
 class MetaObjectTreeModel;
-
 class ConnectionModel;
 class ObjectListModel;
 class ObjectTreeModel;
 class ToolModel;
 class MainWindow;
-
-/**
- * Creates Probe instance in main thread and deletes self afterwards.
- */
-class ProbeCreator : public QObject
-{
-  Q_OBJECT
-  public:
-    enum Type {
-      CreateOnly,
-      CreateAndFindExisting
-    };
-    explicit ProbeCreator(Type t);
-
-  private slots:
-    void createProbe();
-
-  private:
-    Type m_type;
-};
 
 class GAMMARAY_EXPORT Probe : public QObject, public ProbeInterface
 {
@@ -101,7 +82,8 @@ class GAMMARAY_EXPORT Probe : public QObject, public ProbeInterface
      * Lock this to check the validity of a QObject
      * and to access it safely afterwards.
      */
-    QReadWriteLock *objectLock() const;
+    static QReadWriteLock *objectLock();
+
     /**
      * check whether @p obj is still valid
      *
@@ -110,6 +92,9 @@ class GAMMARAY_EXPORT Probe : public QObject, public ProbeInterface
     bool isValidObject(QObject *obj) const;
 
     bool filterObject(QObject *obj) const;
+
+    /// internal
+    static void startupHookReceived();
 
   signals:
     /**
@@ -131,7 +116,12 @@ class GAMMARAY_EXPORT Probe : public QObject, public ProbeInterface
     void objectParentChanged();
 
   private:
+    friend class ProbeCreator;
+
+    static QThread* filteredThread();
+
     void objectFullyConstructed(QObject *obj);
+    static bool createProbe();
 
     explicit Probe(QObject *parent = 0);
     static void addObjectRecursive(QObject *obj);
@@ -146,8 +136,16 @@ class GAMMARAY_EXPORT Probe : public QObject, public ProbeInterface
     QSet<QObject*> m_validObjects;
     QQueue<QObject*> m_queuedObjects;
     QTimer *m_queueTimer;
+};
 
-    friend class ProbeCreator;
+class GAMMARAY_EXPORT SignalSlotsLocationStore
+{
+public:
+  /// store the location of @p method
+  static void flagLocation(const char *method);
+
+  /// retrieve the location of @p member
+  static const char *extractLocation(const char *member);
 };
 
 }


### PR DESCRIPTION
Use two libraries approach:
- Gammaray Core: core library
- Gammaray Probe: probe library (with hooks) linked to core library

Benefits:
- Plugins may link to gammaray_core directly
- We can write unit tests that link against gammaray_core
  Benefit: No hooking mechanisms triggered then
- Clearer separation of what belongs to hooking

It is mostly moving around of code, not too many semantic changes.
There _might_ be issues wrt multithreading / missing locks.

TODO:
- Some things are marked with a TODO where I am unsure wrt correctness
- Please review those TODOs ACCURATELY!

---

Milian, Volker: Please review.
