### PR TITLE
Fix incorrect editor height on OSX.

### DIFF
--- a/ui/propertyeditor/propertyextendededitor.ui
+++ b/ui/propertyeditor/propertyextendededitor.ui
@@ -21,10 +21,22 @@
     <widget class="QLabel" name="valueLabel"/>
    </item>
    <item>
-    <widget class="QPushButton" name="editButton">
-     <property name="text">
-      <string>...</string>
-     </property>
+    <widget class="QWidget" name="widget" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="editButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
On OSX when a button is used in a layout, its sibling widgets
get extra margin, reducing their heights.
In this case, the label height was too small to be readable.

To break this weirdness layout behavior on OSX, we need to put the
button in a dedicated widget.