### PR TITLE
Implement QObject counting grouped by metaobject

### DIFF
--- a/core/metaobjecttreemodel.h
+++ b/core/metaobjecttreemodel.h
@@ -30,6 +30,8 @@
 
 namespace GammaRay {
 
+class MetaObjectInfoTracker;
+
 class MetaObjectTreeModel : public QAbstractItemModel
 {
   Q_OBJECT
@@ -40,10 +42,14 @@ class MetaObjectTreeModel : public QAbstractItemModel
     };
 
     enum Column {
-      ObjectColumn
+      ObjectColumn,
+      ObjectSelfCountColumn,
+      ObjectInclusiveCountColumn,
+      _Last
     };
 
     explicit MetaObjectTreeModel(QObject *parent = 0);
+    virtual ~MetaObjectTreeModel();
 
     // reimplemented methods
     virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
@@ -64,6 +70,10 @@ class MetaObjectTreeModel : public QAbstractItemModel
     void objectAdded(QObject *obj);
     void objectRemoved(QObject *obj);
 
+  private Q_SLOTS:
+    void objectAddedMainThread(QObject *obj);
+    void objectRemovedMainThread(const QMetaObject *metaObject);
+
   private:
     void addMetaObject(const QMetaObject *metaObject);
     void removeMetaObject(const QMetaObject *metaObject);
@@ -76,6 +86,8 @@ class MetaObjectTreeModel : public QAbstractItemModel
     // data
     QHash<const QMetaObject*, const QMetaObject*> m_childParentMap;
     QHash<const QMetaObject*, QVector<const QMetaObject*> > m_parentChildMap;
+
+    MetaObjectInfoTracker* m_infoTracker;
 };
 
 }

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -494,6 +494,7 @@ void Probe::objectRemoved(QObject *obj)
     instance()->m_queuedObjects.removeOne(obj);
 
     instance()->m_objectListModel->objectRemoved(obj);
+    instance()->m_metaObjectTreeModel->objectRemoved(obj);
 
     instance()->connectionRemoved(obj, 0, 0, 0);
     instance()->connectionRemoved(0, 0, obj, 0);


### PR DESCRIPTION
- New groups in meta object browser:
  - #Objects (of exactly this type)
  - #Objects (that inherit this type)
- Made meta object model thread-safe (just as in objectlistmodel.cpp)

Suggestions for better column titles are welcome
