### PR TITLE
Do not pass -fPIE when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,10 +318,6 @@ if(Qt5Core_FOUND)
   set(HAVE_QT_WEBKIT ${Qt5WebKit_FOUND})
   set(HAVE_QT_WEBKIT1 ${Qt5WebKitWidgets_FOUND})
 
-  if(Qt5_POSITION_INDEPENDENT_CODE AND NOT WIN32)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  endif()
-
   # TODO: Remove me once fixed in ECM module
   # more hacks: find qpa/... includes
   # also see https://codereview.qt-project.org/#change,30483


### PR DESCRIPTION
Any recent CMake (and all the ones that we support anyhow) should
automatically get the right flags to build position-independent code
from Qt.

Instead, by forcing PIC to be enabled, we end up passing -fPIE to the
compiler when building executables, instead of (only) -fPIC as demanded
by Qt.

So: leave the PIC options alone.