### PR TITLE
Meta Objects: Don't warn about internal methods

### DIFF
--- a/core/qmetaobjectvalidator.cpp
+++ b/core/qmetaobjectvalidator.cpp
@@ -61,9 +61,12 @@ QMetaObjectValidatorResult::Results QMetaObjectValidator::checkMethod(const QMet
 
     // check for parameters with unknown type
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    for (int j = 0; j < method.parameterCount(); ++j) {
-        if (method.parameterType(j) == QMetaType::UnknownType)
-            r |= QMetaObjectValidatorResult::UnknownMethodParameterType;
+    // don't check internal methods such as _q_createJSWrapper() from QQuickItem
+    if (!method.name().startsWith("_q")) {
+        for (int j = 0; j < method.parameterCount(); ++j) {
+            if (method.parameterType(j) == QMetaType::UnknownType)
+                r |= QMetaObjectValidatorResult::UnknownMethodParameterType;
+        }
     }
 
     // check for signal overrides


### PR DESCRIPTION
With the introduction of private _q_createJSWrapper() in QQuickItem the
entire class hierarchy gets flagged in the meta object browser for having
slots that aren't dynamically invokable. The warning is of dubious use
for private methods though, as invoking those dynamically is far less
common/needed.

So let's just warn about issues in the public interface.