### PR TITLE
Prevent adding transtions where states are not added

### DIFF
--- a/plugins/statemachineviewer/statemachineviewerserver.h
+++ b/plugins/statemachineviewer/statemachineviewerserver.h
@@ -56,11 +56,11 @@ class StateMachineViewerServer : public StateMachineViewerInterface
     explicit StateMachineViewerServer(ProbeInterface *probe, QObject *parent = 0);
 
     void addState(QAbstractState *state);
-    void addTransition(QAbstractTransition *transition);
 
     QStateMachine *selectedStateMachine() const;
 
     using StateMachineViewerInterface::stateConfigurationChanged;
+
   private slots:
     void stateEntered(QAbstractState *state);
     void stateExited(QAbstractState *state);
@@ -80,6 +80,9 @@ class StateMachineViewerServer : public StateMachineViewerInterface
     void repopulateGraph();
 
   private:
+
+    void addStateOnly(QAbstractState *state);
+    void addTransition(QAbstractTransition *transition);
 
     void updateStateItems();
 


### PR DESCRIPTION
Current recursive adding of states does not work.

The old code tries to catch this,

```
  QState *parentState = state->parentState();
  if (parentState) {
    addStateOnly(parentState); // be sure that parent is added first
  }
```

but this does not work, because a unadded state could be used in addTransition(), then the graphs shows dangling states.
