### PR TITLE
Fix Android support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,10 +459,10 @@ else()
     set(DOC_INSTALL_DIR "${DATAROOTDIR}/doc/gammaray/")
   endif()
 endif()
+
 if(ANDROID)
   # Android doesn't support sub-directories in lib/
-  set(PLUGIN_INSTALL_DIR "${LIB_INSTALL_DIR}")
-  set(PROBE_PLUGIN_INSTALL_DIR "${PLUGIN_INSTALL_DIR}")
+  set(PROBE_PLUGIN_INSTALL_DIR "plugins/gammaray")
 else()
   set(PROBE_PLUGIN_INSTALL_DIR "${PLUGIN_INSTALL_DIR}/${GAMMARAY_PLUGIN_VERSION}/${GAMMARAY_PROBE_ABI}")
 endif()

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -64,7 +64,7 @@ QUrl Client::serverAddress() const
   return m_serverAddress;
 }
 
-void Client::connectToHost(const QUrl &url)
+void Client::connectToHost(const QUrl &url, int tryAgain)
 {
   m_serverAddress = url;
   m_initState = 0;
@@ -80,6 +80,7 @@ void Client::connectToHost(const QUrl &url)
   connect(m_clientDevice, SIGNAL(persistentError(QString)), this, SIGNAL(persisitentConnectionError(QString)));
   connect(m_clientDevice, SIGNAL(transientError()), this, SLOT(socketError()));
   connect(m_clientDevice, SIGNAL(persistentError(QString)), this, SLOT(socketError()));
+  m_clientDevice->setTryAgain(tryAgain);
   m_clientDevice->connectToHost();
 }
 

--- a/client/client.h
+++ b/client/client.h
@@ -42,7 +42,7 @@ public:
   ~Client();
 
   /** Connect to a server reachable on @p url. */
-  void connectToHost(const QUrl &url);
+  void connectToHost(const QUrl &url, int tryAgain = 0);
   void disconnectFromHost();
 
   /**

--- a/client/clientconnectionmanager.cpp
+++ b/client/clientconnectionmanager.cpp
@@ -78,7 +78,8 @@ ClientConnectionManager::ClientConnectionManager(QObject* parent, bool showSplas
   m_client(new Client(this)),
   m_mainWindow(0),
   m_toolModel(0),
-  m_ignorePersistentError(false)
+  m_ignorePersistentError(false),
+  m_tries(0)
 {
   if (showSplashScreenOnStartUp)
      showSplashScreen();
@@ -99,10 +100,11 @@ QMainWindow *ClientConnectionManager::mainWindow() const
   return m_mainWindow;
 }
 
-void ClientConnectionManager::connectToHost(const QUrl &url)
+void ClientConnectionManager::connectToHost(const QUrl &url, int tryAgain)
 {
   m_serverUrl = url;
   m_connectionTimeout.start();
+  m_tries = tryAgain;
   connectToHost();
 }
 
@@ -113,7 +115,7 @@ void ClientConnectionManager::disconnectFromHost()
 
 void ClientConnectionManager::connectToHost()
 {
-  m_client->connectToHost(m_serverUrl);
+  m_client->connectToHost(m_serverUrl, m_tries ? m_tries-- : 0);
 }
 
 void ClientConnectionManager::connectionEstablished()

--- a/client/clientconnectionmanager.h
+++ b/client/clientconnectionmanager.h
@@ -55,7 +55,7 @@ class GAMMARAY_CLIENT_EXPORT ClientConnectionManager : public QObject
     QMainWindow *mainWindow() const;
 
     /** Connect to a GammaRay probe at @p url. */
-    void connectToHost(const QUrl &url);
+    void connectToHost(const QUrl &url, int tryAgain = 0);
 
     /** One-time initialization of stream operators and factory callbacks. */
     static void init();
@@ -108,6 +108,7 @@ class GAMMARAY_CLIENT_EXPORT ClientConnectionManager : public QObject
     QAbstractItemModel *m_toolModel;
     QTime m_connectionTimeout;
     bool m_ignorePersistentError;
