### PR TITLE
Build and work with VTK 6.0

### DIFF
--- a/plugins/objectvisualizer/CMakeLists.txt
+++ b/plugins/objectvisualizer/CMakeLists.txt
@@ -10,6 +10,8 @@ include_directories(
   ${VTK_INCLUDE_DIRS}
 )
 
+include(${VTK_USE_FILE})
+
 link_directories(${VTK_LIBRARY_DIRS})
 
 set(gammaray_objectvisualizer_plugin_srcs


### PR DESCRIPTION
As described in issue #49, correctly link against VTK 6.0 and fix a crash in VTK 6.0 when initializing ObjectVisualizer.

Both changes are backwards compatible, although I haven't tested against VTK 5.x
