### PR TITLE
statemachineviewer: Add support for scxml log

### DIFF
--- a/plugins/statemachineviewer/qscxmlstatemachinedebuginterface.cpp
+++ b/plugins/statemachineviewer/qscxmlstatemachinedebuginterface.cpp
@@ -54,6 +54,8 @@ QScxmlStateMachineDebugInterface::QScxmlStateMachineDebugInterface(QScxmlStateMa
 {
     connect(stateMachine, SIGNAL(runningChanged(bool)), this, SIGNAL(runningChanged(bool)));
 
+    connect(stateMachine, SIGNAL(log(QString, QString)), this, SIGNAL(logMessage(QString, QString)));
+
     connect(m_info.data(), SIGNAL(statesEntered(QVector<QScxmlStateMachineInfo::StateId>)), this, SLOT(statesEntered(QVector<QScxmlStateMachineInfo::StateId>)));
     connect(m_info.data(), SIGNAL(statesExited(QVector<QScxmlStateMachineInfo::StateId>)), this, SLOT(statesExited(QVector<QScxmlStateMachineInfo::StateId>)));
     connect(m_info.data(), SIGNAL(transitionsTriggered(QVector<QScxmlStateMachineInfo::TransitionId>)), this, SLOT(transitionsTriggered(QVector<QScxmlStateMachineInfo::TransitionId>)));

--- a/plugins/statemachineviewer/statemachinedebuginterface.h
+++ b/plugins/statemachineviewer/statemachinedebuginterface.h
@@ -102,6 +102,8 @@ signals:
     void stateExited(State state);
 
     void transitionTriggered(Transition transition);
+
+    void logMessage(const QString &label, const QString &message);
 };
 }
 

--- a/plugins/statemachineviewer/statemachineviewerserver.cpp
+++ b/plugins/statemachineviewer/statemachineviewerserver.cpp
@@ -148,10 +148,7 @@ void StateMachineViewerServer::setSelectedStateMachine(StateMachineDebugInterfac
         return;
 
     if (oldMachine) {
-        disconnect(oldMachine, SIGNAL(runningChanged(bool)), this, SLOT(updateStartStop()));
-        disconnect(oldMachine, SIGNAL(stateEntered(State)), this, SLOT(stateEntered(State)));
-        disconnect(oldMachine, SIGNAL(stateExited(State)), this, SLOT(stateExited(State)));
-        disconnect(oldMachine, SIGNAL(transitionTriggered(Transition)), this, SLOT(handleTransitionTriggered(Transition)));
+        oldMachine->disconnect(this);
     }
 
     m_stateModel->setStateMachine(machine);
@@ -166,6 +163,7 @@ void StateMachineViewerServer::setSelectedStateMachine(StateMachineDebugInterfac
         connect(machine, SIGNAL(stateEntered(State)), this, SLOT(stateEntered(State)));
         connect(machine, SIGNAL(stateExited(State)), this, SLOT(stateExited(State)));
         connect(machine, SIGNAL(transitionTriggered(Transition)), this, SLOT(handleTransitionTriggered(Transition)));
+        connect(machine, SIGNAL(logMessage(QString, QString)), this, SLOT(handleLogMessage(QString, QString)));
     }
     updateStartStop();
 
@@ -320,6 +318,11 @@ void StateMachineViewerServer::toggleRunning()
         selectedStateMachine()->stop();
     else
         selectedStateMachine()->start();
+}
+
+void StateMachineViewerServer::handleLogMessage(const QString &label, const QString &msg)
+{
+    emit message(tr("Log [label=%1]: %2").arg(label, msg));
 }
 
 StateMachineViewerFactory::StateMachineViewerFactory(QObject *parent)

--- a/plugins/statemachineviewer/statemachineviewerserver.h
+++ b/plugins/statemachineviewer/statemachineviewerserver.h
@@ -83,6 +83,8 @@ private slots:
 
     void repopulateGraph() Q_DECL_OVERRIDE;
 
+    void handleLogMessage(const QString &label, const QString &message);
+
 private:
     bool mayAddState(State state);
 


### PR DESCRIPTION
Display log messages created via scxml <log> in the statemachineviewer log.