### PR TITLE
Make compile with both cgraph and graph library

### DIFF
--- a/plugins/statemachineviewer/CMakeLists.txt
+++ b/plugins/statemachineviewer/CMakeLists.txt
@@ -4,12 +4,27 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${GRAPHVIZ_INCLUDE_DIR}
+
+  # TODO: Work-around issue in graphviz/types.h header
+  # <cgraph.h> is included there, but it should rather be "cgraph.h"
+  ${GRAPHVIZ_INCLUDE_DIR}/graphviz
 )
+
+if (GRAPHVIZ_CGRAPH_LIBRARY AND GRAPHVIZ_VERSION VERSION_GREATER 2.30.0)
+  message(STATUS "Enabling use of experimental 'cgraph' library of GraphViz")
+  # you must add this define when using cgraph from graphviz
+  # some headers check for this define (see for example graphviz/types.h header)
+  add_definitions(-DWITH_CGRAPH)
+  set(STATEMACHINEVIEWER_LIBRARIES ${GRAPHVIZ_CGRAPH_LIBRARY})
+else()
+  set(STATEMACHINEVIEWER_LIBRARIES ${GRAPHVIZ_GRAPH_LIBRARY})
+endif()
 
 set(gammaray_statemachineviewer_plugin_srcs
   # this part depends on graphviz
   gvgraph/gvgraph.cpp
   gvgraph/gvgraphitems.cpp
+  gvgraph/gvutils.cpp
 
   statemachineview.cpp
   statemachineviewer.cpp
@@ -27,7 +42,7 @@ set(gammaray_statemachineviewer_plugin_libs
   ${QT_QTCORE_LIBRARIES}
   ${QT_QTGUI_LIBRARIES}
 
-  ${GRAPHVIZ_GRAPH_LIBRARY}
+  ${STATEMACHINEVIEWER_LIBRARIES}
   ${GRAPHVIZ_GVC_LIBRARY}
   gammaray_core
 )
@@ -44,6 +59,7 @@ target_link_libraries(gammaray_statemachineviewer_plugin
 add_executable(statemachineviewer_test
   gvgraph/gvgraph.cpp
   gvgraph/gvgraphitems.cpp
+  gvgraph/gvutils.cpp
 
   test_main.cpp
 )

--- a/plugins/statemachineviewer/gvgraph/gvgraph.h
+++ b/plugins/statemachineviewer/gvgraph/gvgraph.h
@@ -25,14 +25,11 @@
 #include "gvgraphelements.h"
 #include "gvtypes.h"
 
+#include <graphviz/types.h>
+
 #include <QFont>
 #include <QHash>
 #include <QString>
-
-struct Agedge_t;
-struct Agnode_t;
-struct Agraph_t;
-typedef struct GVC_s GVC_t;
 
 namespace GammaRay {
 

--- a/plugins/statemachineviewer/gvgraph/gvutils.cpp
+++ b/plugins/statemachineviewer/gvgraph/gvutils.cpp
@@ -1,0 +1,98 @@
+#include "gvutils.h"
+
+#include <graphviz/gvc.h>
+#ifdef WITH_CGRAPH
+#  include <graphviz/cgraph.h>
+#else
+#  include <graphviz/graph.h>
+#endif
+
+using namespace GammaRay;
+
+#ifdef WITH_CGRAPH
+Agraph_t *GVUtils::_agopen(const QString &name, Agdesc_t kind, Agdisc_t *disc)
+#else
+Agraph_t *GVUtils::_agopen(const QString &name, int kind)
+#endif
+{
+#ifdef WITH_CGRAPH
+  return agopen(const_cast<char *>(qPrintable(name)), kind, disc);
+#else
+  return agopen(const_cast<char *>(qPrintable(name)), kind);
+#endif
+}
+
+QString GVUtils::_agget(void* object, const QString &attr, const QString &alt)
+{
+  const QString str = agget(object, const_cast<char *>(qPrintable(attr)));
+  if(str.isEmpty()) {
+    return alt;
+  } else {
+    return str;
+  }
+}
+
+Agsym_t* GVUtils::_agnodeattr(Agraph_t *object, const QString &attr, const QString &alt)
+{
+#ifdef WITH_CGRAPH
+  return agattr(object, AGNODE,
+#else
+  return agnodeattr(object,
+#endif
+                const_cast<char *>(qPrintable(attr)),
+                const_cast<char *>(qPrintable(alt)));
+}
+
+Agsym_t* GVUtils::_agedgeattr(Agraph_t *object, const QString &attr, const QString &alt)
+{
+#ifdef WITH_CGRAPH
+  return agattr(object, AGEDGE,
+#else
+  return agedgeattr(object,
+#endif
+                const_cast<char *>(qPrintable(attr)),
+                const_cast<char *>(qPrintable(alt)));
+}
+
+Agnode_t* GVUtils::_agnode(Agraph_t* graph, const QString& attr, bool create)
+{
+#ifdef WITH_CGRAPH
+  return agnode(graph, const_cast<char*>(qPrintable(attr)), create);
+#else
+  Q_UNUSED(create);
+  return agnode(graph, const_cast<char*>(qPrintable(attr)));
+#endif
+}
+
+Agedge_t* GVUtils::_agedge(Agraph_t *graph, Agnode_t *tail, Agnode_t *head,
+                           const QString &name, bool create)
+{
+#ifdef WITH_CGRAPH
+  return agedge(graph, tail, head, const_cast<char*>(qPrintable(name)), create);
+#else
+  Q_UNUSED(name);
+  Q_UNUSED(create);
+  return agedge(graph, tail, head);
+#endif
+}
+
+Agraph_t* GVUtils::_agsubg(Agraph_t *graph, const QString &attr, bool create)
+{
+#ifdef WITH_CGRAPH
+  return agsubg(graph, const_cast<char*>(qPrintable(attr)), create);
+#else
+  Q_UNUSED(create);
+  return agsubg(graph, const_cast<char*>(qPrintable(attr)));
+#endif
+}
+
+int GVUtils::_agset(void *object, const QString &attr, const QString &value)
+{
+  return agsafeset(object, const_cast<char *>(qPrintable(attr)),
+                   const_cast<char *>(qPrintable(value)), const_cast<char *>(""));
+}
+
+int GVUtils::_gvLayout(GVC_t* gvc, graph_t* g, const char* engine)
+{
+  return gvLayout(gvc, g, const_cast<char*>(engine));
+}

--- a/plugins/statemachineviewer/gvgraph/gvutils.h
+++ b/plugins/statemachineviewer/gvgraph/gvutils.h
@@ -23,65 +23,39 @@
 #define GAMMARAY_GVUTILS_H
 
 #include <graphviz/types.h>
-#include <graphviz/graph.h>
-#include <graphviz/gvc.h>
 
 #include <QString>
 #include <qglobal.h>
 
 namespace GammaRay {
 
+namespace GVUtils {
+
 /// The agopen method for opening a graph
-static inline Agraph_t *_agopen(QString name, int kind)
-{
-  return agopen(const_cast<char *>(qPrintable(name)), kind);
-}
+#ifdef WITH_CGRAPH
+extern Agraph_t *_agopen(const QString &name, Agdesc_t kind, Agdisc_t *disc);
+#else
+extern Agraph_t *_agopen(const QString &name, int kind);
+#endif
 
 /// Add an alternative value parameter to the method for getting an object's attribute
-static inline QString _agget(void *object, QString attr, QString alt=QString())
-{
-  const QString str = agget(object, const_cast<char *>(qPrintable(attr)));
-  if(str.isEmpty()) {
-    return alt;
-  } else {
-    return str;
-  }
-}
+QString _agget(void *object, const QString &attr, const QString& alt = QString());
 
-static inline Agsym_t *_agnodeattr(Agraph_t *object, QString attr, QString alt=QString())
-{
-  return agnodeattr(object,
-                    const_cast<char *>(qPrintable(attr)),
-                    const_cast<char *>(qPrintable(alt)));
-}
+Agsym_t *_agnodeattr(Agraph_t *object, const QString &attr,
+                     const QString &alt = QString());
+Agsym_t *_agedgeattr(Agraph_t *object, const QString &attr,
+                                   const QString &alt = QString());
 
-static inline Agsym_t *_agedgeattr(Agraph_t *object, QString attr, QString alt=QString())
-{
-  return agedgeattr(object,
-                    const_cast<char *>(qPrintable(attr)),
-                    const_cast<char *>(qPrintable(alt)));
-}
+int _gvLayout(GVC_t *gvc, graph_t *g, const char *engine);
 
-static inline int _gvLayout(GVC_t *gvc, graph_t *g, const char *engine)
-{
-  return gvLayout(gvc, g, const_cast<char*>(engine));
-}
-
-static inline Agnode_t *_agnode(Agraph_t *graph, const QString &attr)
-{
-  return agnode(graph, const_cast<char*>(qPrintable(attr)));
-}
-
-static inline Agraph_t *_agsubg(Agraph_t *graph, const QString &attr)
-{
-  return agsubg(graph, const_cast<char*>(qPrintable(attr)));
-}
+Agnode_t *_agnode(Agraph_t *graph, const QString &attr, bool create = true);
+Agedge_t *_agedge(Agraph_t *graph, Agnode_t *tail, Agnode_t *head,
+                  const QString &name = QString(), bool create = true);
+Agraph_t *_agsubg(Agraph_t *graph, const QString &attr, bool create = true);
 
 /// Directly use agsafeset which always works, contrarily to agset
-static inline int _agset(void *object, QString attr, QString value)
-{
-  return agsafeset(object, const_cast<char *>(qPrintable(attr)),
-                   const_cast<char *>(qPrintable(value)), const_cast<char *>(""));
+int _agset(void* object, const QString& attr, const QString& value);
+
 }
 
 }


### PR DESCRIPTION
GraphViz offers two libraries to build up graph structures with:
- graph (deprecated)
- cgraph

Prior to this patch we were only supporting the 'graph' approach. This
patch makes it possible to compile both against 'graph' and 'cgraph'.

cgraph seems to be available for some time already, but it is not
stable for graphviz <2.30.x. For me, gammaray instantly crashes when
calling gvContext() in 2.29 (from Ubuntu repositories) when linked
against cgraph. Hence we only use cgraph in case we have >=2.30 and when
cgraph is actually available.

This should also fix the build issues under windows, where the package
provided by graphviz.org only provides the cgraph library.
