### PR TITLE
Remove qtypetraits.h's contents altogether

### DIFF
--- a/3rdparty/qt/modeltest.cpp
+++ b/3rdparty/qt/modeltest.cpp
@@ -1,31 +1,26 @@
 /****************************************************************************
 **
-** Copyright (C) 2015 The Qt Company Ltd.
-** Contact: http://www.qt.io/licensing/
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
 **
 ** This file is part of the test suite of the Qt Toolkit.
 **
-** $QT_BEGIN_LICENSE:LGPL21$
+** $QT_BEGIN_LICENSE:GPL-EXCEPT$
 ** Commercial License Usage
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
 ** a written agreement between you and The Qt Company. For licensing terms
-** and conditions see http://www.qt.io/terms-conditions. For further
-** information use the contact form at http://www.qt.io/contact-us.
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
 **
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 or version 3 as published by the Free
-** Software Foundation and appearing in the file LICENSE.LGPLv21 and
-** LICENSE.LGPLv3 included in the packaging of this file. Please review the
-** following information to ensure the GNU Lesser General Public License
-** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
-** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** As a special exception, The Qt Company gives you certain additional
-** rights. These rights are described in The Qt Company LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
+** GNU General Public License Usage
+** Alternatively, this file may be used under the terms of the GNU
+** General Public License version 3 as published by the Free Software
+** Foundation with exceptions as appearing in the file LICENSE.GPL3-EXCEPT
+** included in the packaging of this file. Please review the following
+** information to ensure the GNU General Public License requirements will
+** be met: https://www.gnu.org/licenses/gpl-3.0.html.
 **
 ** $QT_END_LICENSE$
 **
@@ -109,10 +104,10 @@ void ModelTest::runAllTests()
 */
 void ModelTest::nonDestructiveBasicTest()
 {
-    QVERIFY( model->buddy ( QModelIndex() ) == QModelIndex() );
+    QVERIFY(!model->buddy(QModelIndex()).isValid());
     model->canFetchMore ( QModelIndex() );
     QVERIFY( model->columnCount ( QModelIndex() ) >= 0 );
-    QVERIFY( model->data ( QModelIndex() ) == QVariant() );
+    QCOMPARE(model->data(QModelIndex()), QVariant());
     fetchingMore = true;
     model->fetchMore ( QModelIndex() );
     fetchingMore = false;
@@ -126,7 +121,7 @@ void ModelTest::nonDestructiveBasicTest()
     QVariant cache;
     model->match ( QModelIndex(), -1, cache );
     model->mimeTypes();
-    QVERIFY( model->parent ( QModelIndex() ) == QModelIndex() );
+    QVERIFY(!model->parent(QModelIndex()).isValid());
     QVERIFY( model->rowCount() >= 0 );
     QVariant variant;
     model->setData ( QModelIndex(), variant, -1 );
@@ -216,9 +211,9 @@ void ModelTest::index()
 {
 //     qDebug() << "i";
     // Make sure that invalid values returns an invalid index
-    QVERIFY( model->index ( -2, -2 ) == QModelIndex() );
-    QVERIFY( model->index ( -2, 0 ) == QModelIndex() );
-    QVERIFY( model->index ( 0, -2 ) == QModelIndex() );
+    QVERIFY(!model->index(-2, -2).isValid());
+    QVERIFY(!model->index(-2, 0).isValid());
+    QVERIFY(!model->index(0, -2).isValid());
 
     int rows = model->rowCount();
     int columns = model->columnCount();
@@ -227,13 +222,13 @@ void ModelTest::index()
         return;
 
     // Catch off by one errors
-    QVERIFY( model->index ( rows, columns ) == QModelIndex() );
-    QVERIFY( model->index ( 0, 0 ).isValid() );
+    QVERIFY(!model->index(rows, columns).isValid());
+    QVERIFY(model->index(0, 0).isValid());
 
     // Make sure that the same index is *always* returned
     QModelIndex a = model->index ( 0, 0 );
     QModelIndex b = model->index ( 0, 0 );
-    QVERIFY( a == b );
+    QCOMPARE(a, b);
 
     // index() is tested more extensively in checkChildren(),
     // but this catches the big mistakes
@@ -247,7 +242,7 @@ void ModelTest::parent()
 //     qDebug() << "p";
     // Make sure the model won't crash and will return an invalid QModelIndex
     // when asked for the parent of an invalid index.
-    QVERIFY( model->parent ( QModelIndex() ) == QModelIndex() );
+    QVERIFY(!model->parent(QModelIndex()).isValid());
 
     if ( model->rowCount() == 0 )
         return;
@@ -260,13 +255,13 @@ void ModelTest::parent()
     // Common error test #1, make sure that a top level index has a parent
     // that is a invalid QModelIndex.
     QModelIndex topIndex = model->index ( 0, 0, QModelIndex() );
-    QVERIFY( model->parent ( topIndex ) == QModelIndex() );
+    QVERIFY(!model->parent(topIndex).isValid());
 
     // Common error test #2, make sure that a second level index has a parent
     // that is the first level index.
     if ( model->rowCount ( topIndex ) > 0 ) {
         QModelIndex childIndex = model->index ( 0, 0, topIndex );
-        QVERIFY( model->parent ( childIndex ) == topIndex );
+        QCOMPARE(model->parent(childIndex), topIndex);
     }
 
     // Common error test #3, the second column should NOT have the same children
@@ -341,28 +336,28 @@ void ModelTest::checkChildren ( const QModelIndex &parent, int currentDepth )
             QVERIFY( model->hasIndex ( r, c, parent ) );
             QModelIndex index = model->index ( r, c, parent );
             // rowCount() and columnCount() said that it existed...
-            QVERIFY( index.isValid() );
+            QVERIFY(index.isValid());
 
             // index() should always return the same index when called twice in a row
             QModelIndex modifiedIndex = model->index ( r, c, parent );
-            QVERIFY( index == modifiedIndex );
+            QCOMPARE(index, modifiedIndex);
 
             // Make sure we get the same index if we request it twice in a row
             QModelIndex a = model->index ( r, c, parent );
             QModelIndex b = model->index ( r, c, parent );
-            QVERIFY( a == b );
+            QCOMPARE(a, b);
 
             {
                 const QModelIndex sibling = model->sibling( r, c, topLeftChild );
-                QVERIFY( index == sibling );
+                QCOMPARE(index, sibling);
             }
             {
                 const QModelIndex sibling = topLeftChild.sibling( r, c );
-                QVERIFY( index == sibling );
+                QCOMPARE(index, sibling);
             }
 
             // Some basic checking on the index that is returned
-            QVERIFY( index.model() == model );
+            QCOMPARE(index.model(), model);
             QCOMPARE( index.row(), r );
             QCOMPARE( index.column(), c );
             // While you can technically return a QVariant usually this is a sign
@@ -392,7 +387,7 @@ void ModelTest::checkChildren ( const QModelIndex &parent, int currentDepth )
 
             // make sure that after testing the children that the index doesn't change.
             QModelIndex newerIndex = model->index ( r, c, parent );
-            QVERIFY( index == newerIndex );
+            QCOMPARE(index, newerIndex);
         }
     }
 }
