### PR TITLE
Ui: Prevent toolSelector-scrollbar from looking ugly

### DIFF
--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -33,10 +33,12 @@
        <enum>Qt::CustomContextMenu</enum>
       </property>
       <property name="styleSheet">
-       <string notr="true">background-image: url(:/gammaray/kdab-gammaray-logo.png);
+       <string notr="true">QWidget#toolSelector{
+background-image: url(:/gammaray/kdab-gammaray-logo.png);
 background-repeat: no-repeat;
 background-attachment:fixed;
 background-position:bottom right;
+}
 </string>
       </property>
       <property name="frameShape">
@@ -89,7 +91,7 @@ background-position:bottom right;
      <x>0</x>
      <y>0</y>
      <width>829</width>
-     <height>27</height>
+     <height>39</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_GammaRay">


### PR DESCRIPTION
StyleSheet needed to be enhanced with a selector
(QWidget#toolSelector{...}) in order to prevent inheritance.
This apparently affected the Scrollbar.
![gamma_why](https://cloud.githubusercontent.com/assets/315665/21316227/050ee436-c600-11e6-8c14-1c84968ae649.png)