### PR TITLE
Fix build failure on GNU Hurd.

### DIFF
--- a/plugins/timertop/functioncalltimer.cpp
+++ b/plugins/timertop/functioncalltimer.cpp
@@ -26,7 +26,7 @@
 #include <Windows.h>
 #endif
 
-#ifdef __MACH__
+#if defined(Q_OS_MAC) && defined(__MACH__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif


### PR DESCRIPTION
Currently gammaray fails to build on Debian GNU Hurd because it includes
mach headers that seem to be only available on Mac OS.

As the mach functions are only used on Mac OS anyway I added a defined(Q_OS_MAC) check.
