### PR TITLE
Use disabled foreground palette for hidden widgets in widget model.

### DIFF
--- a/plugins/widgetinspector/CMakeLists.txt
+++ b/plugins/widgetinspector/CMakeLists.txt
@@ -62,6 +62,7 @@ if(GAMMARAY_BUILD_UI)
     widgetinspectorwidget.cpp
     widgetinspectorinterface.cpp
     widgetinspectorclient.cpp
+    widgetclientmodel.cpp
 
     waextension/widgetattributetab.cpp
   )

--- a/plugins/widgetinspector/widgetclientmodel.cpp
+++ b/plugins/widgetinspector/widgetclientmodel.cpp
@@ -1,11 +1,11 @@
 /*
-  widget-layouting.cpp
+  widgetclientmodel.cpp
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
   Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Author: Milian Wolff <milian.wolff@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,33 +26,27 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ui_contactform.h"
+#include "widgetclientmodel.h"
+#include "widgetmodelroles.h"
 
 #include <QApplication>
+#include <QPalette>
 
-class ContactForm : public QWidget
+using namespace GammaRay;
+
+WidgetClientModel::WidgetClientModel(QObject *parent)
+    : QIdentityProxyModel(parent)
 {
-    Q_OBJECT
-public:
-    ContactForm(QWidget *parent = Q_NULLPTR) :
-        QWidget(parent),
-        ui(new Ui::ContactForm)
-    {
-        ui->setupUi(this);
-    }
-
-private:
-    QScopedPointer<Ui::ContactForm> ui;
-};
-
-int main(int argc, char** argv)
-{
-    QApplication app(argc, argv);
-    QWidget w1;
-    QWidget w2;
-    ContactForm form;
-    form.show();
-    return app.exec();
 }
 
-#include "widget-layouting.moc"
+WidgetClientModel::~WidgetClientModel() = default;
+
+QVariant WidgetClientModel::data(const QModelIndex &index, int role) const
+{
+    if (index.isValid() && role == Qt::ForegroundRole) {
+        bool isVisible = index.data(WidgetModelRoles::VisibleRole).toBool();
+        if (!isVisible)
+            return qApp->palette().color(QPalette::Disabled, QPalette::Text);
+    }
+    return QIdentityProxyModel::data(index, role);
+}

--- a/plugins/widgetinspector/widgetclientmodel.h
+++ b/plugins/widgetinspector/widgetclientmodel.h
@@ -1,11 +1,11 @@
 /*
-  widget-layouting.cpp
+  widgetclientmodel.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
   Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Author: Milian Wolff <milian.wolff@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,33 +26,22 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ui_contactform.h"
+#ifndef GAMMARAY_WIDGETINSPECTOR_WIDGETCLIENTMODEL_H
+#define GAMMARAY_WIDGETINSPECTOR_WIDGETCLIENTMODEL_H
 
-#include <QApplication>
+#include <QIdentityProxyModel>
 
-class ContactForm : public QWidget
+namespace GammaRay {
+/** UI-dependent (and thus client-side) bits of the widget tree model. */
+class WidgetClientModel : public QIdentityProxyModel
 {
     Q_OBJECT
 public:
-    ContactForm(QWidget *parent = Q_NULLPTR) :
-        QWidget(parent),
-        ui(new Ui::ContactForm)
-    {
-        ui->setupUi(this);
-    }
+    explicit WidgetClientModel(QObject *parent = 0);
+    ~WidgetClientModel();
 
-private:
-    QScopedPointer<Ui::ContactForm> ui;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
 };
-
-int main(int argc, char** argv)
-{
-    QApplication app(argc, argv);
-    QWidget w1;
-    QWidget w2;
-    ContactForm form;
-    form.show();
-    return app.exec();
 }
 
-#include "widget-layouting.moc"
+#endif // GAMMARAY_WIDGETINSPECTOR_WIDGETCLIENTMODEL_H

--- a/plugins/widgetinspector/widgetinspectorwidget.cpp
+++ b/plugins/widgetinspector/widgetinspectorwidget.cpp
@@ -30,6 +30,7 @@
 #include "widgetinspectorwidget.h"
 #include "widgetinspectorinterface.h"
 #include "widgetinspectorclient.h"
+#include "widgetclientmodel.h"
 #include "ui_widgetinspectorwidget.h"
 #include "waextension/widgetattributetab.h"
 
@@ -70,7 +71,9 @@ WidgetInspectorWidget::WidgetInspectorWidget(QWidget *parent)
     ui->setupUi(this);
     ui->widgetPropertyWidget->setObjectBaseName(m_inspector->objectName());
 
-    auto widgetModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.WidgetTree"));
+    auto widgetTree = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.WidgetTree"));
+    auto widgetModel = new WidgetClientModel(this);
+    widgetModel->setSourceModel(widgetTree);
     ui->widgetTreeView->header()->setObjectName("widgetTreeViewHeader");
     ui->widgetTreeView->setDeferredResizeMode(0, QHeaderView::Stretch);
     ui->widgetTreeView->setDeferredResizeMode(1, QHeaderView::Interactive);

--- a/plugins/widgetinspector/widgetmodelroles.h
+++ b/plugins/widgetinspector/widgetmodelroles.h
@@ -1,11 +1,11 @@
 /*
-  widget-layouting.cpp
+  widgetmodelroles.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
   Copyright (C) 2016 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Author: Milian Wolff <milian.wolff@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,33 +26,18 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ui_contactform.h"
+#ifndef GAMMARAY_WIDGETINSPECTOR_WIDGETMODELROLES_H
+#define GAMMARAY_WIDGETINSPECTOR_WIDGETMODELROLES_H
 
-#include <QApplication>
+#include <common/objectmodel.h>
 
-class ContactForm : public QWidget
-{
-    Q_OBJECT
-public:
-    ContactForm(QWidget *parent = Q_NULLPTR) :
-        QWidget(parent),
-        ui(new Ui::ContactForm)
-    {
-        ui->setupUi(this);
-    }
-
-private:
-    QScopedPointer<Ui::ContactForm> ui;
+namespace GammaRay {
+/** Model roles shared between client and server. */
+namespace WidgetModelRoles {
+enum Roles {
+    VisibleRole = ObjectModel::UserRole,
 };
-
-int main(int argc, char** argv)
-{
-    QApplication app(argc, argv);
-    QWidget w1;
-    QWidget w2;
-    ContactForm form;
-    form.show();
-    return app.exec();
+}
 }
 
-#include "widget-layouting.moc"
+#endif // GAMMARAY_WIDGETINSPECTOR_WIDGETMODELROLES_H

--- a/plugins/widgetinspector/widgettreemodel.cpp
+++ b/plugins/widgetinspector/widgettreemodel.cpp
@@ -28,10 +28,9 @@
 
 #include "widgettreemodel.h"
 #include "common/modelutils.h"
+#include "widgetmodelroles.h"
 
-#include <QApplication>
 #include <QLayout>
-#include <QPalette>
 #include <QWidget>
 
 using namespace GammaRay;
@@ -56,7 +55,7 @@ QPair<int, QVariant> WidgetTreeModel::defaultSelectedItem() const
 
 QVariant WidgetTreeModel::data(const QModelIndex &index, int role) const
 {
-    if (index.isValid() && role == Qt::ForegroundRole) {
+    if (index.isValid() && role == WidgetModelRoles::VisibleRole) {
         QObject *obj = index.data(ObjectModel::ObjectRole).value<QObject *>();
         QWidget *widget = qobject_cast<QWidget *>(obj);
         if (!widget) {
@@ -64,10 +63,16 @@ QVariant WidgetTreeModel::data(const QModelIndex &index, int role) const
             if (layout)
                 widget = layout->parentWidget();
         }
-        if (widget && !widget->isVisible())
-            return qApp->palette().color(QPalette::Disabled, QPalette::Text);
+        return !widget || widget->isVisible();
     }
     return QSortFilterProxyModel::data(index, role);
+}
+
+QMap<int, QVariant> WidgetTreeModel::itemData(const QModelIndex &index) const
+{
+    auto d = ObjectFilterProxyModelBase::itemData(index);
+    d.insert(WidgetModelRoles::VisibleRole, data(index, WidgetModelRoles::VisibleRole));
+    return d;
 }
 
 bool WidgetTreeModel::filterAcceptsObject(QObject *object) const

--- a/plugins/widgetinspector/widgettreemodel.h
+++ b/plugins/widgetinspector/widgettreemodel.h
@@ -41,6 +41,7 @@ class WidgetTreeModel : public ObjectFilterProxyModelBase
 public:
     explicit WidgetTreeModel(QObject *parent = 0);
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    QMap<int, QVariant> itemData(const QModelIndex &index) const Q_DECL_OVERRIDE;
 
 public slots:
     QPair<int, QVariant> defaultSelectedItem() const;


### PR DESCRIPTION
This feature was broken in the out-of-process client/server mode.
I noticed this recently while demoing the tool for a customer on
a widget application that contained multiple top-level widgets.
Contrary to my first expectations, only one of them was visible
at any given time. This patch makes this distinction clear by
applying the same mechanism used in the quick inspector also for
widgets, namely introducing a client-side proxy model that applies
the styling filter. The server-side tree model is taught a new
VisibleRole.