### PR TITLE
Fix selection synchronization on server-side sorting/filtering.

### DIFF
--- a/client/selectionmodelclient.cpp
+++ b/client/selectionmodelclient.cpp
@@ -29,11 +29,25 @@
 #include "selectionmodelclient.h"
 #include "client.h"
 
+#include <QTimer>
+
 using namespace GammaRay;
 
 SelectionModelClient::SelectionModelClient(const QString& objectName, QAbstractItemModel* model, QObject* parent) :
-  NetworkSelectionModel(objectName, model, parent)
+  NetworkSelectionModel(objectName, model, parent), m_timer(new QTimer(this))
 {
+  m_timer->setSingleShot(true);
+  m_timer->setInterval(125);
+  Q_ASSERT(model);
+  // We do use a timer to group requests to avoid network overhead
+  connect(model, SIGNAL(modelAboutToBeReset()), this, SLOT(clearPendingSelection()));
+  connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)), m_timer, SLOT(start()));
+  connect(model, SIGNAL(rowsMoved(QModelIndex,int,int,QModelIndex,int)), m_timer, SLOT(start()));
+  connect(model, SIGNAL(columnsInserted(QModelIndex,int,int)), m_timer, SLOT(start()));
+  connect(model, SIGNAL(columnsMoved(QModelIndex,int,int,QModelIndex,int)), m_timer, SLOT(start()));
+  connect(model, SIGNAL(layoutChanged()), m_timer, SLOT(start()));
+  connect(m_timer, SIGNAL(timeout()), this, SLOT(timeout()));
+
   m_myAddress = Client::instance()->objectAddress(objectName);
   connect(Client::instance(), SIGNAL(objectRegistered(QString,Protocol::ObjectAddress)), SLOT(serverRegistered(QString,Protocol::ObjectAddress)));
   connect(Client::instance(), SIGNAL(objectUnregistered(QString,Protocol::ObjectAddress)),  SLOT(serverUnregistered(QString,Protocol::ObjectAddress)));
@@ -42,6 +56,7 @@ SelectionModelClient::SelectionModelClient(const QString& objectName, QAbstractI
 
 SelectionModelClient::~SelectionModelClient()
 {
+  m_timer->stop();
 }
 
 void SelectionModelClient::connectToServer()
@@ -49,7 +64,17 @@ void SelectionModelClient::connectToServer()
   if (m_myAddress == Protocol::InvalidObjectAddress)
     return;
   Client::instance()->registerMessageHandler(m_myAddress, this, "newMessage");
-  // TODO: send initial selection?
+  // There can be some delay between the selection model is created and its connections went done in the UI part.
+  // So, let delay the request a bit, not perfect but can help.
+  // Probably a better way would be to consider some GammaRay::Message to be pendable and put them in a pool
+  // to be handled again later.
+  // connectionEstablished does not seems to help here (bader).
+  QTimer::singleShot(125, this, SLOT(requestSelection()));
+}
+
+void SelectionModelClient::timeout()
+{
+  applyPendingSelection();
 }
 
 void SelectionModelClient::serverRegistered(const QString& objectName, Protocol::ObjectAddress objectAddress)
@@ -66,4 +91,3 @@ void SelectionModelClient::serverUnregistered(const QString& objectName, Protoco
   if (objectName == m_objectName)
     m_myAddress = Protocol::InvalidObjectAddress;
 }
-

--- a/client/selectionmodelclient.h
+++ b/client/selectionmodelclient.h
@@ -31,6 +31,8 @@
 
 #include <common/networkselectionmodel.h>
 
+class QTimer;
+
 namespace GammaRay {
 
 /** Client side of the network transparent QItemSelectionModel. */
@@ -42,11 +44,14 @@ public:
   ~SelectionModelClient();
 
 private slots:
+  void timeout();
   void serverRegistered(const QString &objectName, Protocol::ObjectAddress objectAddress);
   void serverUnregistered(const QString &objectName, Protocol::ObjectAddress objectAddress);
 
 private:
   void connectToServer();
+
+  QTimer *m_timer;
 };
 
 }

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -12,6 +12,7 @@ set(gammaray_common_srcs
   paths.cpp
   propertysyncer.cpp
   modelevent.cpp
+  modelutils.cpp
   paintanalyzerinterface.cpp
   sourcelocation.cpp
 

--- a/common/modelutils.cpp
+++ b/common/modelutils.cpp
@@ -32,12 +32,13 @@
 
 using namespace GammaRay;
 
-QModelIndexList ModelUtils::match(const QAbstractItemModel* model, const QModelIndex& start,
-    int role, bool (*accept)(const QVariant&), int hits, Qt::MatchFlags flags)
+QModelIndexList ModelUtils::match(const QModelIndex& start,
+    int role, MatchAcceptor accept, int hits, Qt::MatchFlags flags)
 {
-  if (!model || !start.isValid() || role < 0)
+  if (!start.isValid() || role < 0)
     return QModelIndexList();
 
+  const QAbstractItemModel *model = start.model();
   const QModelIndex parentIndex = model->parent(start);
   bool recurse = flags & Qt::MatchRecursive;
   bool wrap = flags & Qt::MatchWrap;
@@ -60,7 +61,7 @@ QModelIndexList ModelUtils::match(const QAbstractItemModel* model, const QModelI
 
       // search the hierarchy
       if (recurse && model->hasChildren(idx)) {
-        result += match(model, model->index(0, idx.column(), idx), role,
+        result += match(model->index(0, idx.column(), idx), role,
                         accept, (allHits ? -1 : hits - result.count()), flags);
       }
     }

--- a/common/modelutils.h
+++ b/common/modelutils.h
@@ -29,6 +29,8 @@
 #ifndef GAMMARAY_MODELUTILS_H
 #define GAMMARAY_MODELUTILS_H
 
+#include "gammaray_common_export.h"
+
 #include <QModelIndex>
 
 namespace GammaRay {
@@ -46,12 +48,15 @@ namespace ModelUtils {
   *
   * @see QAbstractItemModel::match(...)
   */
-  QModelIndexList match(const QAbstractItemModel* model, const QModelIndex& start,
-                              int role, bool (*accept)(const QVariant&),
+  typedef bool (*MatchAcceptor)(const QVariant&);
+  GAMMARAY_COMMON_EXPORT QModelIndexList match(const QModelIndex& start,
+                              int role, MatchAcceptor accept,
                               int hits = 1, Qt::MatchFlags flags = Qt::MatchFlags(Qt::MatchWrap));
 
 }
 
 }
+
+Q_DECLARE_METATYPE(GammaRay::ModelUtils::MatchAcceptor)
 
 #endif // GAMMARAY_MODELUTILS_H

--- a/common/networkselectionmodel.h
+++ b/common/networkselectionmodel.h
@@ -48,6 +48,11 @@ protected:
   QString m_objectName;
   Protocol::ObjectAddress m_myAddress;
 
+protected slots:
+  void requestSelection();
+  void sendSelection();
+  void applyPendingSelection();
+
 private:
   static Protocol::ItemSelection readSelection(const Message &msg);
   bool translateSelection(const Protocol::ItemSelection &selection, QItemSelection &qselection) const;
@@ -60,7 +65,6 @@ private slots:
   void slotCurrentRowChanged(const QModelIndex &current, const QModelIndex &previous);
   void slotSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
-  void applyPendingSelection();
   void clearPendingSelection();
 
 private:

--- a/common/protocol.cpp
+++ b/common/protocol.cpp
@@ -45,8 +45,8 @@ QModelIndex toQModelIndex(const QAbstractItemModel* model, const Protocol::Model
 {
   QModelIndex qmi;
 
-  for (int i = 0; i < index.size(); ++i) {
-    qmi = model->index(index.at(i).first, index.at(i).second, qmi);
+  for (Protocol::ModelIndex::ConstIterator it = index.constBegin(), end = index.constEnd(); it != end; ++it) {
+    qmi = model->index(it->first, it->second, qmi);
     if (!qmi.isValid()) {
       return QModelIndex(); // model isn't loaded to the full depth, so don't restart from the top
     }
@@ -57,7 +57,7 @@ QModelIndex toQModelIndex(const QAbstractItemModel* model, const Protocol::Model
 
 qint32 version()
 {
-  return 21;
+  return 22;
 }
 
 qint32 broadcastFormatVersion()

--- a/common/protocol.h
+++ b/common/protocol.h
@@ -69,6 +69,7 @@ enum BuildInMessageType {
   ModelSetDataRequest,
   ModelSortRequest,
   ModelSyncBarrier,
+  SelectionModelStateRequest,
 
   // server -> client
   ModelRowColumnCountReply,
@@ -84,6 +85,7 @@ enum BuildInMessageType {
   ModelColumnsRemoved,
   ModelReset,
   ModelLayoutChanged,
+  SelectionModelClearSelect,
 
   // server <-> client
   SelectionModelSelect,

--- a/config-gammaray.h.cmake
+++ b/config-gammaray.h.cmake
@@ -1,5 +1,8 @@
 #include <qglobal.h>
 
+#if !defined(CONFIG_GAMMARAY_H)
+#define CONFIG_GAMMARAY_H
+
 #cmakedefine GAMMARAY_INSTALL_QT_LAYOUT
 #define GAMMARAY_DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}"
 
@@ -50,3 +53,5 @@
 #cmakedefine HAVE_ELF
 
 #cmakedefine GAMMARAY_ENABLE_GPL_ONLY_FEATURES
+
+#endif // CONFIG_GAMMARAY_H

--- a/core/objectlistmodel.cpp
+++ b/core/objectlistmodel.cpp
@@ -31,6 +31,7 @@
 #include "probe.h"
 
 #include <QThread>
+#include <QCoreApplication>
 
 #include <algorithm>
 #include <iostream>
@@ -45,6 +46,12 @@ ObjectListModel::ObjectListModel(Probe *probe)
           this, SLOT(objectAdded(QObject*)));
   connect(probe, SIGNAL(objectDestroyed(QObject*)),
           this, SLOT(objectRemoved(QObject*)));
+}
+
+QPair<int, QVariant> ObjectListModel::defaultSelectedItem() const
+{
+  // select the qApp object (if any) in the object model
+  return QPair<int, QVariant>(ObjectModel::ObjectRole, QVariant::fromValue<QObject*>(qApp));
 }
 
 QVariant ObjectListModel::data(const QModelIndex &index, int role) const

--- a/core/objectlistmodel.h
+++ b/core/objectlistmodel.h
@@ -59,6 +59,9 @@ class ObjectListModel : public ObjectModelBase<QAbstractTableModel>
     int columnCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
 
+  public slots:
+    QPair<int, QVariant> defaultSelectedItem() const;
+
   private slots:
     void objectAdded(QObject *obj);
     void objectRemoved(QObject *obj);

--- a/core/objecttreemodel.cpp
+++ b/core/objecttreemodel.cpp
@@ -33,6 +33,7 @@
 #include <QEvent>
 #include <QMutex>
 #include <QThread>
+#include <QCoreApplication>
 
 #include <algorithm>
 #include <iostream>
@@ -53,6 +54,12 @@ ObjectTreeModel::ObjectTreeModel(Probe *probe)
           this, SLOT(objectRemoved(QObject*)));
   connect(probe, SIGNAL(objectReparented(QObject*)),
           this, SLOT(objectReparented(QObject*)));
+}
+
+QPair<int, QVariant> ObjectTreeModel::defaultSelectedItem() const
+{
+  // select the qApp object (if any) in the object model
+  return QPair<int, QVariant>(ObjectModel::ObjectRole, QVariant::fromValue<QObject*>(qApp));
 }
 
 static inline QObject *parentObject(QObject *obj)

--- a/core/objecttreemodel.h
+++ b/core/objecttreemodel.h
@@ -48,6 +48,9 @@ class ObjectTreeModel : public ObjectModelBase<QAbstractItemModel>
     QModelIndex parent(const QModelIndex &child) const Q_DECL_OVERRIDE;
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
 
+  public slots:
+    QPair<int, QVariant> defaultSelectedItem() const;
+
   private slots:
     void objectAdded(QObject *obj);
     void objectRemoved(QObject *obj);

--- a/core/remote/selectionmodelserver.h
+++ b/core/remote/selectionmodelserver.h
@@ -31,6 +31,8 @@
 
 #include <common/networkselectionmodel.h>
 
+class QTimer;
+
 namespace GammaRay {
 
 /** Server-side of the network transparent QItemSelection model. */
@@ -40,6 +42,12 @@ class SelectionModelServer : public NetworkSelectionModel
 public:
   explicit SelectionModelServer(const QString& objectName, QAbstractItemModel* model, QObject* parent);
   ~SelectionModelServer();
+
+private slots:
+  void timeout();
+
+private:
+  QTimer *m_timer;
 };
 
 }

--- a/core/toolmodel.cpp
+++ b/core/toolmodel.cpp
@@ -225,6 +225,12 @@ QModelIndexList ToolModel::toolsForObject(const void* object, const QString& typ
   return ret;
 }
 
+QPair<int, QVariant> ToolModel::defaultSelectedItem() const
+{
+  // Select the Objects tool by default
+  return QPair<int, QVariant>(ToolModelRole::ToolId, QStringLiteral("GammaRay::ObjectInspector"));
+}
+
 void ToolModel::addToolFactory(ToolFactory* tool)
 {
     m_tools.push_back(tool);

--- a/core/toolmodel.h
+++ b/core/toolmodel.h
@@ -70,6 +70,7 @@ class ToolModel : public QAbstractListModel
     QModelIndexList toolsForObject(const void *object, const QString &typeName) const;
 
   public slots:
+    QPair<int, QVariant> defaultSelectedItem() const;
     /** Check if we have to activate tools for this type */
     void objectAdded(QObject *obj);
 

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -92,7 +92,7 @@ void MetaObjectBrowser::objectSelected(void *obj, const QString &typeName)
 
 void MetaObjectBrowser::metaObjectSelected(const QMetaObject *mo)
 {
-    const auto indexes = m_model->match(QModelIndex(), MetaObjectTreeModel::MetaObjectRole, QVariant::fromValue(mo));
+    const auto indexes = m_model->match(m_model->index(0,0), MetaObjectTreeModel::MetaObjectRole, QVariant::fromValue(mo));
     if (indexes.isEmpty())
         return;
     ObjectBroker::selectionModel(m_model)->select(indexes.first(), QItemSelectionModel::Rows | QItemSelectionModel::ClearAndSelect);

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -64,24 +64,6 @@ ObjectInspector::ObjectInspector(ProbeInterface *probe, QObject *parent)
           SLOT(objectSelectionChanged(QItemSelection)));
 
   connect(probe->probe(), SIGNAL(objectSelected(QObject*,QPoint)), SLOT(objectSelected(QObject*)));
-
-  // when we end up here the object model isn't populated yet
-  // TODO defer this call until a client connects
-  QMetaObject::invokeMethod(this, "selectDefaultItem", Qt::QueuedConnection);
-}
-
-void ObjectInspector::selectDefaultItem()
-{
-  // select the qApp object (if any) in the object treeView
-  const QAbstractItemModel *viewModel = m_selectionModel->model();
-  Model::used(viewModel);
-  const QModelIndexList matches = viewModel->match(viewModel->index(0, 0),
-      ObjectModel::ObjectRole, QVariant::fromValue<QObject*>(qApp), 1,
-      Qt::MatchFlags(Qt::MatchExactly|Qt::MatchRecursive));
-
-  if (!matches.isEmpty()) {
-    m_selectionModel->setCurrentIndex(matches.first(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-  }
 }
 
 void ObjectInspector::objectSelectionChanged(const QItemSelection& selection)

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -48,7 +48,6 @@ class ObjectInspector : public QObject
     explicit ObjectInspector(ProbeInterface *probe, QObject *parent = 0);
 
   private slots:
-    void selectDefaultItem();
     void objectSelected(const QModelIndex &index);
     void objectSelectionChanged(const QItemSelection &selection);
     void objectSelected(QObject *object);

--- a/plugins/objectvisualizer/objectvisualizerwidget.cpp
+++ b/plugins/objectvisualizer/objectvisualizerwidget.cpp
@@ -68,30 +68,12 @@ GraphViewerWidget::GraphViewerWidget(QWidget *parent)
   QHBoxLayout *hbox = new QHBoxLayout(this);
   hbox->addWidget(splitter);
 
-  QMetaObject::invokeMethod(this, "delayedInit", Qt::QueuedConnection);
+  mWidget->vtkWidget()->setModel(mModel);
+  mWidget->vtkWidget()->setSelectionModel(mObjectTreeView->selectionModel());
 }
 
 GraphViewerWidget::~GraphViewerWidget()
 {
-}
-
-void GraphViewerWidget::delayedInit()
-{
-  // make all existing objects known to the vtk widget
-  mWidget->vtkWidget()->setModel(mModel);
-  mWidget->vtkWidget()->setSelectionModel(mObjectTreeView->selectionModel());
-
-  /// FIXME: This won't work for remote clients!
-  // select the qApp object (if any) in the object treeView
-  const QAbstractItemModel *viewModel = mObjectTreeView->model();
-  const QModelIndexList matches = viewModel->match(viewModel->index(0, 0),
-      ObjectModel::ObjectRole, QVariant::fromValue<QObject*>(qApp), 1,
-      Qt::MatchFlags(Qt::MatchExactly|Qt::MatchRecursive));
-
-  if (!matches.isEmpty()) {
-    Q_ASSERT(matches.first().data(ObjectModel::ObjectRole).value<QObject*>() == qApp);
-    mObjectTreeView->setCurrentIndex(matches.first());
-  }
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/plugins/objectvisualizer/objectvisualizerwidget.h
+++ b/plugins/objectvisualizer/objectvisualizerwidget.h
@@ -46,9 +46,6 @@ class GraphViewerWidget : public QWidget
     explicit GraphViewerWidget(QWidget *parent = 0);
     virtual ~GraphViewerWidget();
 
-  private Q_SLOTS:
-    void delayedInit();
-
   private:
     QAbstractItemModel* mModel;
     QTreeView *mObjectTreeView;

--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -112,10 +112,6 @@ SceneInspector::SceneInspector(ProbeInterface *probe, QObject *parent)
   m_itemSelectionModel = ObjectBroker::selectionModel(sceneProxy);
   connect(m_itemSelectionModel, SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
           this, SLOT(sceneItemSelected(QItemSelection)));
-
-  if (singleColumnProxy->rowCount()) {
-    sceneSelection->setCurrentIndex(singleColumnProxy->index(0, 0), QItemSelectionModel::ClearAndSelect);
-  }
 }
 
 void SceneInspector::sceneSelected(const QItemSelection& selection)

--- a/plugins/statemachineviewer/statemachineviewerwidgetng.cpp
+++ b/plugins/statemachineviewer/statemachineviewerwidgetng.cpp
@@ -166,7 +166,7 @@ StateMachineViewerWidgetNG::StateMachineViewerWidgetNG(QWidget* parent, Qt::Wind
   m_ui->singleStateMachineView->setSelectionMode(QAbstractItemView::ExtendedSelection);
   new DeferredResizeModeSetter(m_ui->singleStateMachineView->header(), 0, QHeaderView::Stretch);
   new DeferredResizeModeSetter(m_ui->singleStateMachineView->header(), 1, QHeaderView::ResizeToContents);
-  new DeferredTreeViewConfiguration(m_ui->singleStateMachineView, true, false);
+  new DeferredTreeViewConfiguration(m_ui->singleStateMachineView, true);
   m_ui->singleStateMachineView->setItemDelegate(new StateModelDelegate(this));
 
   connect(m_ui->actionStartStopStateMachine, SIGNAL(triggered()), m_interface, SLOT(toggleRunning()));

--- a/plugins/widgetinspector/CMakeLists.txt
+++ b/plugins/widgetinspector/CMakeLists.txt
@@ -5,7 +5,6 @@ set(gammaray_widgetinspector_plugin_srcs
   widgetinspectorserver.cpp
   overlaywidget.cpp
   widgettreemodel.cpp
-  modelutils.cpp
 )
 
 gammaray_add_plugin(gammaray_widgetinspector_plugin

--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -33,7 +33,6 @@
 
 #include "overlaywidget.h"
 #include "widgettreemodel.h"
-#include "modelutils.h"
 
 #include "core/propertycontroller.h"
 #include "core/metaobject.h"
@@ -50,6 +49,7 @@
 #include "common/objectbroker.h"
 #include "common/settempvalue.h"
 #include "common/metatypedeclarations.h"
+#include "common/modelutils.h"
 #include "common/objectmodel.h"
 #include "common/paths.h"
 #include <common/remoteviewframe.h>
@@ -111,9 +111,6 @@ WidgetInspectorServer::WidgetInspectorServer(ProbeInterface *probe, QObject *par
           SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
           SLOT(widgetSelected(QItemSelection)));
 
-  // TODO this needs to be delayed until there actually is something to select
-  selectDefaultItem();
-
   if (m_probe->needsObjectDiscovery()) {
     connect(m_probe->probe(), SIGNAL(objectCreated(QObject*)), SLOT(objectCreated(QObject*)));
     discoverObjects();
@@ -131,24 +128,6 @@ WidgetInspectorServer::~WidgetInspectorServer()
   disconnect(m_overlayWidget, SIGNAL(destroyed(QObject*)),
              this, SLOT(recreateOverlayWidget()));
   delete m_overlayWidget.data();
-}
-
-static bool isMainWindowSubclassAcceptor(const QVariant &v)
-{
-  return qobject_cast<QMainWindow*>(v.value<QObject*>());
-}
-
-void WidgetInspectorServer::selectDefaultItem()
-{
-  const QAbstractItemModel *viewModel = m_widgetSelectionModel->model();
-  const QModelIndexList matches =
-    ModelUtils::match(
-      viewModel, viewModel->index(0, 0),
-      ObjectModel::ObjectRole, isMainWindowSubclassAcceptor);
-
-  if (!matches.isEmpty()) {
-    m_widgetSelectionModel->select(matches.first(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-  }
 }
 
 void WidgetInspectorServer::widgetSelected(const QItemSelection &selection)

--- a/plugins/widgetinspector/widgetinspectorserver.h
+++ b/plugins/widgetinspector/widgetinspectorserver.h
@@ -56,8 +56,6 @@ class WidgetInspectorServer : public WidgetInspectorInterface
     explicit WidgetInspectorServer(ProbeInterface *probe, QObject *parent = 0);
     ~WidgetInspectorServer();
 
-    void selectDefaultItem();
-
   protected:
     bool eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
 

--- a/plugins/widgetinspector/widgettreemodel.cpp
+++ b/plugins/widgetinspector/widgettreemodel.cpp
@@ -27,6 +27,7 @@
 */
 
 #include "widgettreemodel.h"
+#include "common/modelutils.h"
 
 #include <QApplication>
 #include <QLayout>
@@ -35,9 +36,21 @@
 
 using namespace GammaRay;
 
+static bool isMainWindowSubclassAcceptor(const QVariant &v)
+{
+  const QObject *object = v.value<QObject*>();
+  return object && object->inherits("QMainWindow");
+}
+
 WidgetTreeModel::WidgetTreeModel(QObject *parent)
   : ObjectFilterProxyModelBase(parent)
 {
+}
+
+QPair<int, QVariant> WidgetTreeModel::defaultSelectedItem() const
+{
+  // select the first QMainwindow window (if any) in the widget model
+  return QPair<int, QVariant>(ObjectModel::ObjectRole, QVariant::fromValue(&isMainWindowSubclassAcceptor));
 }
 
 QVariant WidgetTreeModel::data(const QModelIndex &index, int role) const

--- a/plugins/widgetinspector/widgettreemodel.h
+++ b/plugins/widgetinspector/widgettreemodel.h
@@ -43,6 +43,9 @@ class WidgetTreeModel : public ObjectFilterProxyModelBase
     explicit WidgetTreeModel(QObject *parent = 0);
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
 
+  public slots:
+    QPair<int, QVariant> defaultSelectedItem() const;
+
   protected:
     bool filterAcceptsObject(QObject *object) const Q_DECL_OVERRIDE;
 };

--- a/ui/deferredtreeviewconfiguration.h
+++ b/ui/deferredtreeviewconfiguration.h
@@ -33,9 +33,11 @@
 
 #include <QObject>
 #include <QVector>
+#include <QPersistentModelIndex>
 
 class QModelIndex;
 class QTreeView;
+class QTimer;
 
 namespace GammaRay {
 
@@ -56,20 +58,23 @@ class GAMMARAY_UI_EXPORT DeferredTreeViewConfiguration : public QObject
   Q_OBJECT
   public:
     explicit DeferredTreeViewConfiguration(QTreeView *view,
-                                           bool expandNewContent = true, bool selectNewContent = true,
-                                           QObject *parent = 0);
+                                           bool expandNewContent = true, QObject *parent = 0);
+    ~DeferredTreeViewConfiguration();
 
     void hideColumn(int column);
 
   private slots:
     void rowsInserted(const QModelIndex &parent);
     void columnsInserted(const QModelIndex &parent);
+    void timeout();
 
   private:
     QTreeView *m_view;
     bool m_expand;
-    bool m_select;
+    bool m_allExpanded;
+    QVector<QPersistentModelIndex> m_insertedRows;
     QVector<int> m_hiddenColumns;
+    QTimer *m_timer;
 };
 
 }

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -156,10 +156,6 @@ MainWindow::MainWindow(QWidget *parent): QMainWindow(parent), ui(new Ui::MainWin
 
   setWindowTitle(tr("GammaRay (%1)").arg(Endpoint::instance()->label()));
 
-  selectInitialTool();
-  connect(ui->toolSelector->model(), SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(selectInitialTool()));
-  connect(ui->toolSelector->model(), SIGNAL(dataChanged(QModelIndex,QModelIndex)), this, SLOT(selectInitialTool()));
-
 #ifdef Q_OS_MAC
   ui->groupBox->setFlat(true);
   ui->horizontalLayout->setContentsMargins(0, 0, 0, 0);
@@ -275,20 +271,6 @@ void MainWindow::showMessageStatistics()
     view->setModel(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.MessageStatisticsModel")));
     view->horizontalHeader()->setResizeMode(0, QHeaderView::ResizeToContents);
     view->showMaximized();
-}
-
-void MainWindow::selectInitialTool()
-{
-  QAbstractItemModel *model = ui->toolSelector->model();
-  QModelIndexList matches =
-  model->match(model->index(0, 0), ToolModelRole::ToolId, QStringLiteral("GammaRay::ObjectInspector"));
-  if (matches.isEmpty()) {
-    return;
-  }
-
-  disconnect(ui->toolSelector->model(), 0, this, SLOT(selectInitialTool()));
-  ui->toolSelector->setCurrentIndex(matches.first());
-  toolSelected();
 }
 
 void MainWindow::toolSelected()

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -55,7 +55,6 @@ class MainWindow : public QMainWindow
     void showMessageStatistics();
 
     void toolSelected();
-    void selectInitialTool();
 
     void quitHost();
     void detachProbe();


### PR DESCRIPTION
The server is now maintaining a 'at least one row selected' per model
via the NSM::requestSelection().
The UI part should no longer set explicit default selection on its own.

Task-Id: KDEND-43