### PR TITLE
Fix compilation with gcc 4.6

### DIFF
--- a/core/remote/serverproxymodel.h
+++ b/core/remote/serverproxymodel.h
@@ -38,7 +38,7 @@ public:
 
     void addRole(int role);
 
-    QMap<int, QVariant> itemData(const QModelIndex &index) const override;
+    QMap<int, QVariant> itemData(const QModelIndex &index) const Q_DECL_OVERRIDE;
 
 private:
     QVector<int> m_extraRoles;


### PR DESCRIPTION
The support of C++11 in gcc 4.6 is limited, and doesn't include the "override"
keyword.