### PR TITLE
Make ClientToolManager persistent.

### DIFF
--- a/client/client.h
+++ b/client/client.h
@@ -66,8 +66,6 @@ public:
     void unregisterMessageHandler(Protocol::ObjectAddress objectAddress) Q_DECL_OVERRIDE;
 
 signals:
-    /** Emitted when we successfully established a connection and passed the protocol version handshake step. */
-    void connectionEstablished();
     /** Emitted on transient connection errors.
      *  That is, on errors it's worth re-trying, e.g. because the target wasn't up yet.
      */

--- a/client/clientconnectionmanager.cpp
+++ b/client/clientconnectionmanager.cpp
@@ -123,12 +123,14 @@ ClientConnectionManager::ClientConnectionManager(QObject *parent, bool showSplas
     if (showSplashScreenOnStartUp)
         showSplashScreen();
     connect(m_client, SIGNAL(disconnected()), SIGNAL(disconnected()));
-    connect(m_client, SIGNAL(connectionEstablished()), SLOT(connectionEstablished()));
     connect(m_client, SIGNAL(transientConnectionError()), SLOT(transientConnectionError()));
     connect(m_client, SIGNAL(persisitentConnectionError(QString)),
             SIGNAL(persistentConnectionError(QString)));
     connect(this, SIGNAL(persistentConnectionError(QString)), SLOT(delayedHideSplashScreen()));
     connect(this, SIGNAL(ready()), this, SLOT(delayedHideSplashScreen()));
+
+    auto toolManager = new ClientToolManager(this);
+    connect(toolManager, SIGNAL(toolListAvailable()), this, SIGNAL(ready()));
 }
 
 ClientConnectionManager::~ClientConnectionManager()
@@ -157,19 +159,6 @@ void ClientConnectionManager::disconnectFromHost()
 void ClientConnectionManager::connectToHost()
 {
     m_client->connectToHost(m_serverUrl, m_tries ? m_tries-- : 0);
-}
-
-void ClientConnectionManager::connectionEstablished()
-{
-    auto toolManager = ClientToolManager::instance();
-    if (!toolManager) {
-        toolManager = new ClientToolManager(this);
-    }
-
-    // We cannot instantiate the tool manager in the ctor as it's too early (not yet connected) and will
-    // cause object registering issues, so make sure we connect only once.
-    connect(toolManager, SIGNAL(toolListAvailable()), this, SIGNAL(ready()), Qt::UniqueConnection);
-    toolManager->requestAvailableTools();
 }
 
 QMainWindow *ClientConnectionManager::createMainWindow()

--- a/client/clientconnectionmanager.h
+++ b/client/clientconnectionmanager.h
@@ -100,7 +100,6 @@ public slots:
 
 private slots:
     void connectToHost();
-    void connectionEstablished();
     void transientConnectionError();
 
     void delayedHideSplashScreen();

--- a/common/endpoint.h
+++ b/common/endpoint.h
@@ -141,6 +141,8 @@ public slots:
     void sendMessage(const GammaRay::Message &msg);
 
 signals:
+    /** Emitted when a connection to another endpoint was successfully established and passed the protocol version handshake step. */
+    void connectionEstablished();
     /** Emitted when we lost the connection to the other endpoint. */
     void disconnected();
 

--- a/core/remote/server.cpp
+++ b/core/remote/server.cpp
@@ -146,6 +146,8 @@ void Server::newConnection()
     setDevice(con);
 
     sendServerGreeting();
+
+    emit connectionEstablished();
 }
 
 void Server::sendServerGreeting()

--- a/ui/clienttoolmanager.cpp
+++ b/ui/clienttoolmanager.cpp
@@ -172,6 +172,30 @@ ClientToolManager::ClientToolManager(QObject *parent)
 
     initPluginRepository();
 
+    connect(Endpoint::instance(), SIGNAL(disconnected()), this, SLOT(clear()));
+    connect(Endpoint::instance(), SIGNAL(connectionEstablished()), this, SLOT(requestAvailableTools()));
+}
+
+ClientToolManager::~ClientToolManager()
+{
+    for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it)
+        delete it.value().data();
+    s_instance = Q_NULLPTR;
+}
+
+void ClientToolManager::clear()
+{
+    emit aboutToReset();
+    for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it)
+        delete it.value().data();
+    m_tools.clear();
+    disconnect(m_remote, 0, this, 0);
+    m_remote = 0;
+    emit reset();
+}
+
+void ClientToolManager::requestAvailableTools()
+{
     m_remote = ObjectBroker::object<ToolManagerInterface *>();
 
     connect(m_remote, SIGNAL(availableToolsResponse(QVector<GammaRay::ToolData>)),
@@ -182,17 +206,7 @@ ClientToolManager::ClientToolManager(QObject *parent)
             this, SLOT(toolGotSelected(QString)));
     connect(m_remote, SIGNAL(toolsForObjectResponse(GammaRay::ObjectId,QVector<QString>)),
             this, SLOT(toolsForObjectReceived(GammaRay::ObjectId,QVector<QString>)));
-}
 
-ClientToolManager::~ClientToolManager()
-{
-    for (auto it = m_widgets.constBegin(); it != m_widgets.constEnd(); ++it)
-        delete it.value().data();
-    s_instance = Q_NULLPTR;
-}
-
-void ClientToolManager::requestAvailableTools()
-{
     m_remote->requestAvailableTools();
 }
 
@@ -247,8 +261,10 @@ void ClientToolManager::gotTools(const QVector<GammaRay::ToolData> &tools)
     }
     emit toolListAvailable();
 
-    disconnect(m_remote, SIGNAL(availableToolsResponse(QVector<GammaRay::ToolData>)),
-               this, SLOT(gotTools(QVector<GammaRay::ToolData>)));
+    if (m_remote) {
+        disconnect(m_remote, SIGNAL(availableToolsResponse(QVector<GammaRay::ToolData>)),
+                   this, SLOT(gotTools(QVector<GammaRay::ToolData>)));
+    }
 }
 
 bool ClientToolManager::isToolListLoaded() const
@@ -272,11 +288,17 @@ QItemSelectionModel *ClientToolManager::selectionModel()
 
 void ClientToolManager::requestToolsForObject(const ObjectId &id)
 {
+    if (!m_remote) {
+        return;
+    }
     m_remote->requestToolsForObject(id);
 }
 
 void ClientToolManager::selectObject(const ObjectId &id, const ToolInfo &toolInfo)
 {
+    if (!m_remote) {
+        return;
+    }
     m_remote->selectObject(id, toolInfo.id());
 }
 

--- a/ui/clienttoolmanager.h
+++ b/ui/clienttoolmanager.h
@@ -88,7 +88,6 @@ public:
     explicit ClientToolManager(QObject *parent = 0);
     ~ClientToolManager();
 
-    void requestAvailableTools();
     void setToolParentWidget(QWidget *parent);
 
     bool isToolListLoaded() const;
@@ -109,6 +108,10 @@ public:
 
     static ClientToolManager* instance();
 
+public slots:
+    void requestAvailableTools();
+    void clear();
+
 signals:
     void toolEnabled(const QString &toolId);
     void toolEnabledByIndex(int toolIndex);
@@ -117,6 +120,8 @@ signals:
     void toolSelected(const QString &toolId);
     void toolSelectedByIndex(int index);
     void toolsForObjectResponse(const GammaRay::ObjectId &id, const QVector<GammaRay::ToolInfo> &toolInfos);
+    void aboutToReset();
+    void reset();
 
 private slots:
     void gotTools(const QVector<GammaRay::ToolData> &tools);

--- a/ui/clienttoolmodel.cpp
+++ b/ui/clienttoolmodel.cpp
@@ -42,6 +42,8 @@ ClientToolModel::ClientToolModel(ClientToolManager *manager)
 {
     connect(m_toolManager, SIGNAL(aboutToReceiveData()), this, SLOT(startReset()));
     connect(m_toolManager, SIGNAL(toolListAvailable()), this, SLOT(finishReset()));
+    connect(m_toolManager, SIGNAL(aboutToReset()), this, SLOT(startReset()));
+    connect(m_toolManager, SIGNAL(reset()), this, SLOT(finishReset()));
     connect(m_toolManager, SIGNAL(toolEnabledByIndex(int)), this, SLOT(toolEnabled(int)));
 }
 


### PR DESCRIPTION
This commit allows a ClientToolManager instance to survive a disconnect
and reset itself, so when reconnecting the client to another server,
there is no need to delete and reconstruct the ClientToolManager.

To achieve this, this commit moves the connectionEstablished signal from
Client to Endpoint (for linking reasons). I also added an emit to
Server, just to not have misleading API.
