### PR TITLE
Check whether we can read a line before doing do

### DIFF
--- a/launcher/probeabidetector_elf.cpp
+++ b/launcher/probeabidetector_elf.cpp
@@ -69,7 +69,7 @@ static QString qtCoreFromLdd(const QString &path, bool fallback = false)
     }
     proc.waitForFinished();
 
-    forever {
+    while (proc.canReadLine()) {
         const QByteArray line = proc.readLine();
         if (line.isEmpty())
             break;


### PR DESCRIPTION
Fixes a runtime warning saying:

QIODevice::read (QProcess): device not open