### PR TITLE
Fix checking if a quick item is partially or completely out of view

### DIFF
--- a/plugins/quickinspector/quickclientitemmodel.cpp
+++ b/plugins/quickinspector/quickclientitemmodel.cpp
@@ -61,16 +61,22 @@ QVariant QuickClientItemModel::data(const QModelIndex &index, int role) const
         if (role == Qt::ToolTipRole && flags) {
             QString tooltip = QIdentityProxyModel::data(index, role).toString();
             tooltip.append("<p style='white-space:pre'>");
-            if ((flags &QuickItemModelRole::OutOfView)
+            //if flags has OutOfView it has also PartiallyOutOfView, no need to test both
+            if ((flags &QuickItemModelRole::PartiallyOutOfView)
                 && (~flags & QuickItemModelRole::Invisible)) {
                 QByteArray byteArray;
                 QBuffer buffer(&byteArray);
                 QIcon::fromTheme(QStringLiteral("dialog-warning")).pixmap(16, 16).save(&buffer,
                                                                                        "PNG");
                 tooltip.append("<img src=\"data:image/png;base64,").
-                append(byteArray.toBase64()).
-                append("\"> Item is visible, but out of view.");
+                append(byteArray.toBase64());
+                if (flags & QuickItemModelRole::OutOfView)
+                    tooltip.append("\"> Item is visible, but out of view.");
+                else
+                    tooltip.append("\"> Item is visible, but partially out of view.");
+
                 flags &= ~QuickItemModelRole::OutOfView;
+                flags &= ~QuickItemModelRole::PartiallyOutOfView;
                 if (flags)
                     tooltip.append("\n");
             }
@@ -84,6 +90,8 @@ QVariant QuickClientItemModel::data(const QModelIndex &index, int role) const
 
                 if (flags & QuickItemModelRole::OutOfView)
                     flagStrings << tr("is out of view");
+                else if (flags & QuickItemModelRole::PartiallyOutOfView)
+                    flagStrings << tr("is partially out of view");
 
                 if (flags & QuickItemModelRole::HasFocus
                     && ~flags & QuickItemModelRole::HasActiveFocus)

--- a/plugins/quickinspector/quickitemdelegate.cpp
+++ b/plugins/quickinspector/quickitemdelegate.cpp
@@ -90,7 +90,7 @@ void QuickItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
         else if (deco.canConvert<QIcon>())
             icons.push_back(deco.value<QIcon>().pixmap(16, 16));
 
-        if ((flags &QuickItemModelRole::OutOfView) && (~flags & QuickItemModelRole::Invisible))
+        if ((flags &QuickItemModelRole::PartiallyOutOfView) && (~flags & QuickItemModelRole::Invisible))
             icons << QIcon(QStringLiteral(":/gammaray/plugins/quickinspector/warning.png")).pixmap(
                 16, 16);
 

--- a/plugins/quickinspector/quickitemmodelroles.h
+++ b/plugins/quickinspector/quickitemmodelroles.h
@@ -44,10 +44,11 @@ enum ItemFlag {
     None = 0,
     Invisible = 1,
     ZeroSize = 2,
-    OutOfView = 4,
-    HasFocus = 8,
-    HasActiveFocus = 16,
-    JustRecievedEvent = 32
+    PartiallyOutOfView = 4,
+    OutOfView = 8,
+    HasFocus = 16,
+    HasActiveFocus = 32,
+    JustRecievedEvent = 64
 };
 }
 }


### PR DESCRIPTION
In some cases the QtQuick plugin would say that an item is out of view
even if it is only partially so:

```
import QtQuick 2.2
Item {
        width: 400
        height: 400

        Rectangle {
                color: "green"
                x: 300
                y: 300
                width: 20
                height: 200
                scale: -1
        }
}
```

Distinguish between partialy and completely out of view and make sure
to report that correctly.