### PR TITLE
Export the launcher dialog as a shared library

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -119,5 +119,6 @@ endif()
 # UI launcher
 if(HAVE_QT_CONCURRENT AND GAMMARAY_BUILD_UI)
   add_subdirectory(ui)
+  gammaray_install_headers(${CMAKE_CURRENT_BINARY_DIR}/ui/gammaray_launcher_dialog_export.h ui/launcherdialog.h)
 endif()
 endif()

--- a/launcher/launchoptions.h
+++ b/launcher/launchoptions.h
@@ -33,6 +33,7 @@
 
 #include <QHash>
 #include <QSharedDataPointer>
+#include <QUrl>
 
 QT_BEGIN_NAMESPACE
 class QStringList;
@@ -65,6 +66,8 @@ public:
     /** Returns @c true if we are supposed to attach rather than start a new process. */
     bool isAttach() const;
 
+    bool isConnect() const;
+
     /** Returns @c true if no valid launch arguments or process id are set. */
     bool isValid() const;
 
@@ -83,6 +86,9 @@ public:
     /** Process id for the process to attach to. */
     void setPid(int pid);
     int pid() const;
+
+    void setUrl(const QUrl &url);
+    QUrl url() const;
 
     /** UI mode. */
     UiMode uiMode() const;

--- a/launcher/ui/CMakeLists.txt
+++ b/launcher/ui/CMakeLists.txt
@@ -38,6 +38,8 @@ target_link_libraries(gammaray_launcher_ui_internal
   gammaray_ui
 )
 
+install(TARGETS gammaray_launcher_ui_internal EXPORT GammaRayTargets ${INSTALL_TARGETS_DEFAULT_ARGS})
+
 set(gammaray_launcher_ui_srcs main.cpp)
 # TODO we don't need all the class icons here, so split the qrc file accordingly
 qt4_add_resources(gammaray_launcher_ui_srcs ${CMAKE_SOURCE_DIR}/resources/gammaray.qrc)
@@ -54,6 +56,26 @@ gammaray_embed_info_plist(gammaray-launcher ${CMAKE_CURRENT_SOURCE_DIR}/Info.pli
 set_target_properties(gammaray-launcher PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${LIBEXEC_INSTALL_DIR}"
 )
+
+set(gammaray_launcher_dialog_srcs launcherdialog.cpp)
+add_library(gammaray_launcher_dialog SHARED ${gammaray_launcher_dialog_srcs})
+target_link_libraries(gammaray_launcher_dialog
+  ${QT_QTGUI_LIBRARIES}
+  gammaray_common
+  gammaray_launcher_ui_internal
+)
+
+install(TARGETS gammaray_launcher_dialog EXPORT GammaRayTargets ${INSTALL_TARGETS_DEFAULT_ARGS})
+generate_export_header(gammaray_launcher_dialog)
+
+ecm_generate_pri_file(BASE_NAME GammaRayLauncherDialog
+                    LIB_NAME gammaray_launcher_dialog
+                    DEPS "core gui GammaRayCommon GammaRayLauncher"
+                    FILENAME_VAR PRI_FILENAME
+                    INCLUDE_INSTALL_DIR ${INCLUDE_INSTALL_DIR})
+
+install(FILES ${PRI_FILENAME} DESTINATION ${ECM_MKSPECS_INSTALL_DIR})
+
 
 install(TARGETS gammaray-launcher DESTINATION ${LIBEXEC_INSTALL_DIR})
 

--- a/launcher/ui/attachdialog.cpp
+++ b/launcher/ui/attachdialog.cpp
@@ -141,6 +141,11 @@ int AttachDialog::pid() const
     return ui.view->currentIndex().data(ProcessModel::PIDRole).toInt();
 }
 
+QString AttachDialog::name() const
+{
+    return ui.view->currentIndex().data(ProcessModel::NameRole).toString();
+}
+
 void AttachDialog::updateProcesses()
 {
     QFutureWatcher<ProcDataList> *watcher = new QFutureWatcher<ProcDataList>(this);

--- a/launcher/ui/attachdialog.h
+++ b/launcher/ui/attachdialog.h
@@ -49,6 +49,7 @@ public:
 
     LaunchOptions launchOptions() const;
     int pid() const;
+    QString name() const;
 
     /// Returns @c true if a valid process is selected.
     bool isValid() const;

--- a/launcher/ui/connectpage.cpp
+++ b/launcher/ui/connectpage.cpp
@@ -68,13 +68,18 @@ bool ConnectPage::isValid() const
     return !ui->host->text().isEmpty();
 }
 
-void ConnectPage::launchClient()
+QUrl ConnectPage::url() const
 {
     QUrl url;
     url.setScheme(QStringLiteral("tcp"));
     url.setHost(ui->host->text());
     url.setPort(ui->port->value());
-    ClientLauncher::launchDetached(url);
+    return url;
+}
+
+void ConnectPage::launchClient()
+{
+    ClientLauncher::launchDetached(url());
 }
 
 void ConnectPage::writeSettings()

--- a/launcher/ui/connectpage.h
+++ b/launcher/ui/connectpage.h
@@ -46,6 +46,7 @@ public:
 
     bool isValid() const;
     void writeSettings();
+    QUrl url() const;
 
 public slots:
     void launchClient();

--- a/launcher/ui/launcherwindow.cpp
+++ b/launcher/ui/launcherwindow.cpp
@@ -38,9 +38,10 @@
 
 using namespace GammaRay;
 
-LauncherWindow::LauncherWindow(QWidget *parent)
+LauncherWindow::LauncherWindow(bool launchClient, QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::LauncherWindow)
+    , m_launchClient(launchClient)
 {
     ui->setupUi(this);
     ui->aboutLabel->setText(AboutData::aboutText());
@@ -101,7 +102,7 @@ void LauncherWindow::accept()
     ui->attachPage->writeSettings();
     ui->connectPage->writeSettings();
 
-    if (ui->tabWidget->currentWidget() == ui->connectPage)
+    if (ui->tabWidget->currentWidget() == ui->connectPage && m_launchClient)
         ui->connectPage->launchClient();
 
     QDialog::accept();

--- a/launcher/ui/launcherwindow.h
+++ b/launcher/ui/launcherwindow.h
@@ -41,7 +41,7 @@ class LauncherWindow : public QDialog
 {
     Q_OBJECT
 public:
-    explicit LauncherWindow(QWidget *parent = nullptr);
+    explicit LauncherWindow(bool launchClient = true, QWidget *parent = nullptr);
     ~LauncherWindow();
 
     /// returns all information required to perform the launch/attach
@@ -55,6 +55,9 @@ private slots:
 
 private:
     Ui::LauncherWindow *ui;
+    bool m_launchClient;
+
+    friend class LauncherDialog;
 };
 }
 


### PR DESCRIPTION
This is to be used in the qtcreator plugin instead of the custom dialog.