### PR TITLE
Qtivi object navigation

### DIFF
--- a/plugins/qtivi/gammaray_qtivi.json
+++ b/plugins/qtivi/gammaray_qtivi.json
@@ -2,5 +2,6 @@
     "id": "gammaray_qtivi",
     "name": "Qt IVI",
     "types": ["QIviServiceObject", "QIviProperty"],
+    "selectableTypes": ["QIviProperty"],
     "hidden": false
 }

--- a/plugins/qtivi/qtivipropertymodel.cpp
+++ b/plugins/qtivi/qtivipropertymodel.cpp
@@ -282,6 +282,7 @@ Qt::ItemFlags QtIviPropertyModel::flags(const QModelIndex &index) const
         const auto &carrier = m_propertyCarriers.at(index.parent().row());
         const auto &prop = carrier.iviProperties.at(index.row());
 
+        flags |= Qt::ItemNeverHasChildren; // We have two levels, this is the second
         if (!prop.value->isAvailable())
             flags &= ~Qt::ItemIsEnabled;
 

--- a/plugins/qtivi/qtivipropertymodel.h
+++ b/plugins/qtivi/qtivipropertymodel.h
@@ -90,6 +90,7 @@ public:
 
 private:
     int indexOfPropertyCarrier(const QObject *carrier) const;
+    QModelIndex indexOfProperty(const QIviProperty *property, int column = 0 /*NameColumn*/) const;
 
     struct IviPropertyCarrier
     {

--- a/plugins/qtivi/qtivipropertymodel.h
+++ b/plugins/qtivi/qtivipropertymodel.h
@@ -49,7 +49,8 @@ class QtIviPropertyModel : public QAbstractItemModel
     Q_OBJECT
 public:
     enum {
-        ValueConstraintsRole = ObjectModel::UserRole + 1, // transmits the following constraints types
+        ObjectIdRole = ObjectModel::UserRole + 1,
+        ValueConstraintsRole, // transmits the following constraints types
 
         RangeConstraints = 0, // min / max
         AvailableValuesConstraints // list of possible values
@@ -74,6 +75,7 @@ private slots:
     void objectAdded(QObject *obj);
     void objectRemoved(QObject *obj);
     void objectReparented(QObject *obj);
+    void objectSelected(QObject *obj);
     void propertyValueChanged(const QVariant &value);
     void availabilityChanged();
 

--- a/plugins/qtivi/qtivisupportwidget.h
+++ b/plugins/qtivi/qtivisupportwidget.h
@@ -34,6 +34,7 @@
 
 QT_BEGIN_NAMESPACE
 class QModelIndex;
+class QTreeView;
 QT_END_NAMESPACE
 
 namespace GammaRay {
@@ -43,6 +44,12 @@ class QtIVIWidget : public QWidget
     Q_OBJECT
 public:
     explicit QtIVIWidget(QWidget *parent = nullptr);
+
+private slots:
+    void contextMenu(QPoint pos);
+
+private:
+    QTreeView *m_objectTreeView;
 };
 
 class QtIVIUiFactory : public QObject, public StandardToolUiFactory<QtIVIWidget>


### PR DESCRIPTION
Relevant commit message. Question: is the problem described in its second half fixable with reasonable effort?

This allows to navigate from / to QtIvi to / from other plugins
such as QObject, when invoking the context menu on a suitable
object. Unfortunately it doesn't work for parents of QtIviProperty
instances because the parents are not of a special class. The
navigation is based on class names in GammaRay common code.