### PR TITLE
Add code navigation feature for QtQuick Items.

### DIFF
--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -313,10 +313,14 @@ void GammaRay::QuickInspectorWidget::itemContextMenu(const QPoint& pos)
     return;
   }
 
+  const auto sourceFile = index.data(QuickItemModelRole::SourceFileRole).toString();
+  if (sourceFile.isEmpty())
+    return;
+
   QMenu contextMenu;
   QAction *action =
     contextMenu.addAction(tr("Show Code: %1:%2:%3").
-      arg(index.data(QuickItemModelRole::SourceFileRole).toString(),
+      arg(sourceFile,
           index.data(QuickItemModelRole::SourceLineRole).toString(),
           index.data(QuickItemModelRole::SourceColumnRole).toString()));
   action->setData(QuickInspectorWidget::NavigateToCode);
@@ -327,7 +331,7 @@ void GammaRay::QuickInspectorWidget::itemContextMenu(const QPoint& pos)
     switch (action->data().toInt()) {
       case QuickInspectorWidget::NavigateToCode:
         integ = UiIntegration::instance();
-        emit integ->navigateToCode(index.data(QuickItemModelRole::SourceFileRole).toString(),
+        emit integ->navigateToCode(sourceFile,
                                    index.data(QuickItemModelRole::SourceLineRole).toInt(),
                                    index.data(QuickItemModelRole::SourceColumnRole).toInt());
         break;

--- a/plugins/quickinspector/quickinspectorwidget.h
+++ b/plugins/quickinspector/quickinspectorwidget.h
@@ -54,6 +54,11 @@ namespace Ui {
 class QuickInspectorWidget : public QWidget
 {
   Q_OBJECT
+
+  enum Action {
+      NavigateToCode
+  };
+
   public:
     explicit QuickInspectorWidget(QWidget *parent = 0);
     ~QuickInspectorWidget();
@@ -70,6 +75,7 @@ class QuickInspectorWidget : public QWidget
     void setFeatures(GammaRay::QuickInspectorInterface::Features features);
     void setSplitterSizes();
     void itemModelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
+    void itemContextMenu(const QPoint &pos);
 
   private:
     QScopedPointer<Ui::QuickInspectorWidget> ui;

--- a/plugins/quickinspector/quickinspectorwidget.ui
+++ b/plugins/quickinspector/quickinspectorwidget.ui
@@ -40,6 +40,9 @@
          </item>
          <item>
           <widget class="QTreeView" name="itemTreeView">
+           <property name="contextMenuPolicy">
+            <enum>Qt::CustomContextMenu</enum>
+           </property>
            <property name="indentation">
             <number>10</number>
            </property>

--- a/plugins/quickinspector/quickitemmodelroles.h
+++ b/plugins/quickinspector/quickitemmodelroles.h
@@ -36,7 +36,10 @@ namespace GammaRay {
 /** Model roles shared between client and server. */
 namespace QuickItemModelRole {
   enum Roles {
-    ItemFlags = ObjectModel::UserRole
+    ItemFlags = ObjectModel::UserRole,
+    SourceFileRole,
+    SourceLineRole,
+    SourceColumnRole
   };
 
   enum ItemFlag {

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -16,6 +16,7 @@ set(gammaray_ui_srcs
   proxytooluifactory.cpp
   splashscreen.cpp
   searchlinecontroller.cpp
+  uiintegration.cpp
 
   propertyeditor/propertycoloreditor.cpp
   propertyeditor/propertydoublepaireditor.cpp
@@ -126,6 +127,7 @@ gammaray_install_headers(
   propertywidget.h
   propertywidgettab.h
   tooluifactory.h
+  uiintegration.h
 )
 
 ecm_generate_pri_file(BASE_NAME GammaRayUi

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include "aboutdialog.h"
 #include "clienttoolmodel.h"
 #include "aboutdata.h"
+#include "uiintegration.h"
 
 #include "common/objectbroker.h"
 #include "common/modelroles.h"
@@ -48,12 +49,47 @@
 #include <private/qguiapplication_p.h>
 #endif
 
+#include <QAction>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QDesktopServices>
+#include <QInputDialog>
 #include <QLabel>
+#include <QMenu>
+#include <QProcess>
+#include <QSettings>
 #include <QStyleFactory>
+#include <QUrl>
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QStandardPaths>
+#endif
+
+class QDesktopServices;
 using namespace GammaRay;
+struct IdeSettings {
+    const char* const app;
+    const char* const args;
+    const char* const name;
+    const char* const icon;
+};
+
+static const IdeSettings ideSettings[] = {
+#if defined(Q_OS_WIN) || defined(Q_OS_OSX)
+    {"",            "",                         "",                       ""          } // Dummy content, because we can't have empty arrays.
+#else
+    { "kdevelop",   "%f:%l:%c",                 QT_TR_NOOP("KDevelop"),   "kdevelop"  },
+    { "kate",       "%f --line %l --column %c", QT_TR_NOOP("Kate"),       "kate"      },
+    { "kwrite",     "%f --line %l --column %c", QT_TR_NOOP("KWrite"),     nullptr     },
+    { "qtcreator",  "%f",                       QT_TR_NOOP("Qt Creator"), nullptr     }
+#endif
+};
+#if defined(Q_OS_WIN) || defined(Q_OS_OSX) // Remove this #if branch when adding real data to ideSettings for Windows/OSX.
+    static const int ideSettingsSize = 0;
+#else
+    static const int ideSettingsSize = sizeof(ideSettings) / sizeof(IdeSettings);
+#endif
+
 
 MainWindow::MainWindow(QWidget *parent): QMainWindow(parent), ui(new Ui::MainWindow)
 {
@@ -127,6 +163,62 @@ MainWindow::MainWindow(QWidget *parent): QMainWindow(parent), ui(new Ui::MainWin
 
   // get some sane size on startup
   resize(1024, 768);
+
+  // Code Navigation
+  QAction *configAction = new QAction(QIcon::fromTheme("applications-development"), QObject::tr("Code Navigation"), this);
+  auto menu = new QMenu(this);
+  auto group = new QActionGroup(this);
+  group->setExclusive(true);
+
+  QSettings settings("KDAB", "GammaRay");
+  settings.beginGroup("CodeNavigation");
+  const auto currentIdx = settings.value("IDE", -1).toInt();
+
+  for (int i = 0; i < ideSettingsSize; ++i) {
+      auto action = new QAction(menu);
+      action->setText(QObject::tr(ideSettings[i].name));
+      if (ideSettings[i].icon)
+          action->setIcon(QIcon::fromTheme(ideSettings[i].icon));
+      action->setCheckable(true);
+      action->setChecked(currentIdx == i);
+      action->setData(i);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) // It's not worth it to reimplement missing findExecutable for Qt4.
+      action->setEnabled(!QStandardPaths::findExecutable(ideSettings[i].app).isEmpty());
+#endif
+      group->addAction(action);
+      menu->addAction(action);
+  }
+  menu->addSeparator();
+
+  QAction *action = new QAction(menu);
+  action->setText(QObject::tr("Custom..."));
+  action->setCheckable(true);
+  action->setChecked(currentIdx == -1);
+  action->setData(-1);
+  group->addAction(action);
+  menu->addAction(action);
+
+#if defined(Q_OS_WIN) || defined(Q_OS_OSX)
+  // This is a workaround for the cases, where we can't safely do assumptions
+  // about the install location of the IDE
+  action = new QAction(menu);
+  action->setText(QObject::tr("Automatic (No Line numbers)"));
+  action->setCheckable(true);
+  action->setChecked(currentIdx == -2);
+  action->setData(-2);
+  group->addAction(action);
+  menu->addAction(action);
+#endif
+
+  QObject::connect(group, SIGNAL(triggered()), this, SLOT(setCodeNavigationIDE()));
+
+  configAction->setMenu(menu);
+  ui->menuSettings->addMenu(menu);
+
+  // Initialize UiIntegration singleton
+  new UiIntegration(this);
+
+  connect(UiIntegration::instance(), SIGNAL(navigateToCode(QString, int, int)), this, SLOT(navigateToCode(QString, int, int)));
 }
 
 MainWindow::~MainWindow()
@@ -227,6 +319,54 @@ void MainWindow::toolSelected()
   }
   ui->actionsMenu->setEnabled(!ui->actionsMenu->isEmpty());
 }
+
+void MainWindow::navigateToCode(QString filePath, int lineNumber, int columnNumber)
+{
+  QSettings settings("KDAB", "GammaRay");
+  settings.beginGroup("CodeNavigation");
+  const auto ideIdx = settings.value("IDE", -1).toInt();
+
+  QString command;
+  if (ideIdx >= 0 && ideIdx < ideSettingsSize) {
+      command += ideSettings[ideIdx].app;
+      command += ' ';
+      command += ideSettings[ideIdx].args;
+  } else if (ideIdx == -1) {
+      command = settings.value("CustomCommand").toString();
+  } else {
+      QDesktopServices::openUrl(QUrl(filePath));
+  }
+
+  command.replace("%f", filePath);
+  command.replace("%l", QString::number(std::max(0, lineNumber)));
+  command.replace("%c", QString::number(std::max(0, columnNumber)));
+
+  if (!command.isEmpty())
+      QProcess::startDetached(command);
+}
+
+void GammaRay::MainWindow::setCodeNavigationIDE(QAction* action)
+{
+    QSettings settings("KDAB", "GammaRay");
+    settings.beginGroup("CodeNavigation");
+
+    if (action->data() == -1) {
+        const auto customCmd = QInputDialog::getText(
+            this, QObject::tr("Custom Code Navigation"),
+            QObject::tr("Specify command to use for code navigation, '%f' will be replaced by the file name, '%l' by the line number and '%c' by the column number."),
+            QLineEdit::Normal, settings.value("CustomCommand").toString()
+        );
+        if (!customCmd.isEmpty()) {
+            settings.setValue("CustomCommand", customCmd);
+            settings.setValue("IDE", -1);
+        }
+        return;
+    }
+
+    const auto defaultIde = action->data().toInt();
+    settings.setValue("IDE", defaultIde);
+}
+
 
 QWidget *MainWindow::createErrorPage(const QModelIndex &index)
 {

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -210,7 +210,7 @@ MainWindow::MainWindow(QWidget *parent): QMainWindow(parent), ui(new Ui::MainWin
   menu->addAction(action);
 #endif
 
-  QObject::connect(group, SIGNAL(triggered()), this, SLOT(setCodeNavigationIDE()));
+  QObject::connect(group, SIGNAL(triggered(QAction*)), this, SLOT(setCodeNavigationIDE(QAction*)));
 
   configAction->setMenu(menu);
   ui->menuSettings->addMenu(menu);

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -57,6 +57,8 @@ class MainWindow : public QMainWindow
 
     void quitHost();
     void detachProbe();
+    void navigateToCode(QString filePath, int lineNumber, int columnNumber);
+    void setCodeNavigationIDE(QAction *action);
 
   private:
     QWidget* createErrorPage(const QModelIndex &index);

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -21,7 +21,16 @@
        <string/>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -98,7 +107,7 @@ background-position:bottom right;
      <x>0</x>
      <y>0</y>
      <width>829</width>
-     <height>21</height>
+     <height>29</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_GammaRay">
@@ -124,9 +133,15 @@ background-position:bottom right;
      <string>&amp;Actions</string>
     </property>
    </widget>
+   <widget class="QMenu" name="menuSettings">
+    <property name="title">
+     <string>Setti&amp;ngs</string>
+    </property>
+   </widget>
    <addaction name="menu_GammaRay"/>
    <addaction name="actionsMenu"/>
    <addaction name="menu_Help"/>
+   <addaction name="menuSettings"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
    <property name="windowTitle">

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -140,8 +140,8 @@ background-position:bottom right;
    </widget>
    <addaction name="menu_GammaRay"/>
    <addaction name="actionsMenu"/>
-   <addaction name="menu_Help"/>
    <addaction name="menuSettings"/>
+   <addaction name="menu_Help"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
    <property name="windowTitle">

--- a/ui/uiintegration.cpp
+++ b/ui/uiintegration.cpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of GammaRay, the Qt application inspection and
+ * manipulation tool.
+ *
+ * Copyright (C) 2014-2015 Klar?lvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+ * Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+ *
+ * Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+ * accordance with GammaRay Commercial License Agreement provided with the Software.
+ *
+ * Contact info@kdab.com if any conditions of this licensing are not clear to you.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "uiintegration.h"
+
+using namespace GammaRay;
+
+UiIntegration* UiIntegration::s_uiIntegrationInstance = 0;
+
+UiIntegration::UiIntegration(QObject *parent)
+    : QObject(parent)
+{
+    Q_ASSERT(!s_uiIntegrationInstance);
+    s_uiIntegrationInstance = this;
+}
+
+UiIntegration::~UiIntegration()
+{
+    s_uiIntegrationInstance = 0;
+}
+
+UiIntegration * UiIntegration::instance()
+{
+    return s_uiIntegrationInstance;
+}
+

--- a/ui/uiintegration.h
+++ b/ui/uiintegration.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of GammaRay, the Qt application inspection and
+ * manipulation tool.
+ *
+ * Copyright (C) 2014-2015 Klar?lvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+ * Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+ *
+ * Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+ * accordance with GammaRay Commercial License Agreement provided with the Software.
+ *
+ * Contact info@kdab.com if any conditions of this licensing are not clear to you.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef UIINTEGRATION_H
+#define UIINTEGRATION_H
+
+#include "gammaray_ui_export.h"
+
+#include <QObject>
+
+namespace GammaRay {
+
+class GAMMARAY_UI_EXPORT UiIntegration : public QObject
+{
+    Q_OBJECT
+public:
+
+    UiIntegration(QObject *parent = 0);
+    virtual ~UiIntegration();
+
+    static UiIntegration* instance();
+
+Q_SIGNALS:
+    void navigateToCode(QString filePath, int lineNumber, int columnNumber);
+
+private:
+    /** Singleton instance. */
+    static UiIntegration *s_uiIntegrationInstance;
+};
+
+} // namespace GammaRay
+
+#endif // UIINTEGRATION_H


### PR DESCRIPTION
In quick inspector you can now right click an Item from the object
tree and click on "Show Code". This will open the source file, where
the item was declared, in the IDE selected via
Settings->Code Navigation. It also supports overriding the default
open action in order to integrate with an IDE directly (e.g. Qt
Creator).