### PR TITLE
Implement touch events redirection from the QtQuick preview widget

### DIFF
--- a/client/remoteviewclient.cpp
+++ b/client/remoteviewclient.cpp
@@ -81,6 +81,19 @@ void RemoteViewClient::sendWheelEvent(const QPoint &localPos, QPoint pixelDelta,
                                        << QVariant::fromValue(modifiers));
 }
 
+void RemoteViewClient::sendTouchEvent(int type, int touchDeviceType, int deviceCaps, int touchDeviceMaxTouchPoints, int modifiers,
+                                      Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints)
+{
+    Endpoint::instance()->invokeObject(name(), "sendTouchEvent", QVariantList()
+                                       << QVariant::fromValue(type)
+                                       << QVariant::fromValue(touchDeviceType)
+                                       << QVariant::fromValue(deviceCaps)
+                                       << QVariant::fromValue(touchDeviceMaxTouchPoints)
+                                       << QVariant::fromValue(modifiers)
+                                       << QVariant::fromValue(touchPointStates)
+                                       << QVariant::fromValue(touchPoints));
+}
+
 void RemoteViewClient::setViewActive(bool active)
 {
     Endpoint::instance()->invokeObject(name(), "setViewActive", QVariantList() << active);

--- a/client/remoteviewclient.h
+++ b/client/remoteviewclient.h
@@ -47,6 +47,9 @@ public:
                         int modifiers) Q_DECL_OVERRIDE;
     void sendWheelEvent(const QPoint &localPos, QPoint pixelDelta, QPoint angleDelta, int buttons,
                         int modifiers) Q_DECL_OVERRIDE;
+    void sendTouchEvent(int type, int touchDeviceType, int deviceCaps, int touchDeviceMaxTouchPoints, int modifiers,
+                        Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints)
+                        Q_DECL_OVERRIDE;
     void setViewActive(bool active) Q_DECL_OVERRIDE;
     void clientViewUpdated() Q_DECL_OVERRIDE;
 };

--- a/common/remoteviewinterface.h
+++ b/common/remoteviewinterface.h
@@ -83,9 +83,8 @@ private:
 
 }
 
-Q_DECLARE_METATYPE(GammaRay::RemoteViewInterface::RequestMode)
-
 QT_BEGIN_NAMESPACE
+Q_DECLARE_METATYPE(GammaRay::RemoteViewInterface::RequestMode)
 Q_DECLARE_INTERFACE(GammaRay::RemoteViewInterface, "com.kdab.GammaRay.RemoteViewInterface/1.0")
 QT_END_NAMESPACE
 

--- a/common/remoteviewinterface.h
+++ b/common/remoteviewinterface.h
@@ -35,6 +35,7 @@
 
 #include <QObject>
 #include <QPoint>
+#include <QTouchEvent>
 
 namespace GammaRay {
 class RemoteViewFrame;
@@ -67,6 +68,10 @@ public slots:
     virtual void sendWheelEvent(const QPoint &localPos, QPoint pixelDelta, QPoint angleDelta,
                                 int buttons, int modifiers) = 0;
 
+    virtual void sendTouchEvent(int type, int touchDeviceType, int deviceCaps, int touchDeviceMaxTouchPoints, int modifiers,
+                                Qt::TouchPointStates touchPointStates,
+                                const QList<QTouchEvent::TouchPoint> &touchPoints) = 0;
+
     virtual void setViewActive(bool active) = 0;
 
     /// Tell the server we are ready for the next frame.
@@ -84,6 +89,10 @@ private:
 }
 
 QT_BEGIN_NAMESPACE
+Q_DECLARE_METATYPE(QTouchEvent::TouchPoint)
+Q_DECLARE_METATYPE(Qt::TouchPointStates)
+Q_DECLARE_METATYPE(QTouchEvent::TouchPoint::InfoFlags)
+Q_DECLARE_METATYPE(QList<QTouchEvent::TouchPoint>)
 Q_DECLARE_METATYPE(GammaRay::RemoteViewInterface::RequestMode)
 Q_DECLARE_INTERFACE(GammaRay::RemoteViewInterface, "com.kdab.GammaRay.RemoteViewInterface/1.0")
 QT_END_NAMESPACE

--- a/core/remoteviewserver.h
+++ b/core/remoteviewserver.h
@@ -29,6 +29,8 @@
 #ifndef GAMMARAY_REMOTEVIEWSERVER_H
 #define GAMMARAY_REMOTEVIEWSERVER_H
 
