### PR TITLE
Introduce multiline editor for String properties

### DIFF
--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -36,6 +36,7 @@ set(gammaray_ui_srcs
   propertyeditor/propertymatrixdialog.cpp
   propertyeditor/propertymatrixeditor.cpp
   propertyeditor/propertymatrixmodel.cpp
+  propertyeditor/propertytexteditor.cpp
 
   tools/localeinspector/localeinspectorwidget.cpp
   tools/messagehandler/messagedisplaymodel.cpp
@@ -76,6 +77,7 @@ qt4_wrap_ui(gammaray_ui_srcs
   propertyeditor/propertyextendededitor.ui
   propertyeditor/propertyintpaireditor.ui
   propertyeditor/propertymatrixdialog.ui
+  propertyeditor/propertytexteditor.ui
   propertyeditor/palettedialog.ui
 
   tools/localeinspector/localeinspectorwidget.ui

--- a/ui/propertyeditor/propertyeditordelegate.cpp
+++ b/ui/propertyeditor/propertyeditordelegate.cpp
@@ -190,6 +190,25 @@ QSize PropertyEditorDelegate::sizeHint(const QStyleOptionViewItem& option, const
         return sizeHint(option, index, value.value<QQuaternion>());
 #endif
     }
+
+    // We don't want multiline texts for String values
+    if (value.type() == QVariant::String) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+        QStyleOptionViewItem opt = option;
+#else
+        QStyleOptionViewItemV4 opt = *qstyleoption_cast<const QStyleOptionViewItemV4*>(&option);
+#endif
+
+        if (opt.text.isEmpty() && !placeholderText().isEmpty()) {
+            opt.text = defaultDisplayText(index);
+        }
+
+        QSize sh = QStyledItemDelegate::sizeHint(opt, index);
+
+        initStyleOption(&opt, index);
+        return sh.boundedTo(QSize(sh.width(), opt.fontMetrics.height()));
+    }
+
     return QStyledItemDelegate::sizeHint(option, index);
 }
 

--- a/ui/propertyeditor/propertyeditorfactory.cpp
+++ b/ui/propertyeditor/propertyeditorfactory.cpp
@@ -33,6 +33,7 @@
 #include "propertydoublepaireditor.h"
 #include "propertypaletteeditor.h"
 #include "propertymatrixeditor.h"
+#include "propertytexteditor.h"
 
 #include <QItemEditorFactory>
 
@@ -49,6 +50,7 @@ PropertyEditorFactory::PropertyEditorFactory()
   addEditor(QVariant::PointF, new QStandardItemEditorCreator<PropertyPointFEditor>());
   addEditor(QVariant::Size, new QStandardItemEditorCreator<PropertySizeEditor>());
   addEditor(QVariant::SizeF, new QStandardItemEditorCreator<PropertySizeFEditor>());
+  addEditor(QVariant::String, new QStandardItemEditorCreator<PropertyTextEditor>());
   addEditor(QVariant::Transform, new QStandardItemEditorCreator<PropertyMatrixEditor>());
   addEditor(QVariant::Matrix, new QStandardItemEditorCreator<PropertyMatrixEditor>());
   addEditor(QVariant::Matrix4x4, new QStandardItemEditorCreator<PropertyMatrixEditor>());
@@ -98,7 +100,6 @@ void PropertyEditorFactory::initBuiltInTypes()
     << QVariant::UInt
     << QVariant::Date
     << QVariant::DateTime
-    << QVariant::String
     << QVariant::Time;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)

--- a/ui/propertyeditor/propertyextendededitor.cpp
+++ b/ui/propertyeditor/propertyextendededitor.cpp
@@ -46,6 +46,16 @@ PropertyExtendedEditor::~PropertyExtendedEditor()
   delete ui;
 }
 
+Qt::Alignment PropertyExtendedEditor::alignment() const
+{
+    return ui->valueLabel->alignment();
+}
+
+void PropertyExtendedEditor::setAlignment(const Qt::Alignment &alignment)
+{
+    ui->valueLabel->setAlignment(alignment);
+}
+
 QVariant PropertyExtendedEditor::value() const
 {
   return m_value;

--- a/ui/propertyeditor/propertyextendededitor.h
+++ b/ui/propertyeditor/propertyextendededitor.h
@@ -47,6 +47,9 @@ class PropertyExtendedEditor : public QWidget
     explicit PropertyExtendedEditor(QWidget *parent = 0);
     virtual ~PropertyExtendedEditor();
 
+    Qt::Alignment alignment() const;
+    void setAlignment(const Qt::Alignment &alignment);
+
     QVariant value() const;
     void setValue(const QVariant &value);
 

--- a/ui/propertyeditor/propertytexteditor.cpp
+++ b/ui/propertyeditor/propertytexteditor.cpp
@@ -1,0 +1,91 @@
+/*
+  propertytexteditor.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2011-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "propertytexteditor.h"
+
+#include "ui_propertytexteditor.h"
+
+#include <QToolButton>
+
+using namespace GammaRay;
+
+PropertyTextEditorDialog::PropertyTextEditorDialog(const QString &text, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::PropertyTextEditorDialog)
+{
+    ui->setupUi(this);
+    ui->plainTextEdit->setPlainText(text);
+}
+
+PropertyTextEditorDialog::~PropertyTextEditorDialog()
+{
+}
+
+QString PropertyTextEditorDialog::text() const
+{
+    return ui->plainTextEdit->toPlainText();
+}
+
+PropertyTextEditor::PropertyTextEditor(QWidget *parent)
+    : QLineEdit(parent)
+{
+    QHBoxLayout *hl = new QHBoxLayout(this);
+    hl->setMargin(0);
+    hl->setSpacing(1);
+
+    QToolButton *editButton = new QToolButton(this);
+    editButton->setText(QStringLiteral("..."));
+
+    QMargins margins(textMargins());
+    margins.setRight(editButton->sizeHint().width() + hl->spacing());
+
+    setFrame(false);
+    setTextMargins(margins);
+
+    hl->addStretch();
+    hl->addWidget(editButton);
+
+    connect(editButton, SIGNAL(clicked()), SLOT(edit()));
+}
+
+void PropertyTextEditor::save(const QString &text)
+{
+    setText(text);
+
+    // The user already pressed Apply, don't force her/him to do again
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Enter, Qt::NoModifier);
+    QApplication::sendEvent(this, &event);
+}
+
+void PropertyTextEditor::edit()
+{
+    PropertyTextEditorDialog dlg(text(), this);
+    if (dlg.exec() == QDialog::Accepted) {
+      save(dlg.text());
+    }
+}

--- a/ui/propertyeditor/propertytexteditor.h
+++ b/ui/propertyeditor/propertytexteditor.h
@@ -1,0 +1,70 @@
+/*
+  propertytexteditor.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2011-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROPERTYTEXTEDITOR_H
+#define GAMMARAY_PROPERTYTEXTEDITOR_H
+
+#include <QDialog>
+#include <QLineEdit>
+
+namespace GammaRay {
+
+namespace Ui {
+  class PropertyTextEditorDialog;
+}
+
+/** Property editor dialog for texts. */
+class PropertyTextEditorDialog : public QDialog
+{
+  Q_OBJECT
+  public:
+    explicit PropertyTextEditorDialog(const QString &text, QWidget *parent = 0);
+    ~PropertyTextEditorDialog();
+
+    QString text() const;
+
+  protected:
+    QScopedPointer<Ui::PropertyTextEditorDialog> ui;
+};
+
+/** Property editor for texts. */
+class PropertyTextEditor : public QLineEdit
+{
+  Q_OBJECT
+  public:
+    explicit PropertyTextEditor(QWidget *parent = 0);
+
+    void save(const QString &text);
+
+  protected slots:
+    void edit();
+};
+
+}
+
+#endif // GAMMARAY_PROPERTYTEXTEDITOR_H

--- a/ui/propertyeditor/propertytexteditor.ui
+++ b/ui/propertyeditor/propertytexteditor.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GammaRay::PropertyTextEditorDialog</class>
+ <widget class="QDialog" name="GammaRay::PropertyTextEditorDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPlainTextEdit" name="plainTextEdit">
+     <property name="lineWrapMode">
+      <enum>QPlainTextEdit::NoWrap</enum>
+     </property>
+     <property name="tabStopWidth">
+      <number>40</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>GammaRay::PropertyTextEditorDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>31</x>
+     <y>278</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>5</x>
+     <y>245</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>GammaRay::PropertyTextEditorDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>150</x>
+     <y>284</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>396</x>
+     <y>248</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This was a lot annoying editing long text properties.

There is now a multiline text editor for those properties.
This also fix the tree view rows height being too big because of those texts.