### PR TITLE
Improve Util::displayString

### DIFF
--- a/core/util.cpp
+++ b/core/util.cpp
@@ -61,9 +61,9 @@ QString Util::displayString(const QObject *object)
     return "QObject(0x0)";
   }
   if (object->objectName().isEmpty()) {
-    return QString::fromLatin1("%1 (%2)").
-      arg(addressToString(object)).
-      arg(object->metaObject()->className());
+    return QString::fromLatin1("%1[this=%2]").
+      arg(object->metaObject()->className()).
+      arg(addressToString(object));
   }
   return object->objectName();
 }


### PR DESCRIPTION
Render objects without objectName like this:
"ClassName[this=0xdeadbeef]" instead of "0xdeadbeef (ClassName)".

Reasoning: The pointer address is mostly meaningless when looking
through object instances, the class name has more value to us.

This also fixes some representational issues in KDSME
