### PR TITLE
Fix reentrancy issue

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -89,8 +89,7 @@ void Client::connectToHost(const QUrl &url, int tryAgain)
 
     connect(m_clientDevice, SIGNAL(connected()), this, SLOT(socketConnected()));
     connect(m_clientDevice, SIGNAL(transientError()), this, SIGNAL(transientConnectionError()));
-    connect(m_clientDevice, SIGNAL(persistentError(QString)), this,
-            SIGNAL(persisitentConnectionError(QString)));
+    connect(m_clientDevice, SIGNAL(persistentError(QString)), this, SIGNAL(persisitentConnectionError(QString)));
     connect(m_clientDevice, SIGNAL(transientError()), this, SLOT(resetClientDevice()));
     connect(m_clientDevice, SIGNAL(persistentError(QString)), this, SLOT(resetClientDevice()));
     m_clientDevice->setTryAgain(tryAgain);
@@ -101,7 +100,6 @@ void Client::disconnectFromHost()
 {
     if (m_clientDevice) {
         m_clientDevice->disconnectFromHost();
-        resetClientDevice();
     }
 }
 

--- a/client/clientconnectionmanager.cpp
+++ b/client/clientconnectionmanager.cpp
@@ -158,6 +158,7 @@ void ClientConnectionManager::showSplashScreen()
 
 void ClientConnectionManager::disconnectFromHost()
 {
+    targetQuitRequested();
     m_client->disconnectFromHost();
 }
 

--- a/common/endpoint.cpp
+++ b/common/endpoint.cpp
@@ -138,6 +138,8 @@ void Endpoint::readyRead()
 
 void Endpoint::connectionClosed()
 {
+    disconnect(m_socket.data(), SIGNAL(readyRead()), this, SLOT(readyRead()));
+    disconnect(m_socket.data(), SIGNAL(disconnected()), this, SLOT(connectionClosed()));
     m_socket = 0;
     emit disconnected();
 }


### PR DESCRIPTION
There was a recurrent crash when disconnectFromHost was called too much
in a short time.
Also the invalidated socket was still connected and produced responses
for readyRead / disconnected.