### PR TITLE
Autosave on propertyextendededitor.

### DIFF
--- a/ui/propertyeditor/propertycoloreditor.cpp
+++ b/ui/propertyeditor/propertycoloreditor.cpp
@@ -41,7 +41,7 @@ void PropertyColorEditor::edit()
 {
   const QColor color = QColorDialog::getColor(value().value<QColor>(), this);
   if (color.isValid()) {
-    setValue(QVariant::fromValue(color));
+    save(QVariant::fromValue(color));
   }
 }
 

--- a/ui/propertyeditor/propertyextendededitor.cpp
+++ b/ui/propertyeditor/propertyextendededitor.cpp
@@ -30,6 +30,7 @@
 #include "ui_propertyextendededitor.h"
 
 #include <QColorDialog>
+#include <QKeyEvent>
 using namespace GammaRay;
 
 PropertyExtendedEditor::PropertyExtendedEditor(QWidget *parent)
@@ -55,5 +56,14 @@ void PropertyExtendedEditor::setValue(const QVariant &value)
   m_value = value;
   const QString displayValue = property("displayString").toString();
   ui->valueLabel->setText(displayValue.isEmpty() ? value.toString() : displayValue);
+}
+
+void PropertyExtendedEditor::save(const QVariant &value)
+{
+  setValue(value);
+
+  // The user already pressed Apply, don't force her/him to do again
+  QKeyEvent event(QEvent::KeyPress, Qt::Key_Enter, Qt::NoModifier);
+  QApplication::sendEvent(this, &event);
 }
 

--- a/ui/propertyeditor/propertyextendededitor.h
+++ b/ui/propertyeditor/propertyextendededitor.h
@@ -50,6 +50,8 @@ class PropertyExtendedEditor : public QWidget
     QVariant value() const;
     void setValue(const QVariant &value);
 
+    void save(const QVariant &value);
+
   protected slots:
     virtual void edit() = 0;
 

--- a/ui/propertyeditor/propertyfonteditor.cpp
+++ b/ui/propertyeditor/propertyfonteditor.cpp
@@ -42,7 +42,7 @@ void PropertyFontEditor::edit()
   bool ok = false;
   const QFont font = QFontDialog::getFont(&ok, value().value<QFont>(), this);
   if (ok) {
-    setValue(font);
+    save(font);
   }
 }
 

--- a/ui/propertyeditor/propertypaletteeditor.cpp
+++ b/ui/propertyeditor/propertypaletteeditor.cpp
@@ -40,7 +40,7 @@ void PropertyPaletteEditor::edit()
 {
   PaletteDialog dlg(value().value<QPalette>(), this);
   if (dlg.exec() == QDialog::Accepted) {
-    setValue(dlg.editedPalette());
+    save(dlg.editedPalette());
   }
 }
 


### PR DESCRIPTION
So far for extended property editors, that open a dialog, the user had
to press Apply *and* press Enter afterwards to save the value.
Now it will commit the data as soon as the user pressed apply.