### PR TITLE
Move the translated name() member ui-wise.

### DIFF
--- a/core/proxytoolfactory.cpp
+++ b/core/proxytoolfactory.cpp
@@ -46,13 +46,8 @@ bool ProxyToolFactory::isValid() const
 {
     return
         pluginInfo().isValid()
-        && !name().isEmpty()
+        && !id().isEmpty()
         && !supportedTypes().isEmpty();
-}
-
-QString ProxyToolFactory::name() const
-{
-    return pluginInfo().name();
 }
 
 void ProxyToolFactory::init(ProbeInterface *probe)

--- a/core/proxytoolfactory.h
+++ b/core/proxytoolfactory.h
@@ -52,7 +52,6 @@ public:
     /** Returns @c true if the plugin seems valid from all the information we have so far. */
     bool isValid() const;
 
-    QString name() const Q_DECL_OVERRIDE;
     bool isHidden() const Q_DECL_OVERRIDE;
     QVector<QByteArray> selectableTypes() const Q_DECL_OVERRIDE;
 

--- a/core/toolfactory.cpp
+++ b/core/toolfactory.cpp
@@ -38,11 +38,6 @@ ToolFactory::~ToolFactory()
 {
 }
 
-QString ToolFactory::name() const
-{
-    return QString(); // in the common case this is provided via ProxyToolFactory
-}
-
 const QVector<QByteArray> &ToolFactory::supportedTypes() const
 {
     return m_types;

--- a/core/toolfactory.h
+++ b/core/toolfactory.h
@@ -68,13 +68,6 @@ public:
     virtual QString id() const = 0;
 
     /*!
-     * Human readable name of this tool.
-     * You do not need to override this usually, the plugin loader will fill this in.
-     * @return a QString containing the tool name.
-     */
-    virtual QString name() const;
-
-    /*!
      * Class names of types this tool can handle.
      * The tool will only be activated if an object of one of these types
      * is seen in the probed application.

--- a/core/toolmodel.cpp
+++ b/core/toolmodel.cpp
@@ -91,7 +91,7 @@ QVariant ToolModel::data(const QModelIndex &index, int role) const
 
     ToolFactory *toolIface = m_tools.at(index.row());
     if (role == Qt::DisplayRole)
-        return toolIface->name();
+        return toolIface->id();
     else if (role == ToolModelRole::ToolFactory)
         return QVariant::fromValue(toolIface);
     else if (role == ToolModelRole::ToolId)

--- a/core/toolpluginmodel.cpp
+++ b/core/toolpluginmodel.cpp
@@ -42,7 +42,7 @@ ToolPluginModel::~ToolPluginModel()
 int ToolPluginModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 3;
+    return 2;
 }
 
 int ToolPluginModel::rowCount(const QModelIndex &parent) const
@@ -64,8 +64,6 @@ QVariant ToolPluginModel::data(const QModelIndex &index, int role) const
         case 0:
             return factory->id();
         case 1:
-            return factory->name();
-        case 2:
             return factory->supportedTypesString();
         }
     }
@@ -79,8 +77,6 @@ QVariant ToolPluginModel::headerData(int section, Qt::Orientation orientation, i
         case 0:
             return tr("Id");
         case 1:
-            return tr("Name");
-        case 2:
             return tr("Supported types");
         }
     }

--- a/core/tools/localeinspector/localeinspector.cpp
+++ b/core/tools/localeinspector/localeinspector.cpp
@@ -49,8 +49,3 @@ LocaleInspector::LocaleInspector(ProbeInterface *probe, QObject *parent)
     LocaleAccessorModel *accessorModel = new LocaleAccessorModel(registry, this);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.LocaleAccessorModel"), accessorModel);
 }
-
-QString LocaleInspectorFactory::name() const
-{
-    return tr("Locales");
-}

--- a/core/tools/localeinspector/localeinspector.h
+++ b/core/tools/localeinspector/localeinspector.h
@@ -46,8 +46,6 @@ public:
         : QObject(parent)
     {
     }
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/core/tools/messagehandler/messagehandler.cpp
+++ b/core/tools/messagehandler/messagehandler.cpp
@@ -225,8 +225,3 @@ MessageHandlerFactory::MessageHandlerFactory(QObject *parent)
     : QObject(parent)
 {
 }
-
-QString MessageHandlerFactory::name() const
-{
-    return tr("Messages");
-}

--- a/core/tools/messagehandler/messagehandler.h
+++ b/core/tools/messagehandler/messagehandler.h
@@ -62,8 +62,6 @@ class MessageHandlerFactory : public QObject, public StandardToolFactory<QObject
     Q_INTERFACES(GammaRay::ToolFactory)
 public:
     explicit MessageHandlerFactory(QObject *parent);
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -110,11 +110,6 @@ void MetaObjectBrowser::metaObjectSelected(const QMetaObject *mo)
         indexes.first(), QItemSelectionModel::Rows | QItemSelectionModel::ClearAndSelect);
 }
 
-QString MetaObjectBrowserFactory::name() const
-{
-    return tr("Meta Objects");
-}
-
 QVector<QByteArray> MetaObjectBrowserFactory::selectableTypes() const
 {
     return QVector<QByteArray>() << QObject::staticMetaObject.className() << "QMetaObject";

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.h
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.h
@@ -70,7 +70,6 @@ public:
     {
     }
 
-    QString name() const Q_DECL_OVERRIDE;
     QVector<QByteArray> selectableTypes() const Q_DECL_OVERRIDE;
 };
 }

--- a/core/tools/metatypebrowser/metatypebrowser.cpp
+++ b/core/tools/metatypebrowser/metatypebrowser.cpp
@@ -44,8 +44,3 @@ MetaTypeBrowser::MetaTypeBrowser(ProbeInterface *probe, QObject *parent)
     proxy->setSourceModel(mtm);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.MetaTypeModel"), proxy);
 }
-
-QString MetaTypeBrowserFactory::name() const
-{
-    return tr("Meta Types");
-}

--- a/core/tools/metatypebrowser/metatypebrowser.h
+++ b/core/tools/metatypebrowser/metatypebrowser.h
@@ -48,8 +48,6 @@ public:
         : QObject(parent)
     {
     }
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/core/tools/mimetypes/mimetypes.cpp
+++ b/core/tools/mimetypes/mimetypes.cpp
@@ -45,8 +45,3 @@ MimeTypes::MimeTypes(ProbeInterface *probe, QObject *parent)
 MimeTypes::~MimeTypes()
 {
 }
-
-QString MimeTypesFactory::name() const
-{
-    return tr("Mime Types");
-}

--- a/core/tools/mimetypes/mimetypes.h
+++ b/core/tools/mimetypes/mimetypes.h
@@ -53,8 +53,6 @@ public:
         : QObject(parent)
     {
     }
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/core/tools/modelinspector/modelinspector.cpp
+++ b/core/tools/modelinspector/modelinspector.cpp
@@ -161,11 +161,6 @@ void ModelInspector::objectCreated(QObject *object)
         m_probe->discoverObject(proxy->sourceModel());
 }
 
-QString ModelInspectorFactory::name() const
-{
-    return tr("Models");
-}
-
 QVector<QByteArray> ModelInspectorFactory::selectableTypes() const
 {
     return QVector<QByteArray>() << QAbstractItemModel::staticMetaObject.className();

--- a/core/tools/modelinspector/modelinspector.h
+++ b/core/tools/modelinspector/modelinspector.h
@@ -85,7 +85,6 @@ public:
     {
     }
 
-    QString name() const Q_DECL_OVERRIDE;
     QVector<QByteArray> selectableTypes() const Q_DECL_OVERRIDE;
 };
 }

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -118,11 +118,6 @@ void ObjectInspector::registerPCExtensions()
     PropertyController::registerExtension<ApplicationAttributeExtension>();
 }
 
-QString ObjectInspectorFactory::name() const
-{
-    return tr("Objects");
-}
-
 QVector<QByteArray> GammaRay::ObjectInspectorFactory::selectableTypes() const
 {
     return QVector<QByteArray>() << QObject::staticMetaObject.className();

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -70,7 +70,6 @@ public:
     {
     }
 
-    QString name() const Q_DECL_OVERRIDE;
     QVector<QByteArray> selectableTypes() const Q_DECL_OVERRIDE;
 };
 }

--- a/core/tools/resourcebrowser/resourcebrowser.cpp
+++ b/core/tools/resourcebrowser/resourcebrowser.cpp
@@ -99,8 +99,3 @@ void ResourceBrowser::currentChanged(const QModelIndex &current, int line, int c
         emit resourceDeselected();
     }
 }
-
-QString ResourceBrowserFactory::name() const
-{
-    return tr("Resources");
-}

--- a/core/tools/resourcebrowser/resourcebrowser.h
+++ b/core/tools/resourcebrowser/resourcebrowser.h
@@ -63,8 +63,6 @@ public:
         : QObject(parent)
     {
     }
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/core/tools/standardpaths/standardpaths.cpp
+++ b/core/tools/standardpaths/standardpaths.cpp
@@ -41,8 +41,3 @@ StandardPaths::StandardPaths(ProbeInterface *probe, QObject *parent)
 StandardPaths::~StandardPaths()
 {
 }
-
-QString StandardPathsFactory::name() const
-{
-    return tr("Standard Paths");
-}

--- a/core/tools/standardpaths/standardpaths.h
+++ b/core/tools/standardpaths/standardpaths.h
@@ -49,8 +49,6 @@ public:
         : QObject(parent)
     {
     }
-
-    QString name() const Q_DECL_OVERRIDE;
 };
 }
 

--- a/ui/clienttoolmodel.h
+++ b/ui/clienttoolmodel.h
@@ -63,6 +63,7 @@ public:
 
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const Q_DECL_OVERRIDE;
+    bool lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const Q_DECL_OVERRIDE;
 
 private slots:
     void updateToolInitialization(const QModelIndex &topLeft, const QModelIndex &bottomRight);
@@ -71,6 +72,8 @@ private:
     typedef QHash<QString, QPointer<QWidget> > WidgetsHash;
     mutable WidgetsHash m_widgets; // ToolId -> Widget
     QPointer<QWidget> m_parentWidget;
+
+    QString toolLabel(const QString &toolId) const;
 };
 }
 

--- a/ui/proxytooluifactory.cpp
+++ b/ui/proxytooluifactory.cpp
@@ -35,6 +35,11 @@ ProxyToolUiFactory::ProxyToolUiFactory(const PluginInfo &pluginInfo, QObject *pa
 {
 }
 
+QString ProxyToolUiFactory::name() const
+{
+    return pluginInfo().name();
+}
+
 bool ProxyToolUiFactory::isValid() const
 {
     return pluginInfo().isValid();

--- a/ui/proxytooluifactory.h
+++ b/ui/proxytooluifactory.h
@@ -44,6 +44,8 @@ public:
      */
     explicit ProxyToolUiFactory(const PluginInfo &pluginInfo, QObject *parent = 0);
 
+    QString name() const Q_DECL_OVERRIDE;
+
     /** Returns @c true if the plugin seems valid from all the information we have so far. */
     bool isValid() const;
 

--- a/ui/tools/objectinspector/objectinspectorwidget.h
+++ b/ui/tools/objectinspector/objectinspectorwidget.h
@@ -82,6 +82,7 @@ class ObjectInspectorFactory : public QObject, public ToolUiFactory
     Q_OBJECT
 public:
     QString id() const Q_DECL_OVERRIDE { return QStringLiteral("GammaRay::ObjectInspector"); }
+    QString name() const Q_DECL_OVERRIDE { return tr("Objects"); }
     QWidget *createWidget(QWidget *parentWidget) Q_DECL_OVERRIDE
     {
         return new ObjectInspectorWidget(

--- a/ui/tooluifactory.cpp
+++ b/ui/tooluifactory.cpp
@@ -38,6 +38,11 @@ ToolUiFactory::~ToolUiFactory()
 {
 }
 
+QString ToolUiFactory::name() const
+{
+    return QString(); // in the common case this is provided via ProxyToolUIFactory
+}
+
 bool ToolUiFactory::remotingSupported() const
 {
     return true;

--- a/ui/tooluifactory.h
+++ b/ui/tooluifactory.h
@@ -53,6 +53,13 @@ public:
      */
     virtual QString id() const = 0;
 
+    /*!
+     * Human readable name of this tool.
+     * You do not need to override this usually, the plugin loader will fill this in.
+     * @return a QString containing the tool name.
+     */
+    virtual QString name() const;
+
     /**
      * Return @c true if this tool supports remoting, @c false otherwise.
      * The default implementation returns @c true.


### PR DESCRIPTION
This make it easier to have correctly translated names when using
the QtC GammaRay plugin.

Task-Id: KDEND-74