### PR TITLE
List picking in RemoteView support

### DIFF
--- a/client/remoteviewclient.cpp
+++ b/client/remoteviewclient.cpp
@@ -37,9 +37,14 @@ RemoteViewClient::RemoteViewClient(const QString &name, QObject *parent)
 {
 }
 
-void RemoteViewClient::pickElementAt(const QPoint &pos)
+void RemoteViewClient::requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode)
 {
-    Endpoint::instance()->invokeObject(name(), "pickElementAt", QVariantList() << pos);
+    Endpoint::instance()->invokeObject(name(), "requestElementsAt", QVariantList() << pos << QVariant::fromValue(mode));
+}
+
+void RemoteViewClient::pickElementId(const GammaRay::ObjectId &id)
+{
+    Endpoint::instance()->invokeObject(name(), "pickElementId", QVariantList() << QVariant::fromValue(id));
 }
 
 void RemoteViewClient::sendKeyEvent(int type, int key, int modifiers, const QString &text,

--- a/client/remoteviewclient.h
+++ b/client/remoteviewclient.h
@@ -38,7 +38,8 @@ class RemoteViewClient : public RemoteViewInterface
     Q_INTERFACES(GammaRay::RemoteViewInterface)
 public:
     explicit RemoteViewClient(const QString &name, QObject *parent = Q_NULLPTR);
-    void pickElementAt(const QPoint &pos) Q_DECL_OVERRIDE;
+    void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode) Q_DECL_OVERRIDE;
+    void pickElementId(const GammaRay::ObjectId &id) Q_DECL_OVERRIDE;
     void sendKeyEvent(int type, int key, int modifiers,
                       const QString &text = QString(), bool autorep = false,
                       ushort count = 1) Q_DECL_OVERRIDE;

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -13,6 +13,7 @@ set(gammaray_common_srcs
   propertysyncer.cpp
   modelevent.cpp
   modelutils.cpp
+  objectidfilterproxymodel.cpp
   paintanalyzerinterface.cpp
   selflocator.cpp
   sourcelocation.cpp
@@ -92,6 +93,7 @@ if(NOT GAMMARAY_PROBE_ONLY_BUILD)
     objectbroker.h
     objectid.h
     objectmodel.h
+    objectidfilterproxymodel.h
     paths.h
     probecontrollerinterface.h
     propertycontrollerinterface.h

--- a/common/objectidfilterproxymodel.cpp
+++ b/common/objectidfilterproxymodel.cpp
@@ -1,0 +1,77 @@
+/*
+  objectidfilterproxymodel.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2010-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "objectidfilterproxymodel.h"
+#include "objectmodel.h"
+
+using namespace GammaRay;
+
+ObjectIdsFilterProxyModel::ObjectIdsFilterProxyModel(QObject *parent)
+    : KRecursiveFilterProxyModel(parent)
+{
+}
+
+void ObjectIdsFilterProxyModel::sort(int column, Qt::SortOrder order)
+{
+    Q_UNUSED(column);
+    Q_UNUSED(order);
+}
+
+GammaRay::ObjectIds ObjectIdsFilterProxyModel::ids() const
+{
+    return m_ids;
+}
+
+void ObjectIdsFilterProxyModel::setIds(const GammaRay::ObjectIds &ids)
+{
+    if (m_ids == ids)
+        return;
+
+    m_ids = ids;
+    invalidateFilter();
+}
+
+bool ObjectIdsFilterProxyModel::acceptRow(int source_row, const QModelIndex &source_parent) const
+{
+    const QModelIndex source_index = sourceModel()->index(source_row, 0, source_parent);
+    if (!source_index.isValid()) {
+        return false;
+    }
+
+    const GammaRay::ObjectId id = source_index.data(ObjectModel::ObjectIdRole).value<GammaRay::ObjectId>();
+    if (id.isNull() || !filterAcceptsObjectId(id)) {
+        return false;
+    }
+
+    return KRecursiveFilterProxyModel::acceptRow(source_row, source_parent);
+}
+
+bool ObjectIdsFilterProxyModel::filterAcceptsObjectId(const GammaRay::ObjectId &id) const
+{
+    return m_ids.contains(id);
+}

--- a/common/objectidfilterproxymodel.h
+++ b/common/objectidfilterproxymodel.h
@@ -1,0 +1,83 @@
+/*
+  objectidfilterproxymodel.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2010-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_OBJECIDFILTERPROXYMODEL_H
+#define GAMMARAY_OBJECIDFILTERPROXYMODEL_H
+
+#include "gammaray_common_export.h"
+#include "3rdparty/kde/krecursivefilterproxymodel.h"
+
+#include <common/objectid.h>
+
+namespace GammaRay {
+
+/**
+ * @brief A KRecursiveFilterProxyModel for ObjectIds.
+ *
+ * Filter in and sort according to the objects list.
+ */
+class GAMMARAY_COMMON_EXPORT ObjectIdsFilterProxyModel : public KRecursiveFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    /**
+     * Constructor.
+     * @param parent is the parent object for this instance.
+     */
+    explicit ObjectIdsFilterProxyModel(QObject *parent = Q_NULLPTR);
+
+    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) Q_DECL_OVERRIDE;
+
+    GammaRay::ObjectIds ids() const;
+    void setIds(const GammaRay::ObjectIds &ids);
+
+protected:
+    /**
+     * Determines if the item in the specified row can be included in the model.
+     * @param source_row is a non-zero integer representing the row of the item.
+     * @param source_parent is the parent QModelIndex for this model.
+     * @return true if the item in the row can be included in the model;
+     *         otherwise returns false.
+     */
+    bool acceptRow(int source_row, const QModelIndex &source_parent) const Q_DECL_OVERRIDE;
+
+    /**
+     * Determines if the specified ObjectID can be included in the model.
+     * @param id is a ref to the ObjectId to test.
+     * @return true if the ObjectId can be included in the model; false otherwise.
+     */
+    bool filterAcceptsObjectId(const GammaRay::ObjectId &id) const;
+
+private:
+    GammaRay::ObjectIds m_ids;
+};
+
+}
+
+#endif // GAMMARAY_OBJECIDFILTERPROXYMODEL_H

