### PR TITLE
Fix wrong destruction of MethodArgument.

### DIFF
--- a/common/methodargument.cpp
+++ b/common/methodargument.cpp
@@ -50,7 +50,7 @@ class GammaRay::MethodArgumentPrivate : public QSharedData
     ~MethodArgumentPrivate()
     {
       if (data)
-        QMetaType::destroy(value.type(), data);
+        QMetaType::destroy(value.userType(), data);
     }
 
     QVariant value;


### PR DESCRIPTION
The destructor of MethodArgument used type() to determine the type of
the QVariant stored in it. But type is QMetaType::UserType for all
user types. Thus it would try to call the destructor of QWidget*,
which is the first user type. That causes the value not to be
destructed and thus caused a memory leak, causing thousands of images
not to be destructed.
Now it uses userType() to correctly get the actual type
(userType() == type() for non-user types).