### PR TITLE
Global context menu support

### DIFF
--- a/client/probecontrollerclient.cpp
+++ b/client/probecontrollerclient.cpp
@@ -32,8 +32,21 @@
 
 using namespace GammaRay;
 
-ProbeControllerClient::ProbeControllerClient(QObject* parent): QObject(parent)
+ProbeControllerClient::ProbeControllerClient(QObject* parent)
+  : ProbeControllerInterface(parent)
 {
+}
+
+void ProbeControllerClient::selectObject(ObjectId id, const QString &toolId)
+{
+  Endpoint::instance()->invokeObject(objectName(), "selectObject",
+                                     QVariantList() << QVariant::fromValue(id) << toolId);
+}
+
+void ProbeControllerClient::requestSupportedTools(ObjectId id)
+{
+  Endpoint::instance()->invokeObject(objectName(), "requestSupportedTools",
+                                     QVariantList() << QVariant::fromValue(id));
 }
 
 void ProbeControllerClient::detachProbe()

--- a/common/objectmodel.h
+++ b/common/objectmodel.h
@@ -54,7 +54,8 @@ namespace ObjectModel {
     enum Role {
       // Qt4 uses 32, Qt5 256, for Qt::UserRole - use the latter globally to allow combining Qt4/5 client/servers.
       ObjectRole = 256 + 1, /**< the Object role */
-      UserRole                       /**< the UserRole, as defined by Qt */
+      ObjectIdRole,         /**< return ObjectId object */
+      UserRole              /**< the UserRole, as defined by Qt */
     };
 }
 

--- a/common/probecontrollerinterface.cpp
+++ b/common/probecontrollerinterface.cpp
@@ -30,8 +30,15 @@
 
 using namespace GammaRay;
 
-ProbeControllerInterface::ProbeControllerInterface()
+ProbeControllerInterface::ProbeControllerInterface(QObject *parent)
+  : QObject(parent)
 {
+  qRegisterMetaType<ObjectId>();
+  qRegisterMetaTypeStreamOperators<ObjectId>();
+  qRegisterMetaType<ToolInfo>();
+  qRegisterMetaTypeStreamOperators<ToolInfo>();
+  qRegisterMetaType<ToolInfos>();
+  qRegisterMetaTypeStreamOperators<ToolInfos>();
 }
 
 ProbeControllerInterface::~ProbeControllerInterface()

--- a/common/propertymodel.h
+++ b/common/propertymodel.h
@@ -43,7 +43,7 @@ namespace PropertyModel {
       ActionRole = 256 + 1, /**< the property action role */
       UserRole ,             /**< the UserRole, as defined by Qt */
       ValueRole,
-      AppropriateToolRole,
+      ObjectIdRole,
       ResetActionRole
     };
 

--- a/core/aggregatedpropertymodel.cpp
+++ b/core/aggregatedpropertymodel.cpp
@@ -38,6 +38,7 @@
 #include "varianthandler.h"
 #include "util.h"
 
+#include <common/probecontrollerinterface.h>
 #include <common/propertymodel.h>
 
 #include <QDebug>
@@ -125,7 +126,8 @@ QMap<int, QVariant> AggregatedPropertyModel::itemData(const QModelIndex& index) 
     res.insert(Qt::DisplayRole, data(adaptor, d, index.column(), Qt::DisplayRole));
     res.insert(Qt::ToolTipRole, data(adaptor, d, index.column(), Qt::ToolTipRole));
     res.insert(PropertyModel::ActionRole, data(adaptor, d, index.column(), PropertyModel::ActionRole));
-    res.insert(PropertyModel::AppropriateToolRole, data(adaptor, d, index.column(), PropertyModel::AppropriateToolRole));
+    res.insert(PropertyModel::ValueRole, data(adaptor, d, index.column(), PropertyModel::ValueRole));
+    res.insert(PropertyModel::ObjectIdRole, data(adaptor, d, index.column(), PropertyModel::ObjectIdRole));
     if (index.column() == 1) {
         res.insert(Qt::EditRole, data(adaptor, d, index.column(), Qt::EditRole));
         res.insert(Qt::DecorationRole, data(adaptor, d, index.column(), Qt::DecorationRole));
@@ -178,21 +180,14 @@ QVariant AggregatedPropertyModel::data(PropertyAdaptor *adaptor, const PropertyD
         }
         case PropertyModel::ValueRole:
             return d.value();
-        case PropertyModel::AppropriateToolRole:
-        {
-            ToolModel *toolModel = Probe::instance()->toolModel();
-            ToolFactory *factory = 0;
+        case PropertyModel::ObjectIdRole:
             if (d.value().canConvert<QObject*>()) {
-                factory = toolModel->data(toolModel->toolForObject(d.value().value<QObject*>()), ToolModelRole::ToolFactory).value<ToolFactory*>();
+                return QVariant::fromValue(ObjectId(d.value().value<QObject*>()));
             } else if (d.value().isValid()) {
-                const auto v = d.value();
-                factory = toolModel->data(toolModel->toolForObject(*reinterpret_cast<void* const*>(v.data()), v.typeName()), ToolModelRole::ToolFactory).value<ToolFactory*>();
-            }
-            if (factory) {
-                return factory->name();
+                const auto &v = d.value();
+                return QVariant::fromValue(ObjectId(*reinterpret_cast<void* const*>(v.data()), v.typeName()));
             }
             return QVariant();
-        }
     }
 
     return QVariant();

