### PR TITLE
Fix selecting a wayland resource

### DIFF
--- a/plugins/wlcompositorinspector/wlcompositorinspector.cpp
+++ b/plugins/wlcompositorinspector/wlcompositorinspector.cpp
@@ -704,7 +704,7 @@ void WlCompositorInspector::setSelectedClient(int index)
     }
 }
 
-void WlCompositorInspector::setSelectedResource(uint32_t id)
+void WlCompositorInspector::setSelectedResource(uint id)
 {
     wl_resource *res = m_resourcesModel->resource(id);
     QWaylandSurface *surface = nullptr;

--- a/plugins/wlcompositorinspector/wlcompositorinspector.h
+++ b/plugins/wlcompositorinspector/wlcompositorinspector.h
@@ -61,7 +61,7 @@ public slots:
     void connected() override;
     void disconnected() override;
     void setSelectedClient(int index) override;
-    void setSelectedResource(uint32_t id) override;
+    void setSelectedResource(uint id) override;
 
 private slots:
     void objectAdded(QObject *obj);

--- a/plugins/wlcompositorinspector/wlcompositorinterface.h
+++ b/plugins/wlcompositorinspector/wlcompositorinterface.h
@@ -50,7 +50,7 @@ public slots:
   virtual void connected() = 0;
   virtual void disconnected() = 0;
   virtual void setSelectedClient(int index) = 0;
-  virtual void setSelectedResource(uint32_t id) = 0;
+  virtual void setSelectedResource(uint id) = 0;
 
 signals:
   void logMessage(qint64 time, const QByteArray &msg);


### PR DESCRIPTION
For some reason using uint32_t worked correctly with the wayland QPA, but with
the xcb QPA it didn't, and QMetaObject would complain:

QMetaObject::invokeMethod: No such method GammaRay::WlCompositorInspector::setSelectedResource(uint)
Candidates are:
    setSelectedResource(uint32_t)
    setSelectedResource(uint32_t)

Using uint instead works always.