### PR TITLE
respect PLUGIN_INSTALL_DIR

### DIFF
--- a/launcher/injector/CMakeLists.txt
+++ b/launcher/injector/CMakeLists.txt
@@ -17,5 +17,5 @@ set_target_properties(gammaray_injector_style
 
 install(
   TARGETS gammaray_injector_style
-  DESTINATION ${LIB_INSTALL_DIR}/qt4/plugins/styles
+  DESTINATION ${PLUGIN_INSTALL_DIR}/styles
 )


### PR DESCRIPTION
Fixes the injector style plugin to respect PLUGIN_INSTALL_DIR upon installation.
This is useful for Archlinux, where Qt plugins get installed under /usr/lib/qt rather than /usr/lib/qt4.
