### PR TITLE
Fix quickinspector (2commits)

### DIFF
--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -281,6 +281,9 @@ void QuickItemModel::itemReparented()
 
     QQuickItem *sourceParent = m_childParentMap.value(item);
     Q_ASSERT(sourceParent);
+    if (sourceParent == item->parentItem())
+        return;
+
     const QModelIndex sourceParentIndex = indexForItem(sourceParent);
 
     QVector<QQuickItem *> &sourceSiblings = m_parentChildMap[sourceParent];

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -47,6 +47,7 @@ using namespace GammaRay;
 QuickItemModel::QuickItemModel(QObject *parent)
     : ObjectModelBase<QAbstractItemModel>(parent)
 {
+    m_clickEventFilter = new QuickEventMonitor(this);
 }
 
 QuickItemModel::~QuickItemModel()
@@ -150,7 +151,7 @@ void QuickItemModel::connectItem(QQuickItem *item)
     connect(item, SIGNAL(heightChanged()), this, SLOT(itemUpdated()));
     connect(item, SIGNAL(xChanged()), this, SLOT(itemUpdated()));
     connect(item, SIGNAL(yChanged()), this, SLOT(itemUpdated()));
-    item->installEventFilter(new QuickEventMonitor(this));
+    item->installEventFilter(m_clickEventFilter);
 }
 
 void QuickItemModel::disconnectItem(QQuickItem *item)

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -219,7 +219,8 @@ void QuickItemModel::addItem(QQuickItem *item)
     connectItem(item);
 
     const QModelIndex index = indexForItem(parentItem);
-    Q_ASSERT(index.isValid() || !parentItem);
+    if (!index.isValid() && parentItem)
+        return;
 
     QVector<QQuickItem *> &children = m_parentChildMap[parentItem];
     QVector<QQuickItem *>::iterator it = std::lower_bound(children.begin(), children.end(), item);

--- a/plugins/quickinspector/quickitemmodel.h
+++ b/plugins/quickinspector/quickitemmodel.h
@@ -42,6 +42,10 @@ class QQuickWindow;
 QT_END_NAMESPACE
 
 namespace GammaRay {
+
+//forward
+class QuickEventMonitor;
+
 /** QQ2 item tree model. */
 class QuickItemModel : public ObjectModelBase<QAbstractItemModel>
 {
@@ -102,6 +106,7 @@ private:
     QHash<QQuickItem *, QQuickItem *> m_childParentMap;
     QHash<QQuickItem *, QVector<QQuickItem *> > m_parentChildMap;
     QHash<QQuickItem *, int> m_itemFlags;
+    QuickEventMonitor *m_clickEventFilter;
 };
 
 class QuickEventMonitor : public QObject


### PR DESCRIPTION
Fixing bugs about an incomplete qquickitemmodel. 
(due to untracked scene intialization and the according windowchanges)

This makes the QuickItemModel more precise thus improving picking. 
