### PR TITLE
Initial Blackberry10 support

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -24,4 +24,8 @@ add_executable(gammaray-client ${gammaray_client_srcs})
 
 target_link_libraries(gammaray-client ${QT_QTCORE_LIBRARIES} ${QT_QTGUI_LIBRARIES} ${QT_QTNETWORK_LIBRARIES} gammaray_common gammaray_ui gammaray_ui_internal gammaray_core)
 
+if (QNXNTO)
+  target_link_libraries(gammaray-client cpp)
+endif()
+
 install(TARGETS gammaray-client ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/cmake/Toolchain-blackberry-armv7le.cmake
+++ b/cmake/Toolchain-blackberry-armv7le.cmake
@@ -1,0 +1,18 @@
+include(Platform/QNX)
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME BlackBerry)
+
+# which compilers to use for C and C++
+SET(arch gcc_ntoarmv7le)
+SET(CMAKE_C_COMPILER qcc -V${arch})
+SET(CMAKE_CXX_COMPILER qcc -V${arch})
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH $ENV{QNX_TARGET}/armle-v7)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search 
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -116,7 +116,7 @@ else()
   )
 endif()
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT QNXNTO)
   target_link_libraries(gammaray_core dl)
 endif()
 install(TARGETS gammaray_core ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -59,7 +59,12 @@ qt4_automoc(${gammaray_runner_srcs})
 add_executable(gammaray ${gammaray_runner_srcs})
 
 target_link_libraries(gammaray ${QT_QTCORE_LIBRARIES} ${QT_QTGUI_LIBRARIES} gammaray_common_internal gammaray_ui)
-if(UNIX AND NOT APPLE)
+
+if (QNXNTO)
+  target_link_libraries(gammaray cpp)
+endif()
+
+if(UNIX AND NOT APPLE AND NOT QNXNTO)
   target_link_libraries(gammaray dl) # for preload check
 endif()
 

--- a/launcher/injector/interactiveprocess.cpp
+++ b/launcher/injector/interactiveprocess.cpp
@@ -32,6 +32,9 @@
 #ifndef __MINGW32__
 #define fileno _fileno
 #endif
+#elif defined(Q_OS_QNX)
+#include <unistd.h>
+using std::fileno;
 #else
 #include <unistd.h>
 #endif

--- a/plugins/styleinspector/CMakeLists.txt
+++ b/plugins/styleinspector/CMakeLists.txt
@@ -34,3 +34,7 @@ target_link_libraries(gammaray_styleinspector_plugin
   ${QT_QTGUI_LIBRARIES}
   gammaray_core
 )
+
+if(QNXNTO)
+  target_link_libraries(gammaray_styleinspector_plugin cpp)
+endif()

--- a/plugins/styleinspector/complexcontrolmodel.cpp
+++ b/plugins/styleinspector/complexcontrolmodel.cpp
@@ -36,6 +36,10 @@ static double log2(double n)
 }
 #endif
 
+#ifdef Q_OS_QNX
+using std::log2;
+#endif
+
 using namespace GammaRay;
 
 struct complex_control_element_t {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,11 +10,19 @@ target_link_libraries(connectiontest
   ${QT_QTTEST_LIBRARIES}
 )
 
+if(QNXNTO)
+  target_link_libraries(connectiontest cpp)
+endif()
+
 qt4_automoc(attachhelper.cpp)
 
 add_executable(attachhelper attachhelper.cpp)
 
 target_link_libraries(attachhelper ${QT_QTCORE_LIBRARIES})
+
+if(QNXNTO)
+  target_link_libraries(attachhelper cpp)
+endif()
 
 if(UNIX AND NOT APPLE)
   add_test(connectiontest-preload

--- a/tests/manual/CMakeLists.txt
+++ b/tests/manual/CMakeLists.txt
@@ -15,3 +15,7 @@ target_link_libraries(propertywidgettest
   gammaray_core
   gammaray_common
 )
+
+if(QNXNTO)
+  target_link_libraries(propertywidgettest cpp)
+endif()


### PR DESCRIPTION
Some things still need to be set before calling cmake, namely:
export QTDIR=/path/to/BB10/qt
export PATH=$QTDIR/bin:$PATH

The cmake call line looks like this:
cmake -DCMAKE_TOOLCHAIN_FILE=../Toolchain-blackberry-armv7le.cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$PWD/install -DQt5Gui_EGL_LIBRARY=$QNX_TARGET/armle-v7/usr/lib/libEGL.so -DQt5Gui_GLESv2_LIBRARY=$QNX_TARGET/armle-v7/usr/lib/libGLESv2.so ..

I wonder if we can auto deteted the libs explicited above.
