### PR TITLE
Build function overwriter only on Windows and Mac.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -54,11 +54,6 @@ set(gammaray_srcs
   propertyeditor/propertypaletteeditor.cpp
   propertyeditor/palettedialog.cpp
 
-  hooking/abstractfunctionoverwriter.cpp
-  hooking/functionoverwriterfactory.cpp
-  hooking/winfunctionoverwriter.cpp
-  hooking/unixfunctionoverwriter.cpp
-
   tools/modelinspector/modeltester.cpp
   tools/modelinspector/modelmodel.cpp
   tools/modelinspector/modelcellmodel.cpp
@@ -106,6 +101,16 @@ set(gammaray_srcs
   tools/styleinspector/complexcontrolmodel.cpp
   tools/styleinspector/dynamicproxystyle.cpp
 )
+
+if(WIN32 OR APPLE)
+  set(gammaray_srcs
+    ${gammaray_srcs}
+    hooking/abstractfunctionoverwriter.cpp
+    hooking/functionoverwriterfactory.cpp
+    hooking/winfunctionoverwriter.cpp
+    hooking/unixfunctionoverwriter.cpp
+  )
+endif()
 
 if(HAVE_PRIVATE_QT_HEADERS)
   set(gammaray_srcs

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -720,6 +720,7 @@ Q_DECL_EXPORT const char *myFlagLocation(const char *method)
 }
 #endif
 
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
 void overwriteQtFunctions()
 {
   functionsOverwritten = true;
@@ -748,6 +749,7 @@ void overwriteQtFunctions()
 #endif
 #endif
 }
+#endif
 
 #ifdef Q_OS_WIN
 extern "C" Q_DECL_EXPORT void gammaray_probe_inject();


### PR DESCRIPTION
It is not used on GNU/Linux. This patch allows one to build GammaRay also for other architectures than i386 and amd64.
