### PR TITLE
respect PLUGIN_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
 
 set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
 set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
-set(PLUGIN_INSTALL_DIR "${LIB_INSTALL_DIR}/qt4/plugins")
+set(PLUGIN_INSTALL_DIR "${LIB_INSTALL_DIR}/qt/plugins")
 
 set(
   INSTALL_TARGETS_DEFAULT_ARGS

--- a/launcher/injector/CMakeLists.txt
+++ b/launcher/injector/CMakeLists.txt
@@ -17,5 +17,5 @@ set_target_properties(gammaray_injector_style
 
 install(
   TARGETS gammaray_injector_style
-  DESTINATION ${LIB_INSTALL_DIR}/qt4/plugins/styles
+  DESTINATION ${PLUGIN_INSTALL_DIR}/styles
 )


### PR DESCRIPTION
Fixes the injector style plugin to respect PLUGIN_INSTALL_DIR upon installation.
This is useful for Archlinux, where Qt plugins get installed under /usr/lib/qt rather than /usr/lib/qt4.
