### PR TITLE
Use getpwuid/getuid instead of getlogin

### DIFF
--- a/launcher/processfiltermodel.cpp
+++ b/launcher/processfiltermodel.cpp
@@ -36,9 +36,14 @@ static QString qGetLogin() {
   return QString::fromLocal8Bit(winUserName);
 }
 #else
+#include <sys/types.h>
+#include <pwd.h>
 #include <unistd.h>
 static QString qGetLogin(){
-  return QString::fromLocal8Bit(getlogin());
+  struct passwd *pw = getpwuid(getuid());
+  if (!pw || !pw->pw_name)
+    return QString();
+  return QString::fromLocal8Bit(pw->pw_name);
 }
 #endif
 


### PR DESCRIPTION
getlogin() returns "nobody" on my Gentoo Linux machine where I logged in through
kdm from KDE 4.9.0. According to a Gentoo forum [1], this is probably related to
the lack of /var/log/utmp and/or not having pam_loginuid.so in my PAM stack
getting used by the login manager.

Given that GammaRay is the first application to break due to this thing (and
I've been using this box for 7+ years) and considering that my manpage generally
describes this family of functions as something to avoid, I believe that it's
better to use a combination of getpwuid(getuid()) instead.

[1] http://forums.gentoo.org/viewtopic-p-7168094.html
