### PR TITLE
Add a way to disable target decorations

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -493,6 +493,11 @@ void QuickInspector::setCustomRenderMode(
 #endif
 }
 
+void QuickInspector::setServerSideDecorationsEnabled(bool enabled)
+{
+    m_overlay->setDrawDecorations(enabled);
+}
+
 void QuickInspector::applyRenderMode()
 {
     QMutexLocker lock(&m_pendingRenderMode.mutex);
@@ -526,6 +531,11 @@ void QuickInspector::checkFeatures()
 #endif
             )
         );
+}
+
+void QuickInspector::checkServerSideDecorations()
+{
+    emit serverSideDecorations(m_overlay->drawDecorations());
 }
 
 void QuickInspector::itemSelectionChanged(const QItemSelection &selection)

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -81,6 +81,10 @@ public slots:
 
     void checkFeatures() override;
 
+    void setServerSideDecorationsEnabled(bool enabled) override;
+
+    void checkServerSideDecorations() override;
+
     void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
     void pickElementId(const GammaRay::ObjectId& id);
 

--- a/plugins/quickinspector/quickinspectorclient.cpp
+++ b/plugins/quickinspector/quickinspectorclient.cpp
@@ -60,3 +60,16 @@ void QuickInspectorClient::checkFeatures()
 {
     Endpoint::instance()->invokeObject(objectName(), "checkFeatures");
 }
+
+void GammaRay::QuickInspectorClient::setServerSideDecorationsEnabled(bool enabled)
+{
+    Endpoint::instance()->invokeObject(objectName(),
+                                       "setServerSideDecorationsEnabled",
+                                       QVariantList()
+                                       << enabled);
+}
+
+void QuickInspectorClient::checkServerSideDecorations()
+{
+    Endpoint::instance()->invokeObject(objectName(), "checkServerSideDecorations");
+}

--- a/plugins/quickinspector/quickinspectorclient.h
+++ b/plugins/quickinspector/quickinspectorclient.h
@@ -52,6 +52,10 @@ public slots:
     override;
 
     void checkFeatures() override;
+
+    void setServerSideDecorationsEnabled(bool enabled) override;
+
+    void checkServerSideDecorations() override;
 };
 }
 

--- a/plugins/quickinspector/quickinspectorinterface.h
+++ b/plugins/quickinspector/quickinspectorinterface.h
@@ -79,8 +79,13 @@ public slots:
 
     virtual void checkFeatures() = 0;
 
+    virtual void setServerSideDecorationsEnabled(bool enabled) = 0;
+
+    virtual void checkServerSideDecorations() = 0;
+
 signals:
     void features(GammaRay::QuickInspectorInterface::Features features);
+    void serverSideDecorations(bool enabled);
 };
 }
 

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -129,10 +129,13 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
     connect(m_interface, SIGNAL(features(GammaRay::QuickInspectorInterface::Features)),
             this, SLOT(setFeatures(GammaRay::QuickInspectorInterface::Features)));
 
+    connect(m_interface, SIGNAL(serverSideDecorations(bool)), this, SLOT(setServerSideDecorations(bool)));
+
     connect(ui->itemTreeView, SIGNAL(customContextMenuRequested(QPoint)),
             this, SLOT(itemContextMenu(QPoint)));
 
     m_interface->checkFeatures();
+    m_interface->checkServerSideDecorations();
 
     m_stateManager.setDefaultSizes(ui->mainSplitter, UISizeVector() << "50%" << "50%");
     m_stateManager.setDefaultSizes(ui->previewTreeSplitter, UISizeVector() << "50%" << "50%");
@@ -160,6 +163,11 @@ void QuickInspectorWidget::restoreTargetState(QSettings *settings)
 void QuickInspectorWidget::setFeatures(QuickInspectorInterface::Features features)
 {
     m_previewWidget->setSupportsCustomRenderModes(features);
+}
+
+void QuickInspectorWidget::setServerSideDecorations(bool enabled)
+{
+    m_previewWidget->setServerSideDecorationsState(enabled);
 }
 
 void QuickInspectorWidget::itemSelectionChanged(const QItemSelection &selection)

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -140,8 +140,9 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
     m_stateManager.setDefaultSizes(ui->mainSplitter, UISizeVector() << "50%" << "50%");
     m_stateManager.setDefaultSizes(ui->previewTreeSplitter, UISizeVector() << "50%" << "50%");
 
