### PR TITLE
Fix linking with the real VTK libraries

### DIFF
--- a/plugins/objectvisualizer/CMakeLists.txt
+++ b/plugins/objectvisualizer/CMakeLists.txt
@@ -32,6 +32,7 @@ gammaray_add_plugin(gammaray_objectvisualizer_plugin
 target_link_libraries(gammaray_objectvisualizer_plugin
   ${QT_QTCORE_LIBRARIES}
   ${QT_QTGUI_LIBRARIES}
+  ${VTK_LIBRARIES}
   QVTK
   gammaray_probe
 )


### PR DESCRIPTION
Without this patch, linkig fails with the following error:

Linking CXX shared module ../../lib/plugins/gammaray/gammaray_objectvisualizer_plugin.so
cd /home/jkt/work/prog/GammaRay/build/plugins/objectvisualizer && /usr/bin/cmake -E cmake_link_script CMakeFiles/gammaray_objectvisualizer_plugin.dir/link.txt --verbose=1
/usr/bin/c++  -fPIC  -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Wundef -Wpointer-arith -Wcast-qual -Wcast-align -Wmissing-noreturn -Werror=return-type -fvisibility=hidden -Wlogical-op -Wl,--fatal-warnings -Wl,--no-undefined -lc   -shared -Wl,-soname,gammaray_objectvisualizer_plugin.so -o ../../lib/plugins/gammaray/gammaray_objectvisualizer_plugin.so CMakeFiles/gammaray_objectvisualizer_plugin.dir/**/**/3rdparty/kde/kfilterproxysearchline.cpp.o CMakeFiles/gammaray_objectvisualizer_plugin.dir/**/**/3rdparty/kde/krecursivefilterproxymodel.cpp.o CMakeFiles/gammaray_objectvisualizer_plugin.dir/objectvisualizer.cpp.o CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkcontainer.cpp.o CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkpanel.cpp.o CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o /usr/lib64/qt4/libQtCore.so /usr/lib64/qt4/libQtGui.so -lQVTK ../../core/gammaray_probe.so /usr/lib64/qt4/libQtCore.so /usr/lib64/qt4/libQtGui.so -ldl -Wl,-rpath,/usr/lib64/qt4:/home/jkt/work/prog/GammaRay/build/core: 
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkpanel.cpp.o: In function `layoutStrategyForName(QString const&)':
vtkpanel.cpp:(.text+0xb7d): undefined reference to`vtkTreeLayoutStrategy::New()'
vtkpanel.cpp:(.text+0xbc4): undefined reference to `vtkSpanTreeLayoutStrategy::New()'
vtkpanel.cpp:(.text+0xbe5): undefined reference to`vtkForceDirectedLayoutStrategy::New()'
vtkpanel.cpp:(.text+0xc03): undefined reference to `vtkForceDirectedLayoutStrategy::New()'
vtkpanel.cpp:(.text+0xc47): undefined reference to`vtkSimple2DLayoutStrategy::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkpanel.cpp.o: In function `GammaRay::VtkPanel::layoutChanged(int)':
vtkpanel.cpp:(.text+0xd0f): undefined reference to`vtkGraphLayoutView::SetLayoutStrategy(vtkGraphLayoutStrategy_)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkpanel.cpp.o: In function `GammaRay::VtkPanel::stereoModeChanged(int)':
vtkpanel.cpp:(.text+0xe8d): undefined reference to`vtkRenderWindow::SetStereoRender(int)'
vtkpanel.cpp:(.text+0xebe): undefined reference to `vtkRenderWindow::SetStereoRender(int)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`GammaRay::VtkWidget::setupGraph()':
vtkwidget.cpp:(.text+0x5b1): undefined reference to `vtkVariantArray::SetNumberOfValues(long long)'
vtkwidget.cpp:(.text+0x640): undefined reference to`vtkFieldData::AddArray(vtkAbstractArray_)'
vtkwidget.cpp:(.text+0x6b2): undefined reference to `vtkFieldData::AddArray(vtkAbstractArray*)'
vtkwidget.cpp:(.text+0x724): undefined reference to`vtkFieldData::AddArray(vtkAbstractArray_)'
vtkwidget.cpp:(.text+0x795): undefined reference to `vtkGraphLayoutView::New()'
vtkwidget.cpp:(.text+0x7b7): undefined reference to`vtkView::AddRepresentationFromInput(vtkDataObject_)'
vtkwidget.cpp:(.text+0x7c8): undefined reference to `vtkGraphLayoutView::SetVertexLabelVisibility(bool)'
vtkwidget.cpp:(.text+0x7db): undefined reference to`vtkGraphLayoutView::SetVertexLabelArrayName(char const_)'
vtkwidget.cpp:(.text+0x7fa): undefined reference to `vtkGraphLayoutView::SetVertexColorArrayName(char const_)'
vtkwidget.cpp:(.text+0x80b): undefined reference to `vtkGraphLayoutView::SetColorVertices(bool)'
vtkwidget.cpp:(.text+0x89f): undefined reference to`vtkRenderWindowInteractor::SetRenderWindow(vtkRenderWindow_)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `GammaRay::VtkWidget::addObjectInternal(QObject_)':
vtkwidget.cpp:(.text+0xc81): undefined reference to `vtkUnicodeString::from_utf16(unsigned short const*)'
vtkwidget.cpp:(.text+0xc97): undefined reference to`vtkVariant::vtkVariant(vtkUnicodeString const&)'
vtkwidget.cpp:(.text+0xcc0): undefined reference to `vtkVariantArray::SetValue(long long, vtkVariant)'
vtkwidget.cpp:(.text+0xccf): undefined reference to`vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0xcef): undefined reference to `vtkVariant::vtkVariant(int)'
vtkwidget.cpp:(.text+0xd18): undefined reference to`vtkVariantArray::SetValue(long long, vtkVariant)'
vtkwidget.cpp:(.text+0xd27): undefined reference to `vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0xdc9): undefined reference to`vtkVariant::vtkVariant(int)'
vtkwidget.cpp:(.text+0xdf2): undefined reference to `vtkVariantArray::SetValue(long long, vtkVariant)'
vtkwidget.cpp:(.text+0xe01): undefined reference to`vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0xe24): undefined reference to `vtkVariant::vtkVariant(int)'
vtkwidget.cpp:(.text+0xe4d): undefined reference to`vtkVariantArray::SetValue(long long, vtkVariant)'
vtkwidget.cpp:(.text+0xe5c): undefined reference to `vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0xedc): undefined reference to`vtkMutableDirectedGraph::AddVertex(vtkVariantArray_)'
vtkwidget.cpp:(.text+0xfef): undefined reference to `vtkMutableDirectedGraph::AddEdge(long long, long long)'
vtkwidget.cpp:(.text+0x1047): undefined reference to`vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0x106c): undefined reference to `vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0x1080): undefined reference to`vtkVariant::~vtkVariant()'
vtkwidget.cpp:(.text+0x1094): undefined reference to `vtkVariant::~vtkVariant()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`GammaRay::VtkWidget::removeObjectInternal(QObject_)':
vtkwidget.cpp:(.text+0x11e4): undefined reference to `vtkMutableDirectedGraph::RemoveVertex(long long)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkGraphLayoutView::SetLayoutStrategyToSpanTree()':
vtkwidget.cpp:(.text._ZN18vtkGraphLayoutView27SetLayoutStrategyToSpanTreeEv[vtkGraphLayoutView::SetLayoutStrategyToSpanTree()]+0x2a): undefined reference to `vtkGraphLayoutView::SetLayoutStrategy(char const*)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkVariantArray>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI15vtkVariantArrayED2Ev[_ZN15vtkSmartPointerI15vtkVariantArrayED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkMutableDirectedGraph>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI23vtkMutableDirectedGraphED2Ev[_ZN15vtkSmartPointerI23vtkMutableDirectedGraphED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkMutableDirectedGraph>::operator=(vtkSmartPointer<vtkMutableDirectedGraph> const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI23vtkMutableDirectedGraphEaSERKS1_[vtkSmartPointer<vtkMutableDirectedGraph>::operator=(vtkSmartPointer<vtkMutableDirectedGraph> const&)]+0x2e): undefined reference to `vtkSmartPointerBase::operator=(vtkSmartPointerBase const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkVariantArray>::operator=(vtkSmartPointer<vtkVariantArray> const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI15vtkVariantArrayEaSERKS1_[vtkSmartPointer<vtkVariantArray>::operator=(vtkSmartPointer<vtkVariantArray> const&)]+0x2e): undefined reference to `vtkSmartPointerBase::operator=(vtkSmartPointerBase const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkStringArray>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkStringArrayED2Ev[_ZN15vtkSmartPointerI14vtkStringArrayED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkIntArray>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI11vtkIntArrayED2Ev[_ZN15vtkSmartPointerI11vtkIntArrayED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkLookupTable>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkLookupTableED2Ev[_ZN15vtkSmartPointerI14vtkLookupTableED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkViewTheme>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI12vtkViewThemeED2Ev[_ZN15vtkSmartPointerI12vtkViewThemeED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkInteractorStyleTrackballCamera>::~vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI33vtkInteractorStyleTrackballCameraED2Ev[_ZN15vtkSmartPointerI33vtkInteractorStyleTrackballCameraED5Ev]+0x23): undefined reference to `vtkSmartPointerBase::~vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o:vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14QVTKInteractorED2Ev[_ZN15vtkSmartPointerI14QVTKInteractorED5Ev]+0x23): more undefined references to`vtkSmartPointerBase::~vtkSmartPointerBase()' follow
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkVariantArray>::vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI15vtkVariantArrayEC2Ev[_ZN15vtkSmartPointerI15vtkVariantArrayEC5Ev]+0x23): undefined reference to`vtkSmartPointerBase::vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkMutableDirectedGraph>::vtkSmartPointer()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI23vtkMutableDirectedGraphEC2Ev[_ZN15vtkSmartPointerI23vtkMutableDirectedGraphEC5Ev]+0x23): undefined reference to`vtkSmartPointerBase::vtkSmartPointerBase()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkMutableDirectedGraph>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI23vtkMutableDirectedGraphE3NewEv[vtkSmartPointer<vtkMutableDirectedGraph>::New()]+0x21): undefined reference to`vtkMutableDirectedGraph::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkVariantArray>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI15vtkVariantArrayE3NewEv[vtkSmartPointer<vtkVariantArray>::New()]+0x21): undefined reference to`vtkVariantArray::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkStringArray>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkStringArrayE3NewEv[vtkSmartPointer<vtkStringArray>::New()]+0x21): undefined reference to`vtkStringArray::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkIntArray>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI11vtkIntArrayE3NewEv[vtkSmartPointer<vtkIntArray>::New()]+0x21): undefined reference to`vtkIntArray::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkLookupTable>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkLookupTableE3NewEv[vtkSmartPointer<vtkLookupTable>::New()]+0x21): undefined reference to`vtkLookupTable::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkViewTheme>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI12vtkViewThemeE3NewEv[vtkSmartPointer<vtkViewTheme>::New()]+0x21): undefined reference to`vtkViewTheme::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkInteractorStyleTrackballCamera>::New()':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI33vtkInteractorStyleTrackballCameraE3NewEv[vtkSmartPointer<vtkInteractorStyleTrackballCamera>::New()]+0x21): undefined reference to`vtkInteractorStyleTrackballCamera::New()'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkMutableDirectedGraph>::vtkSmartPointer(vtkMutableDirectedGraph*, vtkSmartPointerBase::NoReference const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI23vtkMutableDirectedGraphEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI23vtkMutableDirectedGraphEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): undefined reference to`vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase_, vtkSmartPointerBase::NoReference const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkVariantArray>::vtkSmartPointer(vtkVariantArray_, vtkSmartPointerBase::NoReference const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI15vtkVariantArrayEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI15vtkVariantArrayEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): undefined reference to `vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase*, vtkSmartPointerBase::NoReference const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function`vtkSmartPointer<vtkStringArray>::vtkSmartPointer(vtkStringArray_, vtkSmartPointerBase::NoReference const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkStringArrayEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI14vtkStringArrayEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): undefined reference to `vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase_, vtkSmartPointerBase::NoReference const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkIntArray>::vtkSmartPointer(vtkIntArray*, vtkSmartPointerBase::NoReference const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI11vtkIntArrayEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI11vtkIntArrayEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): undefined reference to`vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase_, vtkSmartPointerBase::NoReference const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o: In function `vtkSmartPointer<vtkLookupTable>::vtkSmartPointer(vtkLookupTable_, vtkSmartPointerBase::NoReference const&)':
vtkwidget.cpp:(.text._ZN15vtkSmartPointerI14vtkLookupTableEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI14vtkLookupTableEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): undefined reference to `vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase*, vtkSmartPointerBase::NoReference const&)'
CMakeFiles/gammaray_objectvisualizer_plugin.dir/vtkwidget.cpp.o:vtkwidget.cpp:(.text._ZN15vtkSmartPointerI12vtkViewThemeEC2EPS0_RKN19vtkSmartPointerBase11NoReferenceE[_ZN15vtkSmartPointerI12vtkViewThemeEC5EPS0_RKN19vtkSmartPointerBase11NoReferenceE]+0x36): more undefined references to`vtkSmartPointerBase::vtkSmartPointerBase(vtkObjectBase_, vtkSmartPointerBase::NoReference const&)' follow
collect2: ld returned 1 exit status
make[2]: *_\* [lib/plugins/gammaray/gammaray_objectvisualizer_plugin.so] Error 1
make[2]: Leaving directory `/home/jkt/work/prog/GammaRay/build'
make[1]: *** [plugins/objectvisualizer/CMakeFiles/gammaray_objectvisualizer_plugin.dir/all] Error 2
make[1]: Leaving directory`/home/jkt/work/prog/GammaRay/build'
make: **\* [all] Error 2
