### PR TITLE
ObjectListModel: Fix assert in objectRemovedMainThread

### DIFF
--- a/core/objectlistmodel.cpp
+++ b/core/objectlistmodel.cpp
@@ -126,17 +126,20 @@ void ObjectListModel::objectRemovedMainThread(QObject *obj, bool fromBackground)
 {
   Q_ASSERT(thread() == QThread::currentThread());
 
-  if (fromBackground) {
+  {
     QMutexLocker lock(&m_mutex);
     bool removed = m_invalidatedObjects.remove(obj);
-    if (!removed) {
-      Q_ASSERT(!m_objects.contains(obj));
-      return;
-    }
-  } else {
+
 #ifndef NDEBUG
-    QMutexLocker lock(&m_mutex);
-    Q_ASSERT(!m_invalidatedObjects.contains(obj));
+    if (fromBackground) {
+      if (!removed) {
+        Q_ASSERT(!m_objects.contains(obj));
+        return;
+      }
+    }
+#else
+    Q_UNUSED(fromBackground);
+    Q_UNUSED(removed);
 #endif
   }
 


### PR DESCRIPTION
It's not safe to assume that m_invalidatedObjects does not contain obj in
case objectRemovedMainThread is called from the main thread.

We can end up in this order of calls:
- objectRemoved from a thread other than the main thread
  - inserts obj into m_invalidatedObjects
  - queues a call to objectRemovedMainThread
- objectAdded with the same obj-pointer
- objectRemoved from the main thread
  - calls objectRemovedMainThread directly
  - m_invalidatedObjects still contains obj.
    => Assertion triggered

We fix this by always trying to remove obj from m_invalidatedObjects in
objectRemovedMainThread.
