### PR TITLE
Allow showing only the current item in the Quick preview widget

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -60,6 +60,7 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QQuickView>
+#include <QQuickItemGrabResult>
 
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -370,6 +371,7 @@ QuickInspector::QuickInspector(ProbeInterface *probe, QObject *parent)
     , m_remoteView(new RemoteViewServer(QStringLiteral("com.kdab.GammaRay.QuickRemoteView"), this))
     , m_pendingRenderMode(new RenderModeRequest(this))
     , m_renderMode(QuickInspectorInterface::NormalRendering)
+    , m_grabMode(QuickInspectorInterface::FullWindow)
 {
     registerMetaTypes();
     registerVariantHandlers();
@@ -561,6 +563,7 @@ void QuickInspector::recreateOverlay()
 {
     ProbeGuard guard;
     m_overlay = new QuickOverlay;
+    m_overlay->setGrabMode(m_grabMode);
 
     connect(m_overlay.data(), &QuickOverlay::sceneChanged, m_remoteView, &RemoteViewServer::sourceChanged);
     connect(m_overlay.data(), &QuickOverlay::sceneGrabbed, this, &QuickInspector::sendRenderedScene);
@@ -656,6 +659,16 @@ void QuickInspector::checkFeatures()
 void QuickInspector::checkServerSideDecorations()
 {
     emit serverSideDecorations(m_overlay->decorationsEnabled());
+}
+
+void QuickInspector::setGrabMode(QuickInspectorInterface::GrabMode mode)
+{
+    if (m_grabMode == mode) {
+        return;
+    }
+
+    m_grabMode = mode;
+    m_overlay->setGrabMode(mode);
 }
 
 void QuickInspector::setOverlaySettings(const GammaRay::QuickDecorationsSettings &settings)

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -118,6 +118,8 @@ public slots:
 
     void checkOverlaySettings() override;
 
+    void setGrabMode(GammaRay::QuickInspectorInterface::GrabMode mode) override;
+
     void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
     void pickElementId(const GammaRay::ObjectId& id);
 
@@ -165,6 +167,7 @@ private:
     RemoteViewServer *m_remoteView;
     RenderModeRequest *m_pendingRenderMode;
     QuickInspectorInterface::RenderMode m_renderMode;
+    GrabMode m_grabMode;
 };
 
 class QuickInspectorFactory : public QObject,

--- a/plugins/quickinspector/quickinspectorclient.cpp
+++ b/plugins/quickinspector/quickinspectorclient.cpp
@@ -88,3 +88,8 @@ void QuickInspectorClient::checkOverlaySettings()
 {
     Endpoint::instance()->invokeObject(objectName(), "checkOverlaySettings");
 }
+
+void QuickInspectorClient::setGrabMode(QuickInspectorInterface::GrabMode mode)
+{
+    Endpoint::instance()->invokeObject(objectName(), "setGrabMode", { QVariant::fromValue(mode) });
+}

--- a/plugins/quickinspector/quickinspectorclient.h
+++ b/plugins/quickinspector/quickinspectorclient.h
@@ -62,6 +62,8 @@ public slots:
     void setOverlaySettings(const GammaRay::QuickDecorationsSettings &settings) override;
 
     void checkOverlaySettings() override;
+
+    void setGrabMode(GammaRay::QuickInspectorInterface::GrabMode mode) override;
 };
 }
 

--- a/plugins/quickinspector/quickinspectorinterface.cpp
+++ b/plugins/quickinspector/quickinspectorinterface.cpp
@@ -63,6 +63,20 @@ QDataStream &operator>>(QDataStream &in, QuickInspectorInterface::RenderMode &va
     return in;
 }
 
+QDataStream &operator<<(QDataStream &out, QuickInspectorInterface::GrabMode value)
+{
+    out << qint32(value);
+    return out;
+}
+
+QDataStream &operator>>(QDataStream &in, QuickInspectorInterface::GrabMode &value)
+{
+    qint32 t;
+    in >> t;
+    value = static_cast<QuickInspectorInterface::GrabMode>(t);
+    return in;
+}
+
 QuickInspectorInterface::QuickInspectorInterface(QObject *parent)
     : QObject(parent)
 {
@@ -72,6 +86,7 @@ QuickInspectorInterface::QuickInspectorInterface(QObject *parent)
     qRegisterMetaTypeStreamOperators<QuickItemGeometry>();
     qRegisterMetaTypeStreamOperators<QVector<QuickItemGeometry>>();
     qRegisterMetaTypeStreamOperators<QuickDecorationsSettings>();
+    qRegisterMetaTypeStreamOperators<GrabMode>();
 }
 
 QuickInspectorInterface::~QuickInspectorInterface()

--- a/plugins/quickinspector/quickinspectorinterface.h
+++ b/plugins/quickinspector/quickinspectorinterface.h
@@ -70,8 +70,14 @@ public:
         VisualizeTraces,
     };
 
+    enum GrabMode {
+        FullWindow,
+        Item
+    };
+
     Q_ENUMS(RenderMode)
     Q_DECLARE_FLAGS(Features, Feature)
+    Q_ENUMS(PreviewMode)
 
     explicit QuickInspectorInterface(QObject *parent = nullptr);
     ~QuickInspectorInterface();
@@ -92,6 +98,8 @@ public slots:
 
     virtual void checkOverlaySettings() = 0;
 
+    virtual void setGrabMode(GrabMode mode) = 0;
+
 signals:
     void features(GammaRay::QuickInspectorInterface::Features features);
     void serverSideDecorations(bool enabled);
@@ -101,6 +109,7 @@ signals:
 
 Q_DECLARE_METATYPE(GammaRay::QuickInspectorInterface::Features)
 Q_DECLARE_METATYPE(GammaRay::QuickInspectorInterface::RenderMode)
+Q_DECLARE_METATYPE(GammaRay::QuickInspectorInterface::GrabMode)
 QT_BEGIN_NAMESPACE
 Q_DECLARE_INTERFACE(GammaRay::QuickInspectorInterface,
                     "com.kdab.GammaRay.QuickInspectorInterface/1.0")

--- a/plugins/quickinspector/quickoverlay.h
+++ b/plugins/quickinspector/quickoverlay.h
@@ -34,6 +34,8 @@
 #include <QQuickItem>
 
 #include "quickdecorationsdrawer.h"
+#include "quickitemgeometry.h"
+#include "quickinspectorinterface.h"
 
 QT_BEGIN_NAMESPACE
 class QQuickWindow;
@@ -103,6 +105,8 @@ public:
 
     void requestGrabWindow(const QRectF &userViewport);
 
+    void setGrabMode(QuickInspectorInterface::GrabMode grabMode);
+
 signals:
     void sceneChanged();
     void sceneGrabbed(const GammaRay::GrabbedFrame &frame);
@@ -150,6 +154,7 @@ private:
         QSize windowSize;
         GraphicsApi graphicsApi;
     } m_renderInfo;
+    QuickInspectorInterface::GrabMode m_grabMode;
 
 private slots:
     void setIsGrabbingMode(bool isGrabbingMode);

--- a/plugins/quickinspector/quickscenecontrolwidget.cpp
+++ b/plugins/quickinspector/quickscenecontrolwidget.cpp
@@ -63,6 +63,7 @@ QuickSceneControlWidget::QuickSceneControlWidget(QuickInspectorInterface *inspec
     , m_gridSettingsWidget(new GridSettingsWidget) // Owned by the QWidgetAction
     , m_legendTool(new QuickOverlayLegend(this))
     , m_inspectorInterface(inspector)
+    , m_grabMode(QuickInspectorInterface::FullWindow)
 {
     m_layout = new QVBoxLayout(this);
     m_layout->setContentsMargins(QMargins());
@@ -169,6 +170,17 @@ QuickSceneControlWidget::QuickSceneControlWidget(QuickInspectorInterface *inspec
     m_toolBar->addActions(m_visualizeGroup->actions());
     connect(m_visualizeGroup, SIGNAL(triggered(QAction*)), this,
             SLOT(visualizeActionTriggered(QAction*)));
+
+    m_toolBar->addSeparator();
+
+    //TODO add icon
+    auto previewItem = new QAction(QIcon(""), tr("Preview only the selected item"), this);
+    previewItem->setCheckable(true);
+    connect(previewItem, &QAction::toggled, this, [this](bool checked) {
+        m_grabMode = checked ? QuickInspectorInterface::Item : QuickInspectorInterface::FullWindow;
+        m_inspectorInterface->setGrabMode(m_grabMode);
+    });
+    m_toolBar->addAction(previewItem);
 
     m_toolBar->addSeparator();
 

--- a/plugins/quickinspector/quickscenecontrolwidget.h
+++ b/plugins/quickinspector/quickscenecontrolwidget.h
@@ -71,6 +71,8 @@ public:
 
     QuickScenePreviewWidget *previewWidget();
 
+    QuickInspectorInterface::GrabMode grabMode() const { return m_grabMode; }
+
 signals:
     void stateChanged();
 
@@ -103,6 +105,7 @@ private:
     QuickOverlayLegend *m_legendTool;
 
     QuickInspectorInterface *m_inspectorInterface;
+    QuickInspectorInterface::GrabMode m_grabMode;
 };
 } // namespace GammaRay
 

--- a/plugins/quickinspector/quickscenepreviewwidget.cpp
+++ b/plugins/quickinspector/quickscenepreviewwidget.cpp
@@ -39,6 +39,7 @@ static const qint32 QuickScenePreviewWidgetStateVersion = 4;
 
 QT_BEGIN_NAMESPACE
 GAMMARAY_ENUM_STREAM_OPERATORS(GammaRay::QuickInspectorInterface::RenderMode)
+GAMMARAY_ENUM_STREAM_OPERATORS(GammaRay::QuickInspectorInterface::GrabMode)
 QT_END_NAMESPACE
 
 QuickScenePreviewWidget::QuickScenePreviewWidget(QuickInspectorInterface *inspector,
@@ -177,6 +178,10 @@ void QuickScenePreviewWidget::resizeEvent(QResizeEvent *e)
 
 void QuickScenePreviewWidget::drawDecoration(QPainter *p)
 {
+    if (m_control->grabMode() == QuickInspectorInterface::Item) {
+        return;
+    }
+
     // Scaling and translations on QuickItemGeometry will be done on demand
 
     if (frame().data().userType() == qMetaTypeId<QuickItemGeometry>()) {


### PR DESCRIPTION
This adds a new button "Preview only the selected item" in the quickinspector ui, and when activated that makes the preview widget show only the item selected in the view, with its children, instead of the whole window. 
We probably need an icon for the button, because right now it's huge.