### PR TITLE
use direct connection to prevent a crash with sender being garbage in onSignalEmitted

### DIFF
--- a/plugins/signalmonitor/signalhistorymodel.cpp
+++ b/plugins/signalmonitor/signalhistorymodel.cpp
@@ -63,7 +63,7 @@ static void signal_begin_callback(QObject *caller, int method_index, void **argv
   Q_UNUSED(argv);
   if (s_historyModel) {
     const int signalIndex = method_index + 1; // offset 1, so unknown signals end up at 0
-    QMetaObject::invokeMethod(s_historyModel, "onSignalEmitted", Qt::AutoConnection, Q_ARG(QObject*, caller), Q_ARG(int, signalIndex));
+    QMetaObject::invokeMethod(s_historyModel, "onSignalEmitted", Qt::DirectConnection, Q_ARG(QObject*, caller), Q_ARG(int, signalIndex));
   }
 }
 


### PR DESCRIPTION
Running into a persistent crash as noted here: https://github.com/KDAB/GammaRay/issues/88

Using Qt 5.2 32-bit with a 32-bit i686 injector on OS X 10.10 x86_64.  Seems that onSignalEmitted's sender is garbage sometimes.  Quick fix is to use a DirectConnection to invoke the method instead of an AutoConnection.

With this fix in place, I'm able to actually launch GammaRay and browse the object hierarchy of my application.