--- a/common/remoteviewinterface.cpp
+++ b/common/remoteviewinterface.cpp
@@ -27,18 +27,40 @@
 */
 
 #include "remoteviewinterface.h"
+#include "streamoperators.h"
 
 #include <common/objectbroker.h>
 #include <common/remoteviewframe.h>
 
 using namespace GammaRay;
+QT_BEGIN_NAMESPACE
+GAMMARAY_ENUM_STREAM_OPERATORS(RemoteViewInterface::RequestMode)
+QT_END_NAMESPACE
 
 RemoteViewInterface::RemoteViewInterface(const QString &name, QObject *parent)
     : QObject(parent)
     , m_name(name)
 {
     ObjectBroker::registerObject(name, this);
-    qRegisterMetaTypeStreamOperators<RemoteViewFrame>();
+
+    qRegisterMetaType<RequestMode>();
+    qRegisterMetaTypeStreamOperators<RequestMode>();
+
+    qRegisterMetaType<ObjectId>();
+    qRegisterMetaTypeStreamOperators<ObjectId>();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+    // This is needed so QVariant based comparison works (ie: QAIM::match)
+    QMetaType::registerComparators<ObjectId>();
+#endif
+
+    qRegisterMetaType<ObjectIds>();
+    qRegisterMetaTypeStreamOperators<ObjectIds>();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+    // This is needed so QVariant based comparison works (ie: QAIM::match)
+    QMetaType::registerComparators<ObjectIds>();
+#endif
+
+    qRegisterMetaTypeStreamOperators<GammaRay::RemoteViewFrame>();
 }
 
 QString RemoteViewInterface::name() const

--- a/common/remoteviewinterface.h
+++ b/common/remoteviewinterface.h
@@ -31,6 +31,8 @@
 
 #include "gammaray_common_export.h"
 
