### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,11 @@ script:
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   - make -j4
-  - make INSTALL_ROOT=appdir install ; cd appdir ; find .
-  - cp ./usr/share/applications/GammaRay.desktop .
-  - cp ./usr/share/icons/hicolor/256x256/apps/GammaRay.png .
-  - cd .. 
-  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/gammaray -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./usr/share/applications/GammaRay.desktop -bundle-non-qt-libs
   # Workaround for https://github.com/probonopd/linuxdeployqt/issues/83
   - ./linuxdeployqt*.AppImage --appimage-extract
   - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-launcher
@@ -31,5 +28,5 @@ script:
   # Apparently the qt_prfxpath in libQt5Core.so
   # is not relative to libQt5Core.so but to the binary that is being executed, is this clever?
   - ( cd ./appdir/usr/lib/gammaray/ ;  ln -s ../../plugins/ . )
-  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/gammaray -appimage 
+  - ./linuxdeployqt*.AppImage ./usr/share/applications/GammaRay.desktop -appimage 
   - curl --upload-file ./GammaRay-*.AppImage https://transfer.sh/GammaRay-git.$(git rev-parse --short HEAD)-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ script:
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   - make -j4
-  - sudo apt-get -y install checkinstall
-  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
-  - mkdir appdir ; cd appdir
-  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - make INSTALL_ROOT=appdir install ; cd appdir ; find .
   - cp ./usr/share/applications/GammaRay.desktop .
   - cp ./usr/share/icons/hicolor/256x256/apps/GammaRay.png .
   - cd .. 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   - make -j4
-  - mkdir appdir ; sudo make DESTIDR=$(readlink -f appdir) install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo make DESTDIR=appdir install ; sudo chown -R $USER appdir ; find appdir/
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  - make -j4
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ./usr/share/applications/GammaRay.desktop .
+  - cp ./usr/share/icons/hicolor/256x256/apps/GammaRay.png .
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/gammaray -bundle-non-qt-libs
+  # Workaround for https://github.com/probonopd/linuxdeployqt/issues/83
+  - ./linuxdeployqt*.AppImage --appimage-extract
+  - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-launcher
+  - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-client
+  # Apparently the qt_prfxpath in libQt5Core.so
+  # is not relative to libQt5Core.so but to the binary that is being executed, is this clever?
+  - ( cd ./appdir/usr/lib/gammaray/ ;  ln -s ../../plugins/ . )
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/gammaray -appimage 
+  - curl --upload-file ./GammaRay-*.AppImage https://transfer.sh/GammaRay-git.$(git rev-parse --short HEAD)-x86_64.AppImage 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   - make -j4
-  - sudo make DESTIDR=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - mkdir appdir ; sudo make DESTIDR=$(readlink -f appdir) install ; sudo chown -R $USER appdir ; find appdir/
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./usr/share/applications/GammaRay.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/GammaRay.desktop -bundle-non-qt-libs
   # Workaround for https://github.com/probonopd/linuxdeployqt/issues/83
   - ./linuxdeployqt*.AppImage --appimage-extract
   - ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-launcher
@@ -28,5 +28,5 @@ script:
   # Apparently the qt_prfxpath in libQt5Core.so
   # is not relative to libQt5Core.so but to the binary that is being executed, is this clever?
   - ( cd ./appdir/usr/lib/gammaray/ ;  ln -s ../../plugins/ . )
-  - ./linuxdeployqt*.AppImage ./usr/share/applications/GammaRay.desktop -appimage 
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/GammaRay.desktop -appimage 
   - curl --upload-file ./GammaRay-*.AppImage https://transfer.sh/GammaRay-git.$(git rev-parse --short HEAD)-x86_64.AppImage 


### PR DESCRIPTION
This PR, when merged, will build GammaRay on [Travis CI](https://travis-ci.org/) each git push, and upload an [AppImage](http://appimage.org/) to travis.ci (the download URL is toward the end of the Travis CI build log).

For this to work, please merge this and follow https://travis-ci.org/getting_started

Providing a continuous [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for testers/users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign AppImages (inside the file)

A growing number of Qt based applications are already being made available in AppImage format for testing by their respective authors, including Kdevelop, MuseScore, Krita, Subsurface, digiKam, and others.