### PR TITLE
Use the property editor delegate in the model inspector.

### DIFF
--- a/ui/itemdelegate.h
+++ b/ui/itemdelegate.h
@@ -35,15 +35,13 @@
 
 namespace GammaRay {
 
-/** @brief A simple delegate that avoid empty display role texts.
+/** @brief A simple interface that avoid empty display role texts.
  */
-
-class GAMMARAY_UI_EXPORT ItemDelegate : public QStyledItemDelegate
+class GAMMARAY_UI_EXPORT ItemDelegateInterface
 {
-  Q_OBJECT
-
 public:
-  explicit ItemDelegate(QObject *parent = 0);
+  ItemDelegateInterface();
+  explicit ItemDelegateInterface(const QString &placeholderText);
 
   // You can put 2 placeholders for row/column using %r and %c
   QString placeholderText() const;
@@ -53,14 +51,27 @@ public:
   QSet<int> placeholderColumns() const;
   void setPlaceholderColumns(const QSet<int> &placeholderColumns);
 
-  void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
-
-private:
+protected:
   QString defaultDisplayText(const QModelIndex &index) const;
+
+  const QWidget *widget(const QStyleOptionViewItem &option) const;
+  QStyle *style(const QStyleOptionViewItem &option) const;
 
 private:
   QString m_placeholderText;
   QSet<int> m_placeholderColumns;
+};
+
+/** @brief A simple delegate that avoid empty display role texts.
+ */
+class GAMMARAY_UI_EXPORT ItemDelegate : public QStyledItemDelegate, public ItemDelegateInterface
+{
+  Q_OBJECT
+
+public:
+  explicit ItemDelegate(QObject *parent = 0);
+
+  void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 };
 
 } // Namespace GammaRay

--- a/ui/propertyeditor/propertyeditordelegate.h
+++ b/ui/propertyeditor/propertyeditordelegate.h
@@ -30,17 +30,19 @@
 #define GAMMARAY_PROPERTYEDITORDELEGATE_H
 
 #include "gammaray_ui_export.h"
+#include "ui/itemdelegate.h"
 #include <QStyledItemDelegate>
 
 class QMatrix4x4;
 
 namespace GammaRay {
 
-class GAMMARAY_UI_EXPORT PropertyEditorDelegate : public QStyledItemDelegate
+class GAMMARAY_UI_EXPORT PropertyEditorDelegate : public QStyledItemDelegate, public ItemDelegateInterface
 {
     Q_OBJECT
 public:
     explicit PropertyEditorDelegate(QObject *parent);
+    explicit PropertyEditorDelegate(const QString &placeholderText, QObject *parent);
     ~PropertyEditorDelegate();
 
     void setEditorData(QWidget* editor, const QModelIndex& index) const Q_DECL_OVERRIDE;

--- a/ui/tools/modelinspector/modelinspectorwidget.cpp
+++ b/ui/tools/modelinspector/modelinspectorwidget.cpp
@@ -32,6 +32,7 @@
 
 #include <ui/itemdelegate.h>
 #include <ui/searchlinecontroller.h>
+#include <ui/propertyeditor/propertyeditordelegate.h>
 
 #include <common/endpoint.h>
 #include <common/objectbroker.h>
@@ -58,9 +59,10 @@ ModelInspectorWidget::ModelInspectorWidget(QWidget *parent)
   ui->modelView->setDeferredResizeMode(0, QHeaderView::ResizeToContents);
 
   ui->modelContentView->header()->setObjectName("modelContentViewHeader");
-  ui->modelContentView->setItemDelegate(new ItemDelegate(this));
+  ui->modelContentView->setItemDelegate(new PropertyEditorDelegate(ItemDelegate::tr("(Item %r)"), this));
 
   ui->modelCellView->header()->setObjectName("modelCellViewHeader");
+  ui->modelCellView->setItemDelegate(new PropertyEditorDelegate(this));
 
   ObjectBroker::registerClientObjectFactoryCallback<ModelInspectorInterface*>(createModelInspectorClient);
   m_interface = ObjectBroker::object<ModelInspectorInterface*>();


### PR DESCRIPTION
As this inspector used special delegate to avoid empty cells,
the delegate code was splitted to be merged into PropertyEditorDelegate.