### PR TITLE
Guard against deadlocks at startup due to object lock being held.

### DIFF
--- a/core/probe.h
+++ b/core/probe.h
@@ -63,8 +63,6 @@ class GAMMARAY_CORE_EXPORT Probe : public QObject, public ProbeInterface
     static void connectionRemoved(QObject *sender, const char *signal,
                                   QObject *receiver, const char *method);
 
-    static void findExistingObjects();
-
     QAbstractItemModel *objectListModel() const;
     QAbstractItemModel *objectTreeModel() const;
     QAbstractItemModel *metaObjectModel() const;
@@ -124,11 +122,13 @@ class GAMMARAY_CORE_EXPORT Probe : public QObject, public ProbeInterface
     static QThread* filteredThread();
 
     void objectFullyConstructed(QObject *obj);
-    static bool createProbe();
+    void findExistingObjects();
+
+    static void createProbe(bool findExisting);
 
     explicit Probe(QObject *parent = 0);
     static void addObjectRecursive(QObject *obj);
-    static Probe *s_instance;
+    static QAtomicPointer<Probe> s_instance;
 
     ObjectListModel *m_objectListModel;
     ObjectTreeModel *m_objectTreeModel;

--- a/hooking/hooks.cpp
+++ b/hooking/hooks.cpp
@@ -65,15 +65,7 @@ extern "C" Q_DECL_EXPORT void qt_startup_hook()
 
 extern "C" Q_DECL_EXPORT void qt_addObject(QObject *obj)
 {
-  if (!Probe::isInitialized()) {
-    IF_DEBUG(cout
-             << "objectAdded Before: "
-             << hex << obj
-             << (fromCtor ? " (from ctor)" : "") << endl;)
-    ProbeCreator::trackObject(obj);
-  } else {
-    Probe::objectAdded(obj, true);
-  }
+  Probe::objectAdded(obj, true);
 
 #if !defined Q_OS_WIN && !defined Q_OS_MAC
   if (!functionsOverwritten) {
@@ -86,11 +78,7 @@ extern "C" Q_DECL_EXPORT void qt_addObject(QObject *obj)
 
 extern "C" Q_DECL_EXPORT void qt_removeObject(QObject *obj)
 {
-  if (!Probe::isInitialized()) {
-    ProbeCreator::untrackObject(obj);
-  } else {
-    Probe::objectRemoved(obj);
-  }
+  Probe::objectRemoved(obj);
 
 #if !defined Q_OS_WIN && !defined Q_OS_MAC
   if (!functionsOverwritten) {

--- a/hooking/probecreator.h
+++ b/hooking/probecreator.h
@@ -41,9 +41,6 @@ class ProbeCreator : public QObject
     };
     explicit ProbeCreator(Type t);
 
-    static void trackObject(QObject* object);
-    static void untrackObject(QObject* object);
-
   private slots:
     void createProbe();
 


### PR DESCRIPTION
When we create the Probe and its children we can deadlock when
other threads also create QObjects which internally use mutexes,
such as e.g. QAbstractSocketEngine. Instead we now create the
probe without holding the lock, and only thereafter acquire the
lock to register all objects which where added beforehand.

This requires some cleanups and refactorings, esp. we get rid of
ProbeCreator::track/untrackObject and now always use
Probe::object{Removed,Added} which keeps track of these items in
a static list if not yet instantiated.