+#include <memory>
+
 #include "gammaray_core_export.h"
 
 #include <common/remoteviewinterface.h>
@@ -36,6 +38,7 @@
 QT_BEGIN_NAMESPACE
 class QTimer;
 class QWindow;
+class QTouchDevice;
 QT_END_NAMESPACE
 
 namespace GammaRay {
@@ -83,6 +86,9 @@ private:
                         int modifiers) Q_DECL_OVERRIDE;
     void sendWheelEvent(const QPoint &localPos, QPoint pixelDelta, QPoint angleDelta, int buttons,
                         int modifiers) Q_DECL_OVERRIDE;
+    void sendTouchEvent(int type, int touchDeviceType, int deviceCaps, int touchDeviceMaxTouchPoints, int modifiers,
+                        Qt::TouchPointStates touchPointStates, const QList<QTouchEvent::TouchPoint> &touchPoints) 
+                        Q_DECL_OVERRIDE;
     void setViewActive(bool active) Q_DECL_OVERRIDE;
     void clientViewUpdated() Q_DECL_OVERRIDE;
 
@@ -98,6 +104,7 @@ private:
     bool m_clientActive;
     bool m_sourceChanged;
     bool m_clientReady;
+    std::unique_ptr<QTouchDevice> m_touchDevice;
 };
 }
 

--- a/ui/remoteviewwidget.cpp
+++ b/ui/remoteviewwidget.cpp
@@ -72,6 +72,10 @@ RemoteViewWidget::RemoteViewWidget(QWidget *parent)
     setMouseTracking(true);
     setMinimumSize(QSize(400, 300));
     setFocusPolicy(Qt::StrongFocus);
+    window()->setAttribute(Qt::WA_AcceptTouchEvents);
+    window()->setAttribute(Qt::WA_TouchPadAcceptSingleTouchEvents);
+    setAttribute(Qt::WA_AcceptTouchEvents);
+    setAttribute(Qt::WA_TouchPadAcceptSingleTouchEvents);
 
     // Background
     QPixmap bgPattern(20, 20);
@@ -676,9 +680,57 @@ QPoint RemoteViewWidget::mapToSource(QPoint pos) const
     return (pos - QPoint(m_x, m_y)) / m_zoom;
 }
 
+QPointF RemoteViewWidget::mapToSource(QPointF pos) const
+{
+    return (pos - QPointF(m_x, m_y)) / m_zoom;
+}
+
+QRectF RemoteViewWidget::mapToSource(const QRectF &r) const
+{
+    return QRectF(mapToSource(r.topLeft()), mapToSource(r.bottomRight()));
+}
+
 QPoint RemoteViewWidget::mapFromSource(QPoint pos) const
 {
     return pos * m_zoom + QPoint(m_x, m_y);
+}
+
+QPointF RemoteViewWidget::mapFromSource(QPointF pos) const
+{
+    return pos * m_zoom + QPointF(m_x, m_y);
+}
+
+QTouchEvent::TouchPoint RemoteViewWidget::mapToSource(const QTouchEvent::TouchPoint &point)
+{
+    QTouchEvent::TouchPoint p;
+
+    p.setFlags(point.flags());
+    p.setId(point.id());
+    p.setPressure(point.pressure());
+    p.setState(point.state());
+
+    p.setStartPos(mapToSource(point.startPos()));
+    p.setLastPos(mapToSource(point.lastPos()));
+    p.setPos(mapToSource(point.pos())); // relative
+    p.setRect(mapToSource(point.rect()));
+
+    p.setStartNormalizedPos(mapToSource(point.startNormalizedPos()));
+    p.setLastNormalizedPos(mapToSource(point.lastNormalizedPos()));
+    p.setNormalizedPos(mapToSource(point.normalizedPos()));
+
+    p.setStartScenePos(mapToSource(point.startScenePos()));
+    p.setLastScenePos(mapToSource(point.lastScenePos()));
+    p.setScenePos(mapToSource(point.scenePos()));
+    p.setSceneRect(mapToSource(point.sceneRect()));
+
+    // These may not have the right x,y but i don't think there is a way to get the right value.
+    // On the other hand, it's not a problem, probably
+    p.setStartScreenPos(mapToSource(point.startScreenPos()));
+    p.setLastScreenPos(mapToSource(point.lastScreenPos()));
+    p.setScreenPos(mapToSource(point.screenPos()));
+    p.setScreenRect(mapToSource(point.screenRect()));
+
+    return p;
 }
 
 void RemoteViewWidget::restoreState(QDataStream &stream)
