### PR TITLE
Add missing include to fix build with clang-3.5 + Qt-5.4

### DIFF
--- a/plugins/quickinspector/materialextension/materialextension.cpp
+++ b/plugins/quickinspector/materialextension/materialextension.cpp
@@ -39,6 +39,7 @@
 #include "config-gammaray.h"
 
 #include <private/qsgmaterialshader_p.h> //krazy:exclude=camelcase
+#include <typeinfo>
 
 using namespace GammaRay;
 


### PR DESCRIPTION
/materialextension.cpp:74:24: error: must #include <typeinfo> before using typeid