+#include "objectid.h"
+
 #include <QObject>
 #include <QPoint>
 
@@ -42,12 +44,18 @@ class GAMMARAY_COMMON_EXPORT RemoteViewInterface : public QObject
 {
     Q_OBJECT
 public:
+    enum RequestMode {
+        RequestBest,
+        RequestAll
+    };
+
     explicit RemoteViewInterface(const QString &name, QObject *parent = Q_NULLPTR);
 
     QString name() const;
 
 public slots:
-    virtual void pickElementAt(const QPoint &pos) = 0;
+    virtual void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode) = 0;
+    virtual void pickElementId(const GammaRay::ObjectId &id) = 0;
 
     virtual void sendKeyEvent(int type, int key, int modifiers,
                               const QString &text = QString(), bool autorep = false,
@@ -66,12 +74,16 @@ public slots:
 
 signals:
     void reset();
+    void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
     void frameUpdated(const GammaRay::RemoteViewFrame &frame);
 
 private:
     QString m_name;
 };
+
 }
+
+Q_DECLARE_METATYPE(GammaRay::RemoteViewInterface::RequestMode)
 
 QT_BEGIN_NAMESPACE
 Q_DECLARE_INTERFACE(GammaRay::RemoteViewInterface, "com.kdab.GammaRay.RemoteViewInterface/1.0")

--- a/common/toolmanagerinterface.cpp
+++ b/common/toolmanagerinterface.cpp
@@ -35,6 +35,13 @@ ToolManagerInterface::ToolManagerInterface(QObject *parent)
 {
     qRegisterMetaType<ObjectId>();
     qRegisterMetaTypeStreamOperators<ObjectId>();
+    qRegisterMetaType<ObjectIds>();
+    qRegisterMetaTypeStreamOperators<ObjectIds>();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
+   // This is needed so QVariant based comparison works (ie: QAIM::match)
+   QMetaType::registerComparators<ObjectId>();
+   QMetaType::registerComparators<ObjectIds>();
+#endif
     qRegisterMetaType<ToolData>();
     qRegisterMetaTypeStreamOperators<ToolData>();
     qRegisterMetaType<QVector<ToolData> >();

--- a/core/remoteviewserver.cpp
+++ b/core/remoteviewserver.cpp
@@ -62,9 +62,14 @@ void RemoteViewServer::setEventReceiver(EventReceiver *receiver)
     m_eventReceiver = receiver;
 }
 
-void RemoteViewServer::pickElementAt(const QPoint &pos)
+void RemoteViewServer::requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode)
 {
-    emit doPickElement(pos);
+    emit elementsAtRequested(pos, mode);
+}
+
+void RemoteViewServer::pickElementId(const GammaRay::ObjectId &id)
+{
+    emit doPickElementId(id);
 }
 
 void RemoteViewServer::resetView()

--- a/core/remoteviewserver.h
+++ b/core/remoteviewserver.h
@@ -65,16 +65,18 @@ public:
     void sendFrame(const RemoteViewFrame &frame);
 
 public slots:
-    /// call this to indicate the source has changed and the client reuqires an update
+    /// call this to indicate the source has changed and the client requires an update
     void sourceChanged();
 
 signals:
-    void doPickElement(const QPoint &pos);
+    void elementsAtRequested(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
+    void doPickElementId(const GammaRay::ObjectId &id);
     /// when receiving this signal, obtain a new frame and send it to the client
     void requestUpdate();
 
 private:
-    void pickElementAt(const QPoint &pos) Q_DECL_OVERRIDE;
+    void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode) Q_DECL_OVERRIDE;
+    void pickElementId(const GammaRay::ObjectId &id) Q_DECL_OVERRIDE;
     void sendKeyEvent(int type, int key, int modifiers, const QString &text, bool autorep,
                       ushort count) Q_DECL_OVERRIDE;
     void sendMouseEvent(int type, const QPoint &localPos, int button, int buttons,

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -223,7 +223,7 @@ static QString qsgTextureWrapModeToString(QSGTexture::WrapMode wrapMode)
 
 static bool isGoodCandidateItem(QQuickItem *item)
 {
-    if (!item->isVisible() || qFuzzyCompare(item->opacity() + 1.0, qreal(1.0)) ||
+    if (!item->isVisible() || item->z() < 0 || qFuzzyCompare(item->opacity() + 1.0, qreal(1.0)) ||
             !item->flags().testFlag(QQuickItem::ItemHasContents) ||
             item->metaObject() == &QQuickItem::staticMetaObject) {
         return false;
@@ -616,7 +616,7 @@ ObjectIds QuickInspector::recursiveItemsAt(QQuickItem *parent, const QPointF &po
                 int bc;
                 objects << recursiveItemsAt(c, p, mode, bc);
 
-                if (bestCandidate == -1 && bc != -1) {
+                if (bestCandidate == -1 && bc != -1 && c->z() >= 0) {
                     bestCandidate = count + bc;
                 }
             }

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -35,6 +35,7 @@
 
 #include <common/modelevent.h>
 #include <common/objectbroker.h>
+#include <common/probecontrollerinterface.h>
 #include <common/remoteviewframe.h>
 
 #include <core/metaobject.h>
@@ -220,6 +221,17 @@ static QString qsgTextureWrapModeToString(QSGTexture::WrapMode wrapMode)
     return QStringLiteral("Unknown: %1").arg(wrapMode);
 }
 
+static bool isGoodCandidateItem(QQuickItem *item)
+{
+    if (!item->isVisible() || qFuzzyCompare(item->opacity() + 1.0, qreal(1.0)) ||
+            !item->flags().testFlag(QQuickItem::ItemHasContents) ||
+            item->metaObject() == &QQuickItem::staticMetaObject) {
+        return false;
+    }
+
+    return true;
+}
+
 QuickInspector::QuickInspector(ProbeInterface *probe, QObject *parent)
     : QuickInspectorInterface(parent)
     , m_probe(probe)
@@ -272,7 +284,9 @@ QuickInspector::QuickInspector(ProbeInterface *probe, QObject *parent)
             this, &QuickInspector::sgSelectionChanged);
     connect(m_sgModel, &QuickSceneGraphModel::nodeDeleted, this, &QuickInspector::sgNodeDeleted);
 
-    connect(m_remoteView, &RemoteViewServer::doPickElement, this, &QuickInspector::pickItemAt);
+    connect(m_remoteView, &RemoteViewServer::elementsAtRequested, this, &QuickInspector::requestElementsAt);
+    connect(this, &QuickInspector::elementsAtReceived, m_remoteView, &RemoteViewServer::elementsAtReceived);
+    connect(m_remoteView, &RemoteViewServer::doPickElementId, this, &QuickInspector::pickElementId);
     connect(m_remoteView, &RemoteViewServer::requestUpdate, this, &QuickInspector::slotGrabWindow);
 }
 
@@ -289,8 +303,13 @@ void QuickInspector::selectWindow(int index)
 
 void QuickInspector::selectWindow(QQuickWindow *window)
 {
-    if (m_window)
+    if (m_window == window) {
+        return;
+    }
+
+    if (m_window) {
         disconnect(m_window, 0, this, 0);
+    }
 
     m_window = window;
     m_itemModel->setWindow(window);
@@ -557,38 +576,76 @@ void QuickInspector::sgNodeDeleted(QSGNode *node)
         m_sgPropertyController->setObject(0);
 }
 
-void QuickInspector::pickItemAt(const QPoint &pos)
+void QuickInspector::requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode)
 {
     if (!m_window)
         return;
-    QQuickItem *item = recursiveChiltAt(m_window->contentItem(), pos);
+
+    int bestCandidate;
+    const ObjectIds objects = recursiveItemsAt(m_window->contentItem(), pos, mode, bestCandidate);
+
+    if (!objects.isEmpty()) {
+        emit elementsAtReceived(objects, bestCandidate);
+    }
+}
+
+void QuickInspector::pickElementId(const GammaRay::ObjectId &id)
+{
+    QQuickItem *item = id.asQObjectType<QQuickItem *>();
     if (item)
         m_probe->selectObject(item);
 }
 
-QQuickItem *QuickInspector::recursiveChiltAt(QQuickItem *parent, const QPointF &pos) const
+ObjectIds QuickInspector::recursiveItemsAt(QQuickItem *parent, const QPointF &pos,
+                                           GammaRay::RemoteViewInterface::RequestMode mode, int &bestCandidate) const
 {
     Q_ASSERT(parent);
-    QQuickItem *child = Q_NULLPTR;
+    ObjectIds objects;
 
-    // almost like QQItem::childAt, but with some extra filtering for better matching what you can see on screen
+    bestCandidate = -1;
+
     const auto childItems = parent->childItems();
     for (int i = childItems.size() - 1; i >= 0; --i) { // backwards to match z order
         auto c = childItems.at(i);
         const QPointF p = parent->mapToItem(c, pos);
-        if (c->isVisible() && p.x() >= 0 && c->width() >= p.x() && p.y() >= 0
-            && c->height() >= p.y()) {
-            child = c;
-            // empty QQItems are less interesting, so continue looking for something better, very common first hits in ListViews for example
-            if (c->metaObject() == &QQuickItem::staticMetaObject && c->childItems().isEmpty())
-                continue;
+        if (c->contains(p)) {
+            const bool hasSubChildren = !c->childItems().isEmpty();
+
+            if (hasSubChildren) {
+                const int count = objects.count();
+                int bc;
+                objects << recursiveItemsAt(c, p, mode, bc);
+
+                if (bestCandidate == -1 && bc != -1) {
+                    bestCandidate = count + bc;
+                }
+            }
+            else {
+                if (bestCandidate == -1 && isGoodCandidateItem(c)) {
+                    bestCandidate = objects.count();
+                }
+
+                objects << ObjectId(c);
+            }
+        }
+
+        if (bestCandidate != -1 && mode == RemoteViewInterface::RequestBest) {
             break;
         }
     }
 
-    if (child)
-        return recursiveChiltAt(child, parent->mapToItem(child, pos));
-    return parent;
+    if (bestCandidate == -1 && isGoodCandidateItem(parent)) {
+        bestCandidate = objects.count();
+    }
+
+    objects << ObjectId(parent);
+
+    if (bestCandidate != -1 && mode == RemoteViewInterface::RequestBest) {
+        objects = ObjectIds() << objects[bestCandidate];
+        bestCandidate = 0;
+    }
+
+    return objects;
 }
 
 void GammaRay::QuickInspector::registerGrabWindowCallback(GrabWindowCallback callback)
@@ -599,13 +656,15 @@ void GammaRay::QuickInspector::registerGrabWindowCallback(GrabWindowCallback cal
 bool QuickInspector::eventFilter(QObject *receiver, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonRelease) {
-        QMouseEvent *mouseEv = static_cast<QMouseEvent *>(event);
-        if (mouseEv->button() == Qt::LeftButton
-            && mouseEv->modifiers() == (Qt::ControlModifier | Qt::ShiftModifier)) {
-            QQuickWindow *window = qobject_cast<QQuickWindow *>(receiver);
+        QMouseEvent *mouseEv = static_cast<QMouseEvent*>(event);
+        if (mouseEv->button() == Qt::LeftButton &&
+                mouseEv->modifiers() == (Qt::ControlModifier | Qt::ShiftModifier)) {
+            QQuickWindow *window = qobject_cast<QQuickWindow*>(receiver);
             if (window && window->contentItem()) {
-                QQuickItem *item = recursiveChiltAt(window->contentItem(), mouseEv->pos());
-                m_probe->selectObject(item);
+                int bestCandidate;
+                const ObjectIds objects = recursiveItemsAt(window->contentItem(), mouseEv->pos(),
+                                                           RemoteViewInterface::RequestBest, bestCandidate);
+                m_probe->selectObject(objects.value(bestCandidate == -1 ? 0 : bestCandidate).asQObject());
             }
         }
     }

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -31,6 +31,7 @@
 
 #include "quickinspectorinterface.h"
 
+#include <common/remoteviewinterface.h>
 #include <core/toolfactory.h>
 
 #include <QQuickWindow>
@@ -55,6 +56,8 @@ class PropertyController;
 class QuickItemModel;
 class QuickSceneGraphModel;
 class RemoteViewServer;
+class ObjectId;
+typedef QVector<ObjectId> ObjectIds;
 
 class QuickInspector : public QuickInspectorInterface
 {
@@ -67,6 +70,9 @@ public:
 
     typedef bool (*GrabWindowCallback)(QQuickWindow *);
 
+signals:
+    void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
+
 public slots:
     void selectWindow(int index) Q_DECL_OVERRIDE;
 
@@ -75,7 +81,8 @@ public slots:
 
     void checkFeatures() Q_DECL_OVERRIDE;
 
-    void pickItemAt(const QPoint &pos);
+    void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
+    void pickElementId(const GammaRay::ObjectId& id);
 
     /** Allow other plugins to provide specific window grabbing callbacks.
      *  Needed for QQuickWidget.
@@ -105,7 +112,8 @@ private:
     void registerPCExtensions();
     QString findSGNodeType(QSGNode *node) const;
 
-    QQuickItem *recursiveChiltAt(QQuickItem *parent, const QPointF &pos) const;
+    GammaRay::ObjectIds recursiveItemsAt(QQuickItem *parent, const QPointF &pos,
+                                         GammaRay::RemoteViewInterface::RequestMode mode, int& bestCandidate) const;
 
     ProbeInterface *m_probe;
     QPointer<QQuickWindow> m_window;

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -123,6 +123,7 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
     new QuickItemTreeWatcher(ui->itemTreeView, ui->sgTreeView, this);
 
     m_previewWidget = new QuickScenePreviewWidget(m_interface, this);
+    m_previewWidget->setPickSourceModel(proxy);
 
     ui->itemPropertyWidget->setObjectBaseName(QStringLiteral("com.kdab.GammaRay.QuickItem"));
     ui->sgPropertyWidget->setObjectBaseName(QStringLiteral("com.kdab.GammaRay.QuickSceneGraph"));

--- a/plugins/widgetinspector/widgetinspectorserver.h
+++ b/plugins/widgetinspector/widgetinspectorserver.h
@@ -31,6 +31,7 @@
 #define GAMMARAY_WIDGETINSPECTOR_WIDGETINSPECTORSERVER_H
 
 #include <widgetinspectorinterface.h>
+#include <common/remoteviewinterface.h>
 
 #include <QPointer>
 
@@ -48,6 +49,8 @@ class PropertyController;
 class OverlayWidget;
 class PaintAnalyzer;
 class RemoteViewServer;
+class ObjectId;
+typedef QVector<ObjectId> ObjectIds;
 
 class WidgetInspectorServer : public WidgetInspectorInterface
 {
@@ -57,10 +60,15 @@ public:
     explicit WidgetInspectorServer(ProbeInterface *probe, QObject *parent = 0);
     ~WidgetInspectorServer();
 
+signals:
+    void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
+
 protected:
     bool eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
 
 private:
+    GammaRay::ObjectIds recursiveWidgetsAt(QWidget *parent, const QPoint &pos,
+                                           GammaRay::RemoteViewInterface::RequestMode mode, int& bestCandidate) const;
     void callExternalExportAction(const char *name, QWidget *widget, const QString &fileName);
     QImage imageForWidget(QWidget *widget);
     void registerWidgetMetaTypes();
@@ -84,7 +92,9 @@ private slots:
     void analyzePainting() Q_DECL_OVERRIDE;
 
     void updateWidgetPreview();
-    void pickElement(const QPoint &pos);
+
+    void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
+    void pickElementId(const GammaRay::ObjectId& id);
 
 private:
     QPointer<OverlayWidget> m_overlayWidget;

--- a/plugins/widgetinspector/widgetinspectorwidget.cpp
+++ b/plugins/widgetinspector/widgetinspectorwidget.cpp
@@ -84,6 +84,7 @@ WidgetInspectorWidget::WidgetInspectorWidget(QWidget *parent)
             SLOT(widgetTreeContextMenu(QPoint)));
 
     m_remoteView->setName(QStringLiteral("com.kdab.GammaRay.WidgetRemoteView"));
+    m_remoteView->setPickSourceModel(widgetModel);
 
     auto layout = new QVBoxLayout;
     layout->setMargin(0);

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -10,6 +10,7 @@ set(gammaray_ui_srcs
   editabletypesmodel.cpp
   itemdelegate.cpp
   methodinvocationdialog.cpp
+  modelpickerdialog.cpp
   palettemodel.cpp
   propertybinder.cpp
   propertywidget.cpp

--- a/ui/modelpickerdialog.cpp
+++ b/ui/modelpickerdialog.cpp
@@ -1,0 +1,128 @@
+/*
+  modelpickerdialog.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2014-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "modelpickerdialog.h"
+#include "deferredtreeview.h"
+
+#include <QVBoxLayout>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QDebug>
+
+using namespace GammaRay;
+
+static QPair<int, QVariant> qNullSelection()
+{
+    return qMakePair(-1, QVariant());
+}
+
+ModelPickerDialog::ModelPickerDialog(QWidget *parent)
+    : QDialog(parent)
+    , m_view(new DeferredTreeView(this))
+    , m_buttons(new QDialogButtonBox(this))
+    , m_pendingSelection(qNullSelection())
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    m_view->setExpandNewContent(true);
+    m_buttons->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+
+    QVBoxLayout *vl = new QVBoxLayout(this);
+    vl->addWidget(m_view);
+    vl->addWidget(m_buttons);
+
+    selectionChanged();
+    resize(640, 480);
+
+    connect(m_view, SIGNAL(newContentExpanded()), this, SLOT(updatePendingSelection()));
+    connect(m_view, SIGNAL(activated(QModelIndex)), this, SLOT(accept()));
+    connect(m_buttons, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(m_buttons, SIGNAL(rejected()), this, SLOT(reject()));
+}
+
+QAbstractItemModel *ModelPickerDialog::model() const
+{
+    return m_view->model();
+}
+
+void ModelPickerDialog::setModel(QAbstractItemModel *model)
+{
+    m_view->setModel(model);
+
+    connect(m_view->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)), this, SLOT(selectionChanged()));
+
+    for (int i = 0; i < m_view->model()->columnCount(); ++i) {
+        m_view->setDeferredResizeMode(i, QHeaderView::ResizeToContents);
+    }
+}
+
+void ModelPickerDialog::setRootIndex(const QModelIndex &index)
+{
+    m_view->setRootIndex(index);
+}
+
+void ModelPickerDialog::setCurrentIndex(const QModelIndex &index)
+{
+    m_pendingSelection = qNullSelection();
+    m_view->setCurrentIndex(index);
+    m_view->scrollTo(index);
+}
+
+void ModelPickerDialog::setCurrentIndex(int role, const QVariant &value)
+{
+    QAbstractItemModel *model = m_view->model();
+    const QModelIndex index = model->match(model->index(0, 0), role, value, 1, Qt::MatchExactly | Qt::MatchRecursive | Qt::MatchWrap).value(0);
+
+    if (index.isValid()) {
+        setCurrentIndex(index);
+    }
+    else {
+        m_pendingSelection = qMakePair(role, value);
+    }
+}
+
+void ModelPickerDialog::selectionChanged()
+{
+    const QModelIndex index = m_view->selectionModel() ? m_view->selectionModel()->selectedRows().value(0) : QModelIndex();
+    m_buttons->button(QDialogButtonBox::Ok)->setEnabled(index.isValid());
+}
+
+void ModelPickerDialog::accept()
+{
+    const QModelIndex index = m_view->selectionModel()->selectedRows().value(0);
+    if (index.isValid()) {
+        emit activated(index);
+        QDialog::accept();
+    }
+}
+
+void ModelPickerDialog::updatePendingSelection()
+{
+    if (m_pendingSelection != qNullSelection())
+        setCurrentIndex(m_pendingSelection.first, m_pendingSelection.second);
+}

--- a/ui/modelpickerdialog.h
+++ b/ui/modelpickerdialog.h
@@ -1,0 +1,80 @@
+/*
+  modelpickerdialog.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2014-2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Filipe Azevedo <filipe.azevedo@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_MODELPICKERDIALOG_H
+#define GAMMARAY_MODELPICKERDIALOG_H
+
+#include "gammaray_ui_export.h"
+
+#include <QDialog>
+#include <QVariant>
+
+QT_BEGIN_NAMESPACE
+class QModelIndex;
+class QAbstractItemModel;
+class QDialogButtonBox;
+QT_END_NAMESPACE
+
+namespace GammaRay {
+
+class DeferredTreeView;
+
+/** @brief A simple dialog that allow to pick a model index. */
+class GAMMARAY_UI_EXPORT ModelPickerDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ModelPickerDialog(QWidget *parent = Q_NULLPTR);
+
+    QAbstractItemModel *model() const;
+    void setModel(QAbstractItemModel *model);
+
+    void setRootIndex(const QModelIndex &index);
+    void setCurrentIndex(const QModelIndex &index);
+    void setCurrentIndex(int role, const QVariant &value);
+
+public slots:
+    void accept() Q_DECL_OVERRIDE;
+
+signals:
+    void activated(const QModelIndex &index);
+
+private:
+    DeferredTreeView *m_view;
+    QDialogButtonBox *m_buttons;
+    QPair<int, QVariant> m_pendingSelection;
+
+private slots:
+    void selectionChanged();
+    void updatePendingSelection();
+};
+
+} // namespace GammaRay
+
+#endif // GAMMARAY_MODELPICKERDIALOG_H

--- a/ui/remoteviewwidget.h
+++ b/ui/remoteviewwidget.h
@@ -32,6 +32,7 @@
 
 #include "gammaray_ui_export.h"
 
+#include <common/objectid.h>
 #include <common/remoteviewframe.h>
 
 #include <QWidget>
@@ -41,10 +42,12 @@ QT_BEGIN_NAMESPACE
 class QAbstractItemModel;
 class QActionGroup;
 class QStandardItemModel;
+class QModelIndex;
 QT_END_NAMESPACE
 
 namespace GammaRay {
 class RemoteViewInterface;
+class ObjectIdsFilterProxyModel;
 
 /** Widget showing remote screen content and providing both visual inspection
  *  capabilities as well as input redirection.
@@ -89,6 +92,9 @@ public:
     QActionGroup *interactionModeActions() const;
     QAction *zoomOutAction() const;
     QAction *zoomInAction() const;
+
+    QAbstractItemModel *pickSourceModel() const;
+    void setPickSourceModel(QAbstractItemModel *pickSourceModel);
 
 public slots:
     /// Clears the current view content.
@@ -159,6 +165,8 @@ private:
 
 private slots:
     void interactionActionTriggered(QAction *action);
+    void pickElementId(const QModelIndex &index);
+    void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
     void frameUpdated(const GammaRay::RemoteViewFrame &frame);
 
 private:
@@ -182,6 +190,7 @@ private:
     QPoint m_measurementStartPosition; // in source coordinates
     QPoint m_measurementEndPosition; // in source coordinates
     bool m_hasMeasurement;
+    ObjectIdsFilterProxyModel *m_pickProxyModel;
 };
 }
 


### PR DESCRIPTION
A new mode appearing allowing picking an item from a tree list.
This mode is optional and triggered with a keyboard Shift+Control modifier while clicking on the preview.
The old one click picking has been reworked to use the new underlying item discovery and is still the default.