@@ -942,6 +994,25 @@ bool RemoteViewWidget::eventFilter(QObject *receiver, QEvent *event)
     return QWidget::eventFilter(receiver, event);
 }
 
+bool RemoteViewWidget::event(QEvent *event)
+{
+    if (m_interactionMode == InputRedirection) {
+        switch (event->type()) {
+        case QEvent::TouchBegin:
+        case QEvent::TouchCancel:
+        case QEvent::TouchEnd:
+        case QEvent::TouchUpdate:
+            sendTouchEvent(static_cast<QTouchEvent *>(event));
+            return true;
+
+        default:
+            break;
+        }
+    }
+
+    return QWidget::event(event);
+}
+
 int RemoteViewWidget::contentWidth() const
 {
     return width() - verticalRulerWidth();
@@ -995,4 +1066,28 @@ void RemoteViewWidget::sendWheelEvent(QWheelEvent *event)
 #endif
     m_interface->sendWheelEvent(mapToSource(event->pos()), pixelDelta, angleDelta,
                                 event->buttons(), event->modifiers());
+}
+
+void RemoteViewWidget::sendTouchEvent(QTouchEvent *event)
+{
+    event->accept();
+
+    QList<QTouchEvent::TouchPoint> touchPoints;
+    foreach (const QTouchEvent::TouchPoint &point, event->touchPoints()) {
+        touchPoints << mapToSource(point);
+    }
+
+    QTouchDevice::Capabilities caps = event->device()->capabilities();
+    caps &= ~QTouchDevice::RawPositions; //we don't have a way to meaningfully map the raw positions to the source
+    caps &= ~QTouchDevice::Velocity; //neither for velocity
+
+    m_interface->sendTouchEvent(event->type(),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+                                event->device()->type(),
+                                caps,
+                                event->device()->maximumTouchPoints(),
+#else
+                                event->deviceType(),
+#endif
+                                event->modifiers(), event->touchPointStates(), touchPoints);
 }

--- a/ui/remoteviewwidget.h
+++ b/ui/remoteviewwidget.h
@@ -36,6 +36,7 @@
 #include <common/remoteviewframe.h>
 
 #include <QWidget>
+#include <QTouchEvent>
 #include <QPointer>
 
 QT_BEGIN_NAMESPACE
@@ -43,6 +44,8 @@ class QAbstractItemModel;
 class QActionGroup;
 class QStandardItemModel;
 class QModelIndex;
+class QEvent;
+class QTouchEvent;
 QT_END_NAMESPACE
 
 namespace GammaRay {
@@ -126,8 +129,13 @@ protected:
 
     // translate from view coordinates to source coordinates
     QPoint mapToSource(QPoint pos) const;
+    QPointF mapToSource(QPointF pos) const;
+    QRectF mapToSource(const QRectF &r) const;
     // translates from source coordinates to view coordinates
     QPoint mapFromSource(QPoint pos) const;
+    QPointF mapFromSource(QPointF pos) const;
+    // translate from view to source coordinates
+    QTouchEvent::TouchPoint mapToSource(const QTouchEvent::TouchPoint &point);
 
     void restoreState(QDataStream &stream);
     void saveState(QDataStream &stream) const;
@@ -145,6 +153,7 @@ protected:
     void contextMenuEvent(QContextMenuEvent *event) Q_DECL_OVERRIDE;
 
     bool eventFilter(QObject *receiver, QEvent *event) Q_DECL_OVERRIDE;
+    bool event(QEvent *event) Q_DECL_OVERRIDE;
 
 private:
     void setupActions();
@@ -161,6 +170,7 @@ private:
     void sendMouseEvent(QMouseEvent *event);
     void sendKeyEvent(QKeyEvent *event);
     void sendWheelEvent(QWheelEvent *event);
+    void sendTouchEvent(QTouchEvent *event);
 
     // size of the content area, ie. excluding the rulers
     int contentWidth() const;


### PR DESCRIPTION
This is based on https://github.com/KDAB/GammaRay/tree/master-KDEND-68 
It now works properly, as far as i can see.
