### PR TITLE
sceneinspector: Protect against deleted QObjects

### DIFF
--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -39,6 +39,7 @@
 #include <core/objecttypefilterproxymodel.h>
 #include <core/probeinterface.h>
 #include <core/singlecolumnobjectproxymodel.h>
+#include <core/probe.h>
 #include <core/remote/server.h>
 
 #include <kde/krecursivefilterproxymodel.h>
@@ -188,7 +189,11 @@ void SceneInspector::renderScene(const QTransform &transform, const QSize &size)
 
   QGraphicsItem *currentItem = m_itemSelectionModel->currentIndex().data(SceneModel::SceneItemRole).value<QGraphicsItem*>();
   if (currentItem) {
-    paintItemDecoration(currentItem, transform, &painter);
+    // protect against deleted, QObject-based QGIs
+    QObject* currentItemAsQObject = dynamic_cast<QObject*>(currentItem);
+    if (!currentItemAsQObject || Probe::instance()->isValidObject(currentItemAsQObject)) {
+      paintItemDecoration(currentItem, transform, &painter);
+    }
   }
 
   emit sceneRendered(view);


### PR DESCRIPTION
How to reproduce:
- Track a QGV
- Select a QObject-based QGI from the tree view
- Invoke deleteLater() (via the Methods tab)
- Crash

This fixes one cause of the crash inside sceneinspector.cpp