### PR TITLE
Fix compilation on ARM when building against Qt 4

### DIFF
--- a/client/messagestatisticsmodel.cpp
+++ b/client/messagestatisticsmodel.cpp
@@ -167,8 +167,8 @@ static const int GRADIENT_SCALE_FACTOR = 4;
 
 static QColor colorForRatio(double ratio)
 {
-    const auto red = qBound(qreal(0.0), ratio * GRADIENT_SCALE_FACTOR, qreal(0.5));
-    const auto green = qBound(qreal(0.0), 1 - ratio * GRADIENT_SCALE_FACTOR, qreal(0.5));
+    const auto red = qBound<qreal>(0.0, ratio * GRADIENT_SCALE_FACTOR, 0.5);
+    const auto green = qBound<qreal>(0.0, 1 - ratio * GRADIENT_SCALE_FACTOR, 0.5);
     auto color = QColor(255 * red, 255 * green, 0);
     if (QApplication::palette().color(QPalette::Base).lightness() > 128)
         return color.lighter(300);

--- a/ui/tools/metaobjectbrowser/metaobjecttreeclientproxymodel.cpp
+++ b/ui/tools/metaobjectbrowser/metaobjecttreeclientproxymodel.cpp
@@ -62,8 +62,8 @@ static const int GRADIENT_SCALE_FACTOR = 4;
 
 static QColor colorForRatio(double ratio)
 {
-    const auto red = qBound(qreal(0.0), ratio * GRADIENT_SCALE_FACTOR, qreal(0.5));
-    const auto green = qBound(qreal(0.0), 1 - ratio * GRADIENT_SCALE_FACTOR, qreal(0.5));
+    const auto red = qBound<qreal>(0.0, ratio * GRADIENT_SCALE_FACTOR, 0.5);
+    const auto green = qBound<qreal>(0.0, 1 - ratio * GRADIENT_SCALE_FACTOR, 0.5);
     auto color = QColor(255 * red, 255 * green, 0);
     if (QApplication::palette().color(QPalette::Base).lightness() > 128)
         return color.lighter(300);


### PR DESCRIPTION
  error: no matching function for call to 'qBound(qreal, double, qreal)'
  note: deduced conflicting types for parameter 'const T' ('float' and 'double')

It was happening because qreal 'is a typedef for float for performance reasons'
on ARM in Qt 4.