--- a/core/objectmodelbase.h
+++ b/core/objectmodelbase.h
@@ -39,6 +39,7 @@
 #define GAMMARAY_OBJECTMODELBASE_H
 
 #include "util.h"
+#include <common/probecontrollerinterface.h>
 #include <common/objectmodel.h>
 
 #include <QModelIndex>
@@ -59,6 +60,8 @@ class ObjectModelBase : public Base
      */
     explicit ObjectModelBase<Base>(QObject *parent) : Base(parent)
     {
+      qRegisterMetaType<ObjectId>();
+      qRegisterMetaTypeStreamOperators<ObjectId>();
     }
 
     /**
@@ -92,6 +95,8 @@ class ObjectModelBase : public Base
         }
       } else if (role == ObjectModel::ObjectRole) {
         return QVariant::fromValue(object);
+      } else if (role == ObjectModel::ObjectIdRole) {
+        return QVariant::fromValue(ObjectId(object));
       } else if (role == Qt::ToolTipRole) {
           return Util::tooltipForObject(object);
       } else if (role == Qt::DecorationRole && index.column() == 0) {
@@ -99,6 +104,13 @@ class ObjectModelBase : public Base
       }
 
       return QVariant();
+    }
+
+    QMap<int, QVariant> itemData(const QModelIndex& index) const
+    {
+      QMap<int, QVariant> map = Base::itemData(index);
+      map.insert(ObjectModel::ObjectIdRole, this->data(index, ObjectModel::ObjectIdRole));
+      return map;
     }
 
     /**

--- a/core/objecttreemodel.cpp
+++ b/core/objecttreemodel.cpp
@@ -104,6 +104,7 @@ void ObjectTreeModel::objectAdded(QObject *obj)
   endInsertRows();
 }
 
+
 void ObjectTreeModel::objectRemoved(QObject *obj)
 {
   // slot, hence should always land in main thread due to auto connection

--- a/core/probe.h
+++ b/core/probe.h
@@ -82,6 +82,7 @@ class GAMMARAY_CORE_EXPORT Probe : public QObject, public ProbeInterface
     bool needsObjectDiscovery() const Q_DECL_OVERRIDE;
     void discoverObject(QObject* object) Q_DECL_OVERRIDE;
     void selectObject(QObject* object, const QPoint& pos = QPoint()) Q_DECL_OVERRIDE;
+    void selectObject(QObject* object, const QString toolId, const QPoint& pos = QPoint()) Q_DECL_OVERRIDE;
     void selectObject(void* object, const QString& typeName) Q_DECL_OVERRIDE;
     void registerSignalSpyCallbackSet(const SignalSpyCallbackSet& callbacks) Q_DECL_OVERRIDE;
 
@@ -162,6 +163,8 @@ class GAMMARAY_CORE_EXPORT Probe : public QObject, public ProbeInterface
   private:
     friend class ProbeCreator;
     friend class BenchSuite;
+
+    void selectTool(const QModelIndex &toolModelSourceIndex);
 
     /* Returns @c true if we have working hooks in QtCore, that is we are notified reliably
      * about every QObject creation/destruction.

--- a/core/probecontroller.h
+++ b/core/probecontroller.h
@@ -33,7 +33,7 @@
 
 namespace GammaRay {
 
-class ProbeController : public QObject, public ProbeControllerInterface
+class ProbeController : public ProbeControllerInterface
 {
   Q_OBJECT
   Q_INTERFACES(GammaRay::ProbeControllerInterface)
@@ -41,6 +41,9 @@ public:
     explicit ProbeController(QObject *parent = 0);
 
 public slots:
+    void selectObject(GammaRay::ObjectId id, const QString &toolId) Q_DECL_OVERRIDE;
+    void requestSupportedTools(GammaRay::ObjectId id) Q_DECL_OVERRIDE;
+
     void detachProbe() Q_DECL_OVERRIDE;
     void quitHost() Q_DECL_OVERRIDE;
 };

--- a/core/probeinterface.h
+++ b/core/probeinterface.h
@@ -138,6 +138,8 @@ class ProbeInterface
      */
     virtual void selectObject(QObject *object, const QPoint &pos = QPoint()) = 0;
 
+    virtual void selectObject(QObject* object, const QString toolId, const QPoint &pos = QPoint()) = 0;
+
     /**
      * Notify the probe about the user selecting one of "your" objects.
      *

--- a/core/toolmodel.cpp
+++ b/core/toolmodel.cpp
@@ -184,38 +184,42 @@ PluginLoadErrors ToolModel::pluginErrors() const
   return m_pluginManager->errors();
 }
 
-QModelIndex ToolModel::toolForObject(QObject* object) const
+QModelIndexList ToolModel::toolsForObject(QObject* object) const
 {
   if (!object)
-    return QModelIndex();
+    return QModelIndexList();
+
+  QModelIndexList ret;
   const QMetaObject *metaObject = object->metaObject();
   while (metaObject) {
     for (int i = 0; i < m_tools.size(); i++) {
       const ToolFactory *factory = m_tools.at(i);
       if (factory && factory->supportedTypes().contains(metaObject->className())) {
-        return index(i, 0);
+        ret += index(i, 0);
       }
     }
     metaObject = metaObject->superClass();
   }
-  return QModelIndex();
+  return ret;
 }
 
-QModelIndex ToolModel::toolForObject(const void* object, const QString& typeName) const
+QModelIndexList ToolModel::toolsForObject(const void* object, const QString& typeName) const
 {
   if (!object)
-    return QModelIndex();
+    return QModelIndexList();
+
+  QModelIndexList ret;
   const MetaObject *metaObject = MetaObjectRepository::instance()->metaObject(typeName);
   while (metaObject) {
     for (int i = 0; i < m_tools.size(); i++) {
       const ToolFactory *factory = m_tools.at(i);
       if (factory && factory->supportedTypes().contains(metaObject->className())) {
-        return index(i, 0);
+        ret += index(i, 0);
       }
     }
     metaObject = metaObject->superClass();
   }
-  return QModelIndex();
+  return ret;
 }
 
 void ToolModel::addToolFactory(ToolFactory* tool)

--- a/core/toolmodel.h
+++ b/core/toolmodel.h
@@ -64,10 +64,10 @@ class ToolModel : public QAbstractListModel
     QVector<ToolFactory*> plugins() const;
     /** returns all plugin load errors. */
     PluginLoadErrors pluginErrors() const;
-    /** returns the tool that is best suited to show information about \p object. */
-    QModelIndex toolForObject(QObject *object) const;
-    /** returns the tool that is best suited to show information about \p object. */
-    QModelIndex toolForObject(const void *object, const QString &typeName) const;
+    /** returns the tools that are best suited to show information about \p object. */
+    QModelIndexList toolsForObject(QObject *object) const;
+    /** returns the tools that are best suited to show information about \p object. */
+    QModelIndexList toolsForObject(const void *object, const QString &typeName) const;
 
   public slots:
     /** Check if we have to activate tools for this type */

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -37,6 +37,7 @@
 
 #include <common/objectbroker.h>
 #include <common/objectmodel.h>
+#include <remote/serverproxymodel.h>
 
 #include <3rdparty/kde/krecursivefilterproxymodel.h>
 
@@ -52,7 +53,7 @@ ObjectInspector::ObjectInspector(ProbeInterface *probe, QObject *parent)
 
   m_propertyController = new PropertyController(QStringLiteral("com.kdab.GammaRay.ObjectInspector"), this);
 
-  auto proxy = new KRecursiveFilterProxyModel(this);
+  auto proxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
   proxy->setSourceModel(probe->objectTreeModel());
   probe->registerModel(QStringLiteral("com.kdab.GammaRay.ObjectInspectorTree"), proxy);
 

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(gammaray_ui_srcs
   aboutdata.cpp
   clienttoolmodel.cpp
+  contextmenuextension.cpp
   deferredresizemodesetter.cpp
   deferredtreeviewconfiguration.cpp
   editabletypesmodel.cpp

--- a/ui/contextmenuextension.cpp
+++ b/ui/contextmenuextension.cpp
@@ -1,0 +1,61 @@
+/*
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2010-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Kevin Funk <kevin.funk@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "contextmenuextension.h"
+#include "clienttoolmodel.h"
+
+#include <common/objectbroker.h>
+#include <common/probecontrollerinterface.h>
+
+#include <QMenu>
+
+using namespace GammaRay;
+
+ContextMenuExtension::ContextMenuExtension(ObjectId id)
+  : m_id(id)
+{
+}
+
+void ContextMenuExtension::populateMenu(QMenu *menu)
+{
+  if (m_id.isNull())
+    return;
+
+  auto probeController = ObjectBroker::object<ProbeControllerInterface*>();
+  probeController->requestSupportedTools(m_id);
+
+  // delay adding actions until we know the supported tools
+  connect(probeController, &ProbeControllerInterface::supportedToolsResponse,
+          menu, [menu](ObjectId id, const ToolInfos &toolInfos) {
+    foreach (const auto &toolInfo, toolInfos) {
+      auto action = menu->addAction(QObject::tr("Show in \"%1\" tool").arg(toolInfo.name));
+      connect(action, &QAction::triggered, [id, toolInfo]() {
+        auto probeController = ObjectBroker::object<ProbeControllerInterface*>();
+        probeController->selectObject(id, toolInfo.id);
+      });
+    }
+  });
+}

--- a/ui/contextmenuextension.h
+++ b/ui/contextmenuextension.h
@@ -1,11 +1,9 @@
 /*
-  probecontrollerclient.h
-
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2013-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2010-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Kevin Funk <kevin.funk@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,27 +24,31 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBECONTROLLERCLIENT_H
-#define GAMMARAY_PROBECONTROLLERCLIENT_H
+#ifndef GAMMARAY_CONTEXTMENUEXTENSION_H
+#define GAMMARAY_CONTEXTMENUEXTENSION_H
 
 #include <common/probecontrollerinterface.h>
 
+#include <QObject>
+#include <QVariant>
+
+class QMenu;
+
 namespace GammaRay {
 
-class ProbeControllerClient : public ProbeControllerInterface
+class ContextMenuExtension : public QObject
 {
   Q_OBJECT
-  Q_INTERFACES(GammaRay::ProbeControllerInterface)
+
 public:
-  explicit ProbeControllerClient(QObject *parent = 0);
+  explicit ContextMenuExtension(ObjectId id);
 
-  void selectObject(ObjectId id, const QString &toolId) Q_DECL_OVERRIDE;
-  void requestSupportedTools(ObjectId id) Q_DECL_OVERRIDE;
+  void populateMenu(QMenu *menu);
 
-  void detachProbe() Q_DECL_OVERRIDE;
-  void quitHost() Q_DECL_OVERRIDE;
+private:
+  ObjectId m_id;
 };
 
 }
 
-#endif // GAMMARAY_PROBECONTROLLERCLIENT_H
+#endif // GAMMARAY_CONTEXTMENUEXTENSION_H

--- a/ui/tools/objectinspector/objectinspectorwidget.cpp
+++ b/ui/tools/objectinspector/objectinspectorwidget.cpp
@@ -30,11 +30,15 @@
 #include "ui_objectinspectorwidget.h"
 
 #include <common/objectbroker.h>
+#include <common/objectmodel.h>
 
+#include <ui/contextmenuextension.h>
 #include <ui/deferredresizemodesetter.h>
 #include <ui/searchlinecontroller.h>
 
+#include <QDebug>
 #include <QLineEdit>
+#include <QMenu>
 #include <QItemSelectionModel>
 #include <QTimer>
 
@@ -44,11 +48,15 @@ ObjectInspectorWidget::ObjectInspectorWidget(QWidget *parent)
   : QWidget(parent),
     ui(new Ui::ObjectInspectorWidget)
 {
+  qRegisterMetaType<ObjectId>();
+  qRegisterMetaTypeStreamOperators<ObjectId>();
+
   ui->setupUi(this);
   ui->objectPropertyWidget->setObjectBaseName(QStringLiteral("com.kdab.GammaRay.ObjectInspector"));
 
   auto model = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ObjectInspectorTree"));
   ui->objectTreeView->setModel(model);
+  ui->objectTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
   new DeferredResizeModeSetter(ui->objectTreeView->header(), 0, QHeaderView::Stretch);
   new DeferredResizeModeSetter(ui->objectTreeView->header(), 1, QHeaderView::Interactive);
   new SearchLineController(ui->objectSearchLine, model);
@@ -63,6 +71,9 @@ ObjectInspectorWidget::ObjectInspectorWidget(QWidget *parent)
                               Qt::QueuedConnection,
                               Q_ARG(QString, QStringLiteral("Object")));
   }
+
+  connect(ui->objectTreeView, &QTreeView::customContextMenuRequested,
+          this, &ObjectInspectorWidget::objectContextMenuRequested);
 }
 
 ObjectInspectorWidget::~ObjectInspectorWidget()
@@ -75,4 +86,19 @@ void ObjectInspectorWidget::objectSelectionChanged(const QItemSelection& selecti
     return;
   const QModelIndex index = selection.first().topLeft();
   ui->objectTreeView->scrollTo(index);
+}
+
+void ObjectInspectorWidget::objectContextMenuRequested(const QPoint& pos)
+{
+  const auto index = ui->objectTreeView->indexAt(pos);
+  if (!index.isValid())
+    return;
+
+  const auto objectId = index.data(ObjectModel::ObjectIdRole).value<ObjectId>();
+  qWarning() << "FOO" << objectId;
+  QMenu menu(tr("Object @ %1").arg(QLatin1String("0x") + QString::number(objectId.id(), 16)));
+  ContextMenuExtension ext(objectId);
+  ext.populateMenu(&menu);
+
+  menu.exec(ui->objectTreeView->viewport()->mapToGlobal(pos));
 }

--- a/ui/tools/objectinspector/objectinspectorwidget.h
+++ b/ui/tools/objectinspector/objectinspectorwidget.h
@@ -66,6 +66,7 @@ class ObjectInspectorWidget : public QWidget
 
   private slots:
     void objectSelectionChanged(const QItemSelection &selection);
+    void objectContextMenuRequested(const QPoint &pos);
 
   private:
     QScopedPointer<Ui::ObjectInspectorWidget> ui;

--- a/ui/tools/objectinspector/propertiestab.cpp
+++ b/ui/tools/objectinspector/propertiestab.cpp
@@ -31,6 +31,7 @@
 #include "propertywidget.h"
 #include "editabletypesmodel.h"
 
+#include <ui/contextmenuextension.h>
 #include <ui/propertyeditor/propertyeditordelegate.h>
 #include <ui/propertyeditor/propertyeditorfactory.h>
 #include <ui/deferredresizemodesetter.h>
@@ -58,6 +59,9 @@ PropertiesTab::PropertiesTab(PropertyWidget *parent)
   m_ui->newPropertyButton->setIcon(QIcon::fromTheme(QStringLiteral("list-add")));
 
   setObjectBaseName(parent->objectBaseName());
+
+  qRegisterMetaType<ObjectId>();
+  qRegisterMetaTypeStreamOperators<ObjectId>();
 }
 
 PropertiesTab::~PropertiesTab()
@@ -147,10 +151,9 @@ void PropertiesTab::propertyContextMenu(const QPoint &pos)
     action->setData(PropertyModel::Reset);
   }
   if (actions & PropertyModel::NavigateTo) {
-    QAction *action =
-      contextMenu.addAction(tr("Show in \"%1\" tool").
-        arg(index.data(PropertyModel::AppropriateToolRole).toString()));
-    action->setData(PropertyModel::NavigateTo);
+    const auto objectId = index.data(PropertyModel::ObjectIdRole).value<ObjectId>();
+    ContextMenuExtension ext(objectId);
+    ext.populateMenu(&contextMenu);
   }
 
   if (QAction *action = contextMenu.exec(m_ui->propertyView->viewport()->mapToGlobal(pos))) {


### PR DESCRIPTION
Changes:
* ProbeController: Allow to select objects (QObjects-only atm)
* ProbeController: Allow to retrieve supports tools for a object
  (QObject-only)
* Introduce a (remotable) ObjectIdRole in ObjectModelBase
* Introduce ObjectId, a class storing a quint64 representing a raw
  pointer on the debuggee
* Introduce a ContextMenuExtension class, which can be used on client
  QAIVs (actually, wherever we may show context menus)
  * Input: ObjectId
  * Output: Actions added to a QMenu*
  * Presents available tools for the moment, nothing else

Only implemented for tech-preview for Object Inspector and Properties
Extension views

TODO:
* Support selecting non-QObjects again (needs more API in
  ProbeController)
* Figure out why we can't make pass ObjectId from server->client
  (currently transported as raw quint64)
* Limit the amount of tools shown (currently almost every tool is shown,
  as they support "QObject" (which every QObject inherits from,
  obviously)
* Split up in multiple commits

Task-Id: KDSME-10