+    int m_tries;
 };
 
 }

--- a/client/clientdevice.cpp
+++ b/client/clientdevice.cpp
@@ -29,7 +29,9 @@
 
 using namespace GammaRay;
 
-ClientDevice::ClientDevice(QObject* parent): QObject(parent)
+ClientDevice::ClientDevice(QObject* parent)
+    : QObject(parent)
+    , m_tries(0)
 {
 }
 
@@ -52,4 +54,9 @@ ClientDevice* ClientDevice::create(const QUrl& url, QObject *parent)
 
     device->m_serverAddress = url;
     return device;
+}
+
+void ClientDevice::setTryAgain(int tries)
+{
+    m_tries = tries;
 }

--- a/client/clientdevice.h
+++ b/client/clientdevice.h
@@ -41,6 +41,7 @@ public:
 
     static ClientDevice* create(const QUrl& url, QObject* parent);
 
+    void setTryAgain(int tries);
     virtual void connectToHost() = 0;
     virtual void disconnectFromHost() = 0;
     virtual QIODevice *device() const = 0;
@@ -54,6 +55,7 @@ signals:
 
 protected:
     QUrl m_serverAddress;
+    int m_tries;
 };
 
 template <typename ClientT>

--- a/client/localclientdevice.cpp
+++ b/client/localclientdevice.cpp
@@ -45,5 +45,22 @@ void LocalClientDevice::disconnectFromHost()
 
 void LocalClientDevice::socketError()
 {
-    emit persistentError(m_socket->errorString());
+    switch (m_socket->error()) {
+    case QLocalSocket::ConnectionRefusedError:
+    case QLocalSocket::ServerNotFoundError:
+    case QLocalSocket::SocketAccessError:
+    case QLocalSocket::SocketTimeoutError:
+    case QLocalSocket::ConnectionError:
+    case QLocalSocket::UnknownSocketError:
+        emit transientError();
+        break;
+    default:
+        if (m_tries) {
+            --m_tries;
+            emit transientError();
+        } else {
+            emit persistentError(m_socket->errorString());
+        }
+        break;
+    }
 }

--- a/cmake/GammaRayMacros.cmake
+++ b/cmake/GammaRayMacros.cmake
@@ -19,11 +19,8 @@ macro(gammaray_add_plugin _target_name _desktop_file)
     PREFIX ""
     LIBRARY_OUTPUT_DIRECTORY ${_build_target_dir}
   )
-  if(ANDROID)
-    # on Android anything in lib/ needs to have a "lib" prefix, and since everything
-    # is mixed in there, we also should have a somewhat unique prefix over all.
-    set_target_properties(${_target_name} PROPERTIES OUTPUT_NAME "libgammaray_plugin_${_target_name}")
-  elseif(APPLE)
+
+  if(APPLE)
     set_target_properties(${_target_name} PROPERTIES INSTALL_RPATH "@loader_path/../../../Frameworks")
   endif()
 

--- a/common/pluginmanager.cpp
+++ b/common/pluginmanager.cpp
@@ -58,7 +58,7 @@ QStringList PluginManagerBase::pluginFilter() const
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   filter.push_back("*.desktop");
 #elif defined(Q_OS_ANDROID)
-  filter.push_back(QLatin1String("libgammaray_plugin_*") + Paths::pluginExtension());
+  filter.push_back(QLatin1String("libplugins_gammaray_gammaray_*") + Paths::pluginExtension());
 #else
   filter.push_back(QLatin1String("*") + Paths::pluginExtension());
 #endif

--- a/config-gammaray.h.cmake
+++ b/config-gammaray.h.cmake
@@ -1,7 +1,11 @@
 #include <qglobal.h>
 
 // relative install dirs
-#define GAMMARAY_PLUGIN_INSTALL_DIR "${PLUGIN_INSTALL_DIR}"
+#ifdef Q_OS_ANDROID
+# define GAMMARAY_PLUGIN_INSTALL_DIR "lib"
+#else
+# define GAMMARAY_PLUGIN_INSTALL_DIR "${PLUGIN_INSTALL_DIR}"
+#endif
 #define GAMMARAY_LIBEXEC_INSTALL_DIR "${LIBEXEC_INSTALL_DIR}"
 #define GAMMARAY_BIN_INSTALL_DIR "${BIN_INSTALL_DIR}"
 
