### PR TITLE
Fix broken launch on macOS

### DIFF
--- a/launcher/injector/preloadinjector.cpp
+++ b/launcher/injector/preloadinjector.cpp
@@ -59,7 +59,6 @@ bool PreloadInjector::launch(const QStringList &programAndArgs, const QString &p
 
     QProcessEnvironment env(e);
 #ifdef Q_OS_MAC
-    env.insert(QStringLiteral("DYLD_FORCE_FLAT_NAMESPACE"), QStringLiteral("1"));
     env.insert(QStringLiteral("DYLD_INSERT_LIBRARIES"), probeDll);
     env.insert(QStringLiteral("GAMMARAY_UNSET_DYLD"), QStringLiteral("1"));
 

--- a/probe/probecreator.cpp
+++ b/probe/probecreator.cpp
@@ -56,10 +56,8 @@ ProbeCreator::ProbeCreator(CreateFlags flags)
     // don't propagate the probe to child processes
     if (qgetenv("GAMMARAY_UNSET_PRELOAD") == "1")
         qputenv("LD_PRELOAD", "");
-    if (qgetenv("GAMMARAY_UNSET_DYLD") == "1") {
+    if (qgetenv("GAMMARAY_UNSET_DYLD") == "1")
         qputenv("DYLD_INSERT_LIBRARIES", "");
-        qputenv("DYLD_FORCE_FLAT_NAMESPACE", "");
-    }
 
     // HACK the webinspector plugin does this as well, but if the web view is created
     // too early the env var from there isn't going to reach the web process


### PR DESCRIPTION
The flat namespaced loading is no longer required.

Task-Id: #292