-    connect(ui->itemPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(propertyWidgetTabsChanged()));
-    connect(ui->sgPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(propertyWidgetTabsChanged()));
+    connect(ui->itemPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(resetState()));
+    connect(ui->sgPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(resetState()));
+    connect(m_previewWidget, SIGNAL(stateChanged()), this, SLOT(saveState()));
 }
 
 QuickInspectorWidget::~QuickInspectorWidget()
@@ -233,8 +234,12 @@ void GammaRay::QuickInspectorWidget::itemContextMenu(const QPoint &pos)
     contextMenu.exec(ui->itemTreeView->viewport()->mapToGlobal(pos));
 }
 
-void QuickInspectorWidget::propertyWidgetTabsChanged()
+void QuickInspectorWidget::resetState()
+{
+    m_stateManager.reset();
+}
+
+void QuickInspectorWidget::saveState()
 {
     m_stateManager.saveState();
-    m_stateManager.reset();
 }

--- a/plugins/quickinspector/quickinspectorwidget.h
+++ b/plugins/quickinspector/quickinspectorwidget.h
@@ -68,7 +68,8 @@ private slots:
     void itemModelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                               const QVector<int> &roles);
     void itemContextMenu(const QPoint &pos);
-    void propertyWidgetTabsChanged();
+    void resetState();
+    void saveState();
 
 private:
     QScopedPointer<Ui::QuickInspectorWidget> ui;

--- a/plugins/quickinspector/quickinspectorwidget.h
+++ b/plugins/quickinspector/quickinspectorwidget.h
@@ -64,6 +64,7 @@ public:
 private slots:
     void itemSelectionChanged(const QItemSelection &selection);
     void setFeatures(GammaRay::QuickInspectorInterface::Features features);
+    void setServerSideDecorations(bool enabled);
     void itemModelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                               const QVector<int> &roles);
     void itemContextMenu(const QPoint &pos);

--- a/plugins/quickinspector/quickoverlay.cpp
+++ b/plugins/quickinspector/quickoverlay.cpp
@@ -122,6 +122,7 @@ bool ItemOrLayoutFacade::isLayout() const
 QuickOverlay::QuickOverlay()
   : m_currentToplevelItem(nullptr)
   , m_isGrabbingMode(false)
+  , m_drawDecorations(true)
 {
 }
 
@@ -171,6 +172,19 @@ void QuickOverlay::placeOn(ItemOrLayoutFacade item)
     updateOverlay();
 }
 
+bool QuickOverlay::drawDecorations() const
+{
+    return m_drawDecorations;
+}
+
+void QuickOverlay::setDrawDecorations(bool enabled)
+{
+    if (m_drawDecorations == enabled)
+        return;
+    m_drawDecorations = enabled;
+    updateOverlay();
+}
+
 void QuickOverlay::setIsGrabbingMode(bool isGrabbingMode)
 {
     if (m_isGrabbingMode == isGrabbingMode)
@@ -217,6 +231,8 @@ void QuickOverlay::windowAfterRendering()
 
 void QuickOverlay::drawDecorations(const QSize &size, qreal dpr)
 {
+    if (!m_drawDecorations)
+        return;
     QOpenGLPaintDevice device(size * dpr);
     device.setDevicePixelRatio(dpr);
     QPainter painter(&device);

--- a/plugins/quickinspector/quickoverlay.h
+++ b/plugins/quickinspector/quickoverlay.h
@@ -83,6 +83,9 @@ public:
      */
     void placeOn(ItemOrLayoutFacade item);
 
+    bool drawDecorations() const;
+    void setDrawDecorations(bool enabled);
+
     static void drawDecoration(QPainter *painter, const QuickItemGeometry &itemGeometry, const QRectF &viewRect,
                                qreal zoom);
 
@@ -112,6 +115,7 @@ private:
     ItemOrLayoutFacade m_currentItem;
     QuickItemGeometry m_effectiveGeometry;
     bool m_isGrabbingMode;
+    bool m_drawDecorations;
 };
 }
 

--- a/plugins/quickinspector/quickscenepreviewwidget.cpp
+++ b/plugins/quickinspector/quickscenepreviewwidget.cpp
@@ -121,6 +121,13 @@ QuickScenePreviewWidget::QuickScenePreviewWidget(QuickInspectorInterface *inspec
                                               "enabled, the QtQuick renderer will thus on each repaint highlight the item(s), "
                                               "that caused the repaint."));
 
+    m_toolBar.serverSideDecorationsEnabled = new QAction(QIcon(QStringLiteral(
+                                                               ":/gammaray/plugins/quickinspector/active-focus.png")),
+                                                     tr("Target Decorations"), this);
+    m_toolBar.serverSideDecorationsEnabled->setCheckable(true);
+    m_toolBar.serverSideDecorationsEnabled->setToolTip(tr("<b>Target Decorations</b><br>"
+                                              "This enable or not the decorations on the target application."));
+
     m_toolBar.toolbarWidget->addActions(m_toolBar.visualizeGroup->actions());
     connect(m_toolBar.visualizeGroup, SIGNAL(triggered(QAction*)), this,
             SLOT(visualizeActionTriggered(QAction*)));
@@ -129,6 +136,11 @@ QuickScenePreviewWidget::QuickScenePreviewWidget(QuickInspectorInterface *inspec
 
     foreach (auto action, interactionModeActions()->actions())
         m_toolBar.toolbarWidget->addAction(action);
+    m_toolBar.toolbarWidget->addSeparator();
+
+    m_toolBar.toolbarWidget->addAction(m_toolBar.serverSideDecorationsEnabled);
+    connect(m_toolBar.serverSideDecorationsEnabled, SIGNAL(triggered(bool)), this,
+            SLOT(serverSideDecorationsTriggered(bool)));
     m_toolBar.toolbarWidget->addSeparator();
 
     m_toolBar.toolbarWidget->addAction(zoomOutAction());
@@ -230,6 +242,12 @@ void QuickScenePreviewWidget::visualizeActionTriggered(QAction *current)
     }
 }
 
+void QuickScenePreviewWidget::serverSideDecorationsTriggered(bool enabled)
+{
+    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
+    m_inspectorInterface->setServerSideDecorationsEnabled(enabled);
+}
+
 void GammaRay::QuickScenePreviewWidget::setSupportsCustomRenderModes(
     QuickInspectorInterface::Features supportedCustomRenderModes)
 {
@@ -241,6 +259,11 @@ void GammaRay::QuickScenePreviewWidget::setSupportsCustomRenderModes(
         supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeOverdraw);
     m_toolBar.visualizeChanges->setEnabled(
         supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeChanges);
+}
+
+void QuickScenePreviewWidget::setServerSideDecorationsState(bool enabled)
+{
+    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
 }
 
 QuickInspectorInterface::RenderMode QuickScenePreviewWidget::customRenderMode() const
@@ -289,4 +312,17 @@ void QuickScenePreviewWidget::setCustomRenderMode(QuickInspectorInterface::Rende
     }
 
     visualizeActionTriggered(currentAction ? currentAction : m_toolBar.visualizeBatches);
+}
+
+bool QuickScenePreviewWidget::serverSideDecorationsEnabled() const
+{
+    return m_toolBar.serverSideDecorationsEnabled->isChecked();
+}
+
+void QuickScenePreviewWidget::setServerSideDecorationsEnabled(bool enabled)
+{
+    if (m_toolBar.serverSideDecorationsEnabled->isChecked() == enabled)
+        return;
+    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
+    serverSideDecorationsTriggered(enabled);
 }

--- a/plugins/quickinspector/quickscenepreviewwidget.cpp
+++ b/plugins/quickinspector/quickscenepreviewwidget.cpp
@@ -43,7 +43,7 @@
 #include <cmath>
 
 using namespace GammaRay;
-static qint32 QuickScenePreviewWidgetStateVersion = 1;
+static qint32 QuickScenePreviewWidgetStateVersion = 2;
 
 QT_BEGIN_NAMESPACE
 GAMMARAY_ENUM_STREAM_OPERATORS(GammaRay::QuickInspectorInterface::RenderMode)
@@ -173,18 +173,29 @@ void QuickScenePreviewWidget::restoreState(const QByteArray &state)
     QDataStream stream(state);
     qint32 version;
     QuickInspectorInterface::RenderMode mode = customRenderMode();
+    bool drawDecorations = serverSideDecorationsEnabled();
     RemoteViewWidget::restoreState(stream);
 
     stream >> version;
 
     switch (version) {
     case 1: {
-        stream >> mode;
+        stream
+                >> mode
+        ;
+        break;
+    }
+    case 2: {
+        stream
+                >> mode
+                >> drawDecorations
+        ;
         break;
     }
     }
 
     setCustomRenderMode(mode);
+    setServerSideDecorationsEnabled(drawDecorations);
 }
 
 QByteArray QuickScenePreviewWidget::saveState() const
@@ -199,7 +210,16 @@ QByteArray QuickScenePreviewWidget::saveState() const
 
         switch (QuickScenePreviewWidgetStateVersion) {
         case 1: {
-            stream << customRenderMode();
+            stream
+                    << customRenderMode()
+            ;
+            break;
+        }
+        case 2: {
+            stream
+                    << customRenderMode()
+                    << serverSideDecorationsEnabled()
+            ;
             break;
         }
         }
@@ -240,12 +260,14 @@ void QuickScenePreviewWidget::visualizeActionTriggered(QAction *current)
                                                   : QuickInspectorInterface::NormalRendering
                                                   );
     }
+    emit stateChanged();
 }
 
 void QuickScenePreviewWidget::serverSideDecorationsTriggered(bool enabled)
 {
     m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
     m_inspectorInterface->setServerSideDecorationsEnabled(enabled);
+    emit stateChanged();
 }
 
 void GammaRay::QuickScenePreviewWidget::setSupportsCustomRenderModes(

--- a/plugins/quickinspector/quickscenepreviewwidget.h
+++ b/plugins/quickinspector/quickscenepreviewwidget.h
@@ -57,12 +57,17 @@ public:
     QByteArray saveState() const override;
 
     void setSupportsCustomRenderModes(QuickInspectorInterface::Features supportedCustomRenderModes);
+    void setServerSideDecorationsState(bool enabled);
 
     QuickInspectorInterface::RenderMode customRenderMode() const;
     void setCustomRenderMode(QuickInspectorInterface::RenderMode customRenderMode);
 
+    bool serverSideDecorationsEnabled() const;
+    void setServerSideDecorationsEnabled(bool enabled);
+
 private Q_SLOTS:
     void visualizeActionTriggered(QAction* current);
+    void serverSideDecorationsTriggered(bool enabled);
 
 private:
     void drawDecoration(QPainter *p) override;
@@ -76,6 +81,7 @@ private:
         QAction *visualizeOverdraw;
         QAction *visualizeBatches;
         QAction *visualizeChanges;
+        QAction *serverSideDecorationsEnabled;
     } m_toolBar;
 
     QuickInspectorInterface *m_inspectorInterface;

--- a/ui/remoteviewwidget.cpp
+++ b/ui/remoteviewwidget.cpp
@@ -369,6 +369,7 @@ void RemoteViewWidget::setZoom(double zoom)
     m_initialZoomDone = true;
     emit zoomChanged();
     emit zoomLevelChanged(index);
+    emit stateChanged();
 
     m_x = contentWidth() / 2 - (contentWidth() / 2 - m_x) * m_zoom / oldZoom;
     m_y = contentHeight() / 2 - (contentHeight() / 2 - m_y) * m_zoom / oldZoom;
@@ -459,6 +460,7 @@ void RemoteViewWidget::setInteractionMode(RemoteViewWidget::InteractionMode mode
     }
 
     update();
+    emit stateChanged();
 }
 
 RemoteViewWidget::InteractionModes RemoteViewWidget::supportedInteractionModes() const

--- a/ui/remoteviewwidget.h
+++ b/ui/remoteviewwidget.h
@@ -124,6 +124,7 @@ public slots:
 signals:
     void zoomChanged();
     void zoomLevelChanged(int zoomLevelIndex);
+    void stateChanged();
 
 protected:
     /** Current frame data. */


### PR DESCRIPTION
Also add support to save/restore remote view toolbar settings (ie: retain any checked actions / mode)