### PR TITLE
Don't create new TransformNodes triggered by Gammaray

### DIFF
--- a/plugins/quickinspector/quickscenegraphmodel.cpp
+++ b/plugins/quickinspector/quickscenegraphmodel.cpp
@@ -305,7 +305,11 @@ void QuickSceneGraphModel::collectItemNodes(QQuickItem *item)
     if (!item)
         return;
 
-    QSGNode *itemNode = QQuickItemPrivate::get(item)->itemNode();
+    QQuickItemPrivate *priv = QQuickItemPrivate::get(item);
+    if (!priv->itemNodeInstance) // Explicitly avoid calling priv->itemNode() here, which would create a new node outside the scenegraph's behavior.
+        return;
+
+    QSGNode *itemNode = priv->itemNodeInstance;
     m_itemItemNodeMap[item] = itemNode;
     m_itemNodeItemMap[itemNode] = item;
 


### PR DESCRIPTION
This fixes a SEGFAULT where in some cases an invalid Transform Node was
implicitly created through QQuickItemPrivate::itemNode.
In the case that no ItemNodeInstance is created, we just skip this item.

Since this is only relevant in individual frames, it does not exclude
the formerly skipped items, as they are re-added in a frame where they
are actually initialized by the scenegraph.