### PR TITLE
Build fix for OS X 10.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,19 @@ if(CMAKE_BUILD_TYPE MATCHES "^[Rr]elease$")
   add_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
 
+if(APPLE)
+  # Qt 4.8 fails to build with libc++
+  #
+  # - QVector::iterator + STL algorithms fails to build when QT_STRICT_ITERATORS
+  #   if defined
+  # - QTBUG-25960
+  # - And possibly others
+  #
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libstdc++")
+endif()
+
 set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
 set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
 if(Qt5Core_FOUND)


### PR DESCRIPTION
OS X 10.9 uses libc++ by default and there are several build
issues with Qt 4.8.2 (and possibly later Qt 4.x versions, I haven't
tested)

This commit changes the C++ lib to libstdc++ on Mac.

I'm not sure that this is the right way to go about setting the C++ library to libstdc++ or even whether that is the right thing to do. Would it be better to require a later version of Qt with the libc++ issues fixed instead?