@@ -37,7 +41,7 @@
 #cmakedefine HAVE_GRAPHVIZ
 #cmakedefine HAVE_ELF_H
 
-#if !defined(QT_NO_SHAREDMEMORY) && !defined(QT_NO_SYSTEMSEMAPHORE)
+#if !defined(QT_NO_SHAREDMEMORY) && !defined(QT_NO_SYSTEMSEMAPHORE) && !defined(Q_OS_ANDROID)
 #define HAVE_SHM
 #endif
 

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -396,6 +396,11 @@ void Probe::createProbe(bool findExisting)
 
 void Probe::startupHookReceived()
 {
+#ifdef Q_OS_ANDROID
+  QDir root = QDir::home();
+  root.cdUp();
+  Paths::setRootPath(root.absolutePath());
+#endif
   s_listener()->trackDestroyed = false;
 }
 

--- a/core/remote/localserverdevice.cpp
+++ b/core/remote/localserverdevice.cpp
@@ -32,6 +32,7 @@ LocalServerDevice::LocalServerDevice(QObject* parent):
     ServerDeviceImpl<QLocalServer>(parent)
 {
     m_server = new QLocalServer(this);
+    m_server->setSocketOptions(QLocalServer::WorldAccessOption);
     connect(m_server, SIGNAL(newConnection()), this, SIGNAL(newConnection()));
 }
 

--- a/hooking/CMakeLists.txt
+++ b/hooking/CMakeLists.txt
@@ -37,15 +37,26 @@ target_link_libraries(gammaray_probe
   gammaray_core
 )
 
-if(NOT WIN32 AND NOT QNXNTO)
+if(NOT WIN32 AND NOT QNXNTO AND NOT ANDROID)
   target_link_libraries(gammaray_probe dl)
 endif()
 
-set_target_properties(gammaray_probe PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${PROBE_PLUGIN_INSTALL_DIR}"
-)
 if(NOT ANDROID)
+  set_target_properties(gammaray_probe PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${PROBE_PLUGIN_INSTALL_DIR}"
+  )
   set_target_properties(gammaray_probe PROPERTIES PREFIX "")
 endif()
 
-install(TARGETS gammaray_probe DESTINATION ${PROBE_PLUGIN_INSTALL_DIR})
+if(ANDROID)
+  install(TARGETS gammaray_probe EXPORT GammaRayTargets ${INSTALL_TARGETS_DEFAULT_ARGS})
+  ecm_generate_pri_file(BASE_NAME GammaRayProbe
+                      LIB_NAME gammaray_probe
+                      DEPS "core gui network GammaRayCommon GammaRayCore"
+                      FILENAME_VAR PRI_FILENAME
+                      INCLUDE_INSTALL_DIR ${INCLUDE_INSTALL_DIR}/..)
+  install(FILES ${PRI_FILENAME} DESTINATION ${ECM_MKSPECS_INSTALL_DIR})
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/gammaray_probe-android-dependencies.xml DESTINATION ${LIB_INSTALL_DIR})
+else()
+  install(TARGETS gammaray_probe DESTINATION ${PROBE_PLUGIN_INSTALL_DIR})
+endif()

--- a/hooking/gammaray_probe-android-dependencies.xml
+++ b/hooking/gammaray_probe-android-dependencies.xml
@@ -1,0 +1,3 @@
+<rules><dependencies><lib name="Qt5Network"><depends>
+<bundled file="plugins/gammaray" />
+</depends></lib></dependencies></rules>


### PR DESCRIPTION
 - fix cmake files.
 - create a local server by default, the server socket will be located
in /data/data/<package name>/files/+gammaray_socket
 - adb forward is not very reliable, we need to try a few times to
connect to server, so I added a new paramater to Client::connectToHost
method.