### PR TITLE
Safer Message reading and writing.

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -138,7 +138,7 @@ void Client::messageReceived(const Message &msg)
             disconnectFromHost();
         }
         qint32 serverVersion;
-        msg.payload() >> serverVersion;
+        msg >> serverVersion;
         if (serverVersion != Protocol::version()) {
             emit persisitentConnectionError(tr("Server version is %1, was expecting %2.").arg(
                                                 serverVersion).arg(Protocol::version()));
@@ -154,7 +154,7 @@ void Client::messageReceived(const Message &msg)
         {
             QString name;
             Protocol::ObjectAddress addr;
-            msg.payload() >> name >> addr;
+            msg >> name >> addr;
             addObjectNameAddressMapping(name, addr);
             m_statModel->addObject(addr, name);
             break;
@@ -162,14 +162,14 @@ void Client::messageReceived(const Message &msg)
         case Protocol::ObjectRemoved:
         {
             QString name;
-            msg.payload() >> name;
+            msg >> name;
             removeObjectNameAddressMapping(name);
             break;
         }
         case Protocol::ObjectMapReply:
         {
             QVector<QPair<Protocol::ObjectAddress, QString> > objects;
-            msg.payload() >> objects;
+            msg >> objects;
             for (QVector<QPair<Protocol::ObjectAddress, QString> >::const_iterator it =
                      objects.constBegin();
                  it != objects.constEnd(); ++it) {
@@ -190,7 +190,7 @@ void Client::messageReceived(const Message &msg)
         case Protocol::ServerInfo:
         {
             QString label;
-            msg.payload() >> label;
+            msg >> label;
             setLabel(label);
             m_initState |= ServerInfoReceived;
             break;
@@ -249,7 +249,7 @@ void Client::monitorObject(Protocol::ObjectAddress objectAddress)
     if (!isConnected())
         return;
     Message msg(endpointAddress(), Protocol::ObjectMonitored);
-    msg.payload() << objectAddress;
+    msg << objectAddress;
     send(msg);
 }
 
@@ -258,7 +258,7 @@ void Client::unmonitorObject(Protocol::ObjectAddress objectAddress)
     if (!isConnected())
         return;
     Message msg(endpointAddress(), Protocol::ObjectUnmonitored);
-    msg.payload() << objectAddress;
+    msg << objectAddress;
     send(msg);
 }
 

--- a/common/endpoint.cpp
+++ b/common/endpoint.cpp
@@ -191,7 +191,7 @@ void Endpoint::invokeObject(const QString &objectName, const char *method,
     Message msg(obj->address, Protocol::MethodCall);
     const QByteArray name(method);
     Q_ASSERT(!name.isEmpty());
-    msg.payload() << name << args;
+    msg << name << args;
     send(msg);
 }
 
@@ -305,11 +305,11 @@ void Endpoint::dispatchMessage(const Message &msg)
     ObjectInfo *obj = it.value();
     if (msg.type() == Protocol::MethodCall) {
         QByteArray method;
-        msg.payload() >> method;
+        msg >> method;
         if (obj->object) {
             Q_ASSERT(!method.isEmpty());
             QVariantList args;
-            msg.payload() >> args;
+            msg >> args;
 
             invokeObjectLocal(obj->object, method.constData(), args);
         } else {

--- a/common/networkselectionmodel.h
+++ b/common/networkselectionmodel.h
@@ -78,4 +78,7 @@ private:
 };
 }
 
+Q_DECLARE_METATYPE(QItemSelectionModel::SelectionFlag)
+Q_DECLARE_METATYPE(QItemSelectionModel::SelectionFlags)
+
 #endif // GAMMARAY_NETWORKSELECTIONMODEL_H

--- a/common/propertysyncer.cpp
+++ b/common/propertysyncer.cpp
@@ -99,7 +99,7 @@ void PropertySyncer::setObjectEnabled(Protocol::ObjectAddress addr, bool enabled
     (*it).enabled = enabled;
     if (enabled && m_initialSync) {
         Message msg(m_address, Protocol::PropertySyncRequest);
-        msg.payload() << addr;
+        msg << addr;
         emit message(msg);
     }
 }
@@ -121,7 +121,7 @@ void PropertySyncer::handleMessage(const GammaRay::Message &msg)
     case Protocol::PropertySyncRequest:
     {
         Protocol::ObjectAddress addr;
-        msg.payload() >> addr;
+        msg >> addr;
         Q_ASSERT(addr != Protocol::InvalidObjectAddress);
 
         const auto it
@@ -142,9 +142,9 @@ void PropertySyncer::handleMessage(const GammaRay::Message &msg)
         Q_ASSERT(!values.isEmpty());
 
         Message msg(m_address, Protocol::PropertyValuesChanged);
-        msg.payload() << addr << (quint32)values.size();
+        msg << addr << (quint32)values.size();
         foreach (const auto &value, values)
-            msg.payload() << value.first << value.second;
+            msg << value.first << value.second;
         emit message(msg);
         break;
     }
@@ -152,7 +152,7 @@ void PropertySyncer::handleMessage(const GammaRay::Message &msg)
     {
         Protocol::ObjectAddress addr;
         quint32 changeSize;
-        msg.payload() >> addr >> changeSize;
+        msg >> addr >> changeSize;
         Q_ASSERT(addr != Protocol::InvalidObjectAddress);
         Q_ASSERT(changeSize > 0);
 
@@ -165,7 +165,7 @@ void PropertySyncer::handleMessage(const GammaRay::Message &msg)
         for (quint32 i = 0; i < changeSize; ++i) {
             QByteArray propName;
             QVariant propValue;
-            msg.payload() >> propName >> propValue;
+            msg >> propName >> propValue;
             (*it).recursionLock = true;
             (*it).obj->setProperty(propName, propValue);
 
@@ -207,9 +207,9 @@ void PropertySyncer::propertyChanged()
     Q_ASSERT(!changes.isEmpty());
 
     Message msg(m_address, Protocol::PropertyValuesChanged);
-    msg.payload() << (*it).addr << (quint32)changes.size();
+    msg << (*it).addr << (quint32)changes.size();
     foreach (const auto &change, changes)
-        msg.payload() << change.first << change.second;
+        msg << change.first << change.second;
     emit message(msg);
 }
 

--- a/core/probesettings.cpp
+++ b/core/probesettings.cpp
@@ -122,7 +122,7 @@ void ProbeSettingsReceiver::readyRead()
         case Protocol::ServerVersion:
         {
             qint32 version;
-            msg.payload() >> version;
+            msg >> version;
             if (version != Protocol::version()) {
                 qWarning()
                         <<
@@ -136,7 +136,7 @@ void ProbeSettingsReceiver::readyRead()
         }
         case Protocol::ProbeSettings:
         {
-            msg.payload() >> s_probeSettings()->settings;
+            msg >> s_probeSettings()->settings;
             // qDebug() << Q_FUNC_INFO << s_probeSettings()->settings;
             const QString probePath = ProbeSettings::value(QStringLiteral("ProbePath")).toString();
             setRootPathFromProbePath(probePath);
@@ -156,7 +156,7 @@ void ProbeSettingsReceiver::sendServerAddress(const QUrl &address)
         return;
 
     Message msg(Protocol::LauncherAddress, Protocol::ServerAddress);
-    msg.payload() << address;
+    msg << address;
     msg.write(m_socket);
 
     m_socket->waitForBytesWritten();

--- a/core/remote/remotemodelserver.cpp
+++ b/core/remote/remotemodelserver.cpp
@@ -172,7 +172,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
     case Protocol::ModelRowColumnCountRequest:
     {
         Protocol::ModelIndex index;
-        msg.payload() >> index;
+        msg >> index;
         const QModelIndex qmIndex = Protocol::toQModelIndex(m_model, index);
 
         qint32 rowCount = -1, columnCount = -1;
@@ -182,7 +182,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
         }
 
         Message msg(m_myAddress, Protocol::ModelRowColumnCountReply);
-        msg.payload() << index << rowCount << columnCount;
+        msg << index << rowCount << columnCount;
         sendMessage(msg);
         break;
     }
@@ -190,14 +190,14 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
     case Protocol::ModelContentRequest:
     {
         quint32 size;
-        msg.payload() >> size;
+        msg >> size;
         Q_ASSERT(size > 0);
 
         QVector<QModelIndex> indexes;
         indexes.reserve(size);
         for (quint32 i = 0; i < size; ++i) {
             Protocol::ModelIndex index;
-            msg.payload() >> index;
+            msg >> index;
             const QModelIndex qmIndex = Protocol::toQModelIndex(m_model, index);
             if (!qmIndex.isValid())
                 continue;
@@ -207,9 +207,9 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
             break;
 
         Message msg(m_myAddress, Protocol::ModelContentReply);
-        msg.payload() << quint32(indexes.size());
+        msg << quint32(indexes.size());
         foreach (const auto &qmIndex, indexes)
-            msg.payload() << Protocol::fromQModelIndex(qmIndex)
+            msg << Protocol::fromQModelIndex(qmIndex)
                           << filterItemData(m_model->itemData(qmIndex))
                           << qint32(m_model->flags(qmIndex));
 
@@ -221,7 +221,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
     {
         qint8 orientation;
         qint32 section;
-        msg.payload() >> orientation >> section;
+        msg >> orientation >> section;
         Q_ASSERT(orientation == Qt::Horizontal || orientation == Qt::Vertical);
         Q_ASSERT(section >= 0);
 
@@ -235,7 +235,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
                                         Qt::ToolTipRole));
 
         Message msg(m_myAddress, Protocol::ModelHeaderReply);
-        msg.payload() << orientation << section << data;
+        msg << orientation << section << data;
         sendMessage(msg);
         break;
     }
@@ -245,7 +245,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
         Protocol::ModelIndex index;
         int role;
         QVariant value;
-        msg.payload() >> index >> role >> value;
+        msg >> index >> role >> value;
 
         m_model->setData(Protocol::toQModelIndex(m_model, index), value, role);
         break;
@@ -254,7 +254,7 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
     case Protocol::ModelSortRequest:
     {
         quint32 column, order;
-        msg.payload() >> column >> order;
+        msg >> column >> order;
         m_model->sort(column, (Qt::SortOrder)order);
         break;
     }
@@ -262,9 +262,9 @@ void RemoteModelServer::newRequest(const GammaRay::Message &msg)
     case Protocol::ModelSyncBarrier:
     {
         qint32 barrierId;
-        msg.payload() >> barrierId;
+        msg >> barrierId;
         Message reply(m_myAddress, Protocol::ModelSyncBarrier);
-        reply.payload() << barrierId;
+        reply << barrierId;
         sendMessage(reply);
         break;
     }
@@ -344,7 +344,7 @@ void RemoteModelServer::dataChanged(const QModelIndex &begin, const QModelIndex 
     if (!isConnected())
         return;
     Message msg(m_myAddress, Protocol::ModelContentChanged);
-    msg.payload() << Protocol::fromQModelIndex(begin) << Protocol::fromQModelIndex(end) << roles;
+    msg << Protocol::fromQModelIndex(begin) << Protocol::fromQModelIndex(end) << roles;
     sendMessage(msg);
 }
 
@@ -353,7 +353,7 @@ void RemoteModelServer::headerDataChanged(Qt::Orientation orientation, int first
     if (!isConnected())
         return;
     Message msg(m_myAddress, Protocol::ModelHeaderChanged);
-    msg.payload() <<  qint8(orientation) << first << last;
+    msg <<  qint8(orientation) << first << last;
     sendMessage(msg);
 }
 
@@ -435,7 +435,7 @@ void RemoteModelServer::sendLayoutChanged(const QVector< Protocol::ModelIndex > 
     if (!isConnected())
         return;
     Message msg(m_myAddress, Protocol::ModelLayoutChanged);
-    msg.payload() << parents << hint;
+    msg << parents << hint;
     sendMessage(msg);
 }
 
@@ -452,7 +452,7 @@ void RemoteModelServer::sendAddRemoveMessage(Protocol::MessageType type, const Q
     if (!isConnected())
         return;
     Message msg(m_myAddress, type);
-    msg.payload() << Protocol::fromQModelIndex(parent) << start << end;
+    msg << Protocol::fromQModelIndex(parent) << start << end;
     sendMessage(msg);
 }
 
@@ -465,7 +465,7 @@ void RemoteModelServer::sendMoveMessage(Protocol::MessageType type,
     if (!isConnected())
         return;
     Message msg(m_myAddress, type);
-    msg.payload() << sourceParent << qint32(sourceStart) << qint32(sourceEnd)
+    msg << sourceParent << qint32(sourceStart) << qint32(sourceEnd)
                   << destinationParent << qint32(destinationIndex);
     sendMessage(msg);
 }

--- a/core/remote/server.cpp
+++ b/core/remote/server.cpp
@@ -141,19 +141,19 @@ void Server::sendServerGreeting()
     // send greeting message for protocol version check
     {
         Message msg(endpointAddress(), Protocol::ServerVersion);
-        msg.payload() << Protocol::version();
+        msg << Protocol::version();
         send(msg);
     }
 
     {
         Message msg(endpointAddress(), Protocol::ServerInfo);
-        msg.payload() << label(); // TODO: expand with anything else needed here: Qt/GammaRay version, hostname, that kind of stuff
+        msg << label(); // TODO: expand with anything else needed here: Qt/GammaRay version, hostname, that kind of stuff
         send(msg);
     }
 
     {
         Message msg(endpointAddress(), Protocol::ObjectMapReply);
-        msg.payload() << objectAddresses();
+        msg << objectAddresses();
         send(msg);
     }
 }
@@ -166,7 +166,7 @@ void Server::messageReceived(const Message &msg)
         case Protocol::ObjectUnmonitored:
         {
             Protocol::ObjectAddress addr;
-            msg.payload() >> addr;
+            msg >> addr;
             Q_ASSERT(addr > Protocol::InvalidObjectAddress);
             m_propertySyncer->setObjectEnabled(addr, msg.type() == Protocol::ObjectMonitored);
             const QHash<Protocol::ObjectAddress,
@@ -224,7 +224,7 @@ Protocol::ObjectAddress Server::registerObject(const QString &name, QObject *obj
 
     if (isConnected()) {
         Message msg(endpointAddress(), Protocol::ObjectAdded);
-        msg.payload() <<  name << m_nextAddress;
+        msg <<  name << m_nextAddress;
         send(msg);
     }
 
@@ -288,7 +288,7 @@ void Server::handlerDestroyed(Protocol::ObjectAddress objectAddress, const QStri
 
     if (isConnected()) {
         Message msg(endpointAddress(), Protocol::ObjectRemoved);
-        msg.payload() << objectName;
+        msg << objectName;
         send(msg);
     }
 }
@@ -301,7 +301,7 @@ void Server::objectDestroyed(Protocol::ObjectAddress /*objectAddress*/, const QS
 
     if (isConnected()) {
         Message msg(endpointAddress(), Protocol::ObjectRemoved);
-        msg.payload() << objectName;
+        msg << objectName;
         send(msg);
     }
 }

--- a/launcher/launcher.cpp
+++ b/launcher/launcher.cpp
@@ -298,13 +298,13 @@ void Launcher::newConnection()
 
     {
         Message msg(Protocol::LauncherAddress, Protocol::ServerVersion);
-        msg.payload() << Protocol::version();
+        msg << Protocol::version();
         msg.write(d->socket);
     }
 
     {
         Message msg(Protocol::LauncherAddress, Protocol::ProbeSettings);
-        msg.payload() << d->options.probeSettings();
+        msg << d->options.probeSettings();
         msg.write(d->socket);
     }
 }
@@ -316,7 +316,7 @@ void Launcher::readyRead()
         switch (msg.type()) {
         case Protocol::ServerAddress:
         {
-            msg.payload() >> d->serverAddress;
+            msg >> d->serverAddress;
             break;
         }
         default:


### PR DESCRIPTION
The Message::payload() has been hidden and now only used
by the Message's >> and << operators.
Those operators ensure compile time check on meta types and run time
check on the payload stream status.