### PR TITLE
Fix missing code navigation support

### DIFF
--- a/plugins/qmlsupport/gammaray_qmlsupport.json
+++ b/plugins/qmlsupport/gammaray_qmlsupport.json
@@ -4,6 +4,6 @@
     "name": "QML Support",
     "name[de]": "QML Unterstützung",
     "types": [
-        "QQmlEngine"
+        "QJSEngine"
     ]
 }

--- a/plugins/qmlsupport/qmlsupport.h
+++ b/plugins/qmlsupport/qmlsupport.h
@@ -31,7 +31,7 @@
 
 #include <core/toolfactory.h>
 
-#include <QQmlEngine>
+#include <QJSEngine>
 
 namespace GammaRay {
 class QmlSupport : public QObject
@@ -41,7 +41,7 @@ public:
     explicit QmlSupport(ProbeInterface *probe, QObject *parent = 0);
 };
 
-class QmlSupportFactory : public QObject, public StandardToolFactory<QQmlEngine, QmlSupport>
+class QmlSupportFactory : public QObject, public StandardToolFactory<QJSEngine, QmlSupport>
 {
     Q_OBJECT
     Q_INTERFACES(GammaRay::ToolFactory)

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -103,6 +103,7 @@ private slots:
     void sgNodeDeleted(QSGNode *node);
     void objectSelected(QObject *object);
     void objectSelected(void *object, const QString &typeName);
+    void objectCreated(QObject *object);
 
 private:
     void selectWindow(QQuickWindow *window);


### PR DESCRIPTION
The issue appear when attaching a qml application
and right clicking an object in any QObject based inspector.

Task-Id: KDEND-41