@@ -443,7 +438,7 @@ void ModelTest::data()
     // Check that the alignment is one we know about
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
-        int alignment = textAlignmentVariant.toInt();
+        Qt::Alignment alignment = textAlignmentVariant.value<Qt::Alignment>();
         QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
     }
 
@@ -495,7 +490,7 @@ void ModelTest::rowsAboutToBeInserted ( const QModelIndex &parent, int start, in
 void ModelTest::rowsInserted ( const QModelIndex & parent, int start, int end )
 {
     Changing c = insert.pop();
-    QVERIFY( c.parent == parent );
+    QCOMPARE(c.parent, parent);
 //    qDebug() << "rowsInserted"  << "start=" << start << "end=" << end << "oldsize=" << c.oldSize
 //    << "parent=" << model->data ( parent ).toString() << "current rowcount of parent=" << model->rowCount ( parent );
 
@@ -505,8 +500,8 @@ void ModelTest::rowsInserted ( const QModelIndex & parent, int start, int end )
 //    }
 //    qDebug();
 
-    QVERIFY( c.oldSize + ( end - start + 1 ) == model->rowCount ( parent ) );
-    QVERIFY( c.last == model->data ( model->index ( start - 1, 0, c.parent ) ) );
+    QCOMPARE(c.oldSize + (end - start + 1), model->rowCount(parent));
+    QCOMPARE(c.last, model->data(model->index(start - 1, 0, c.parent)));
 
     if (c.next != model->data(model->index(end + 1, 0, c.parent))) {
         qDebug() << start << end;
@@ -515,7 +510,7 @@ void ModelTest::rowsInserted ( const QModelIndex & parent, int start, int end )
         qDebug() << c.next << model->data(model->index(end + 1, 0, c.parent));
     }
 
-    QVERIFY( c.next == model->data ( model->index ( end + 1, 0, c.parent ) ) );
+    QCOMPARE(c.next, model->data(model->index(end + 1, 0, c.parent)));
 }
 
 void ModelTest::layoutAboutToBeChanged()
@@ -528,7 +523,7 @@ void ModelTest::layoutChanged()
 {
     for ( int i = 0; i < changing.count(); ++i ) {
         QPersistentModelIndex p = changing[i];
-        QVERIFY( p == model->index ( p.row(), p.column(), p.parent() ) );
+        QCOMPARE(QModelIndex(p), model->index(p.row(), p.column(), p.parent()));
     }
     changing.clear();
 }
@@ -558,10 +553,10 @@ void ModelTest::rowsRemoved ( const QModelIndex & parent, int start, int end )
 {
   qDebug() << "rr" << parent << start << end;
     Changing c = remove.pop();
-    QVERIFY( c.parent == parent );
-    QVERIFY( c.oldSize - ( end - start + 1 ) == model->rowCount ( parent ) );
-    QVERIFY( c.last == model->data ( model->index ( start - 1, 0, c.parent ) ) );
-    QVERIFY( c.next == model->data ( model->index ( start, 0, c.parent ) ) );
+    QCOMPARE(c.parent, parent);
+    QCOMPARE(c.oldSize - (end - start + 1), model->rowCount(parent));
+    QCOMPARE(c.last, model->data(model->index(start - 1, 0, c.parent)));
+    QCOMPARE(c.next, model->data(model->index(start, 0, c.parent)));
 }
 
 void ModelTest::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
@@ -569,7 +564,7 @@ void ModelTest::dataChanged(const QModelIndex &topLeft, const QModelIndex &botto
     QVERIFY(topLeft.isValid());
     QVERIFY(bottomRight.isValid());
     QModelIndex commonParent = bottomRight.parent();
-    QVERIFY(topLeft.parent() == commonParent);
+    QCOMPARE(topLeft.parent(), commonParent);
     QVERIFY(topLeft.row() <= bottomRight.row());
     QVERIFY(topLeft.column() <= bottomRight.column());
     int rowCount = model->rowCount(commonParent);


### PR DESCRIPTION
A recent version of modeltest.cpp is mandatory.

Read the following commit for full details:
https://codereview.qt-project.org/#/c/175770/13//ALL

"So that QFlags can use an (un)signed int matching the
underlying type as identified by the compiler and not by us.

Requires fixing a few warnings about sign conversion due to
QFlags misusages in qtbase that were either plain wrong, or
were relying on the enum being backed by an (un)signed int
when it wasn't."