### PR TITLE
Add generic Boot2Qt/Qt Automotive Suite Toolchain file

### DIFF
--- a/cmake/Toolchain-Yocto.cmake
+++ b/cmake/Toolchain-Yocto.cmake
@@ -1,0 +1,43 @@
+# Basic cmake toolchain file for Qt for Yocto Environment
+# Assumptions: toolchain script is sourced
+#
+
+# Copyright (c) 2013-2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# All rights reserved.
+#
+# Author: Christoph Sterz <christoph.sterz@kdab.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(CMAKE_SYSTEM_NAME "Linux")
+
+string(REGEX MATCH "\-march=(.*) -" PROCESSOR_ARCH "$ENV{CC}")
+set(CMAKE_SYSTEM_PROCESSOR ${PROCESSOR_ARCH})
+
+set(OE_QMAKE_PATH_EXTERNAL_HOST_BINS "$ENV{OECORE_NATIVE_SYSROOT}/usr/bin")
+set(CMAKE_FIND_ROOT_PATH "$ENV{SDKTARGETSYSROOT}")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Use this toolchain file when a B2Qt./AS. environment setup file is present.
This is the case when obtaining image and sysroot from tqtc's online installer.

Reduces the required cmake call when crosscompiling to:
cmake -DCMAKE_TOOLCHAIN_FILE=<path/to/src>/cmake/Toolchain-Boot2Qt.cmake -DCMAKE_INSTALL_PREFIX= < install > <path/to/src>