### PR TITLE
Frame transmission performance

### DIFF
--- a/common/endpoint.h
+++ b/common/endpoint.h
@@ -35,6 +35,14 @@
 #include <QMetaMethod>
 #include <QObject>
 #include <QPointer>
+#include <QTimer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QLoggingCategory>
+Q_DECLARE_LOGGING_CATEGORY(networkstatistics)
+#else
+#include <QDebug>
+#endif
 
 QT_BEGIN_NAMESPACE
 class QIODevice;
@@ -210,6 +218,7 @@ protected:
 
 private slots:
     void readyRead();
+    void logTransmissionRate();
     void connectionClosed();
     void handlerDestroyed(QObject *obj);
     void objectDestroyed(QObject *obj);
@@ -246,6 +255,8 @@ private:
 
     QPointer<QIODevice> m_socket;
     Protocol::ObjectAddress m_myAddress;
+    int m_bytesTransferred;
+    QTimer *m_bandwidthMeasurementTimer;
 
     QString m_label;
     QString m_key;

--- a/common/protocol.cpp
+++ b/common/protocol.cpp
@@ -55,7 +55,7 @@ QModelIndex toQModelIndex(const QAbstractItemModel *model, const Protocol::Model
 
 qint32 version()
 {
-    return 31;
+    return 32;
 }
 
 qint32 broadcastFormatVersion()

--- a/common/remoteviewframe.cpp
+++ b/common/remoteviewframe.cpp
@@ -77,9 +77,20 @@ QImage RemoteViewFrame::image() const
     return m_image.image();
 }
 
+QTransform RemoteViewFrame::transform() const
+{
+    return m_image.transform();
+}
+
 void RemoteViewFrame::setImage(const QImage &image)
 {
     m_image.setImage(image);
+}
+
+void RemoteViewFrame::setImage(const QImage &image, const QTransform transform)
+{
+    m_image.setImage(image);
+    m_image.setTransform(transform);
 }
 
 QVariant RemoteViewFrame::data() const

--- a/common/remoteviewframe.h
+++ b/common/remoteviewframe.h
@@ -60,7 +60,9 @@ public:
     void setSceneRect(const QRectF &sceneRect);
 
     QImage image() const;
+    QTransform transform() const;
     void setImage(const QImage &image);
+    void setImage(const QImage &image, const QTransform transform);
 
     /// tool specific frame data
     QVariant data() const;

--- a/common/transferimage.h
+++ b/common/transferimage.h
@@ -44,6 +44,9 @@ public:
     const QImage &image() const;
     void setImage(const QImage &image);
 
+    QTransform transform() const;
+    void setTransform(const QTransform &transform);
+
     enum Format {
         QImageFormat,
         RawFormat
@@ -51,6 +54,7 @@ public:
 
 private:
     QImage m_image;
+    QTransform m_transform;
 };
 
 QDataStream &operator<<(QDataStream &stream, const GammaRay::TransferImage &image);

--- a/core/remoteviewserver.cpp
+++ b/core/remoteviewserver.cpp
@@ -53,7 +53,7 @@ RemoteViewServer::RemoteViewServer(const QString &name, QObject *parent)
                                                     name), this, "clientConnectedChanged");
 
     m_updateTimer->setSingleShot(true);
-    m_updateTimer->setInterval(100);
+    m_updateTimer->setInterval(10);
     connect(m_updateTimer, SIGNAL(timeout()), this, SLOT(requestUpdateTimeout()));
 }
 

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -15,8 +15,26 @@ if(Qt5Quick_FOUND AND HAVE_PRIVATE_Qt5Quick_HEADERS AND NOT ${Qt5Quick_VERSION} 
 
   include_directories(SYSTEM ${Qt5Quick_PRIVATE_INCLUDE_DIRS})
 
+  # Find if glReadPixels can be used with this configuration
+  # If yes, find based on which platform GL/GLESv2
+  if (TARGET Qt5::Gui_GLESv2)
+      set(HAVE_GLESv2 TRUE)
+      add_definitions(-DENABLE_GL_READPIXELS)
+  endif()
+
+  find_package(OpenGL)
+  if (OpenGL_FOUND)
+      add_definitions(-DENABLE_GL_READPIXELS)
+  endif()
+
   add_library(gammaray_quickinspector_shared STATIC ${gammaray_quickinspector_shared_srcs})
   target_link_libraries(gammaray_quickinspector_shared gammaray_common Qt5::Gui Qt5::Quick)
+
+  # on embedded devices link against GLESv2 for glReadpixels
+  if (HAVE_GLESv2)
+    target_link_libraries(gammaray_quickinspector_shared Qt5::Gui_GLESv2)
+  endif()
+
   set_target_properties(gammaray_quickinspector_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
   set(gammaray_quickinspector_srcs

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -422,10 +422,10 @@ void QuickInspector::recreateOverlay()
     connect(m_overlay.data(), &QObject::destroyed, this, &QuickInspector::recreateOverlay);
 }
 
-void QuickInspector::sendRenderedScene(const QImage &currentFrame)
+void QuickInspector::sendRenderedScene(const QImage &currentFrame, const QTransform transform)
 {
     RemoteViewFrame frame;
-    frame.setImage(currentFrame);
+    frame.setImage(currentFrame, transform);
     QuickItemGeometry itemGeometry;
     if (m_currentItem)
         itemGeometry.initFrom(m_currentItem);

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -93,7 +93,7 @@ public slots:
     void requestElementsAt(const QPoint &pos, GammaRay::RemoteViewInterface::RequestMode mode);
     void pickElementId(const GammaRay::ObjectId& id);
 
-    void sendRenderedScene(const QImage &currentFrame);
+    void sendRenderedScene(const QImage &currentFrame, const QTransform flipped);
 
 protected:
     bool eventFilter(QObject *receiver, QEvent *event) override;

--- a/plugins/quickinspector/quickoverlay.h
+++ b/plugins/quickinspector/quickoverlay.h
@@ -178,7 +178,7 @@ public slots:
 
 signals:
     void sceneChanged();
-    void sceneGrabbed(const QImage &image);
+    void sceneGrabbed(const QImage &image, const QTransform transform);
 
 private:
     struct DrawTextInfo {
@@ -221,6 +221,8 @@ private:
     void disconnectItemChanges(QQuickItem *item);
     void connectTopItemChanges(QQuickItem *item);
     void disconnectTopItemChanges(QQuickItem *item);
+    qreal getDpr();
+    uint textureSize();
 
     QPointer<QQuickWindow> m_window;
     QPointer<QQuickItem> m_currentToplevelItem;
@@ -229,6 +231,7 @@ private:
     QuickOverlaySettings m_settings;
     bool m_isGrabbingMode;
     bool m_drawDecorations;
+    QImage m_frame;
 };
 }
 

--- a/ui/remoteviewwidget.cpp
+++ b/ui/remoteviewwidget.cpp
@@ -484,7 +484,12 @@ void RemoteViewWidget::paintEvent(QPaintEvent *event)
                         // but need to be able to see single pixels when zoomed in.
         p.setRenderHint(QPainter::SmoothPixmapTransform);
     }
+
+    p.save();
+    p.setTransform(m_frame.transform(), true);
     p.drawImage(QRect(QPoint(0, 0), m_frame.viewRect().size().toSize() * m_zoom), m_frame.image());
+    p.restore();
+
     drawDecoration(&p);
     p.restore();
 

--- a/ui/remoteviewwidget.h
+++ b/ui/remoteviewwidget.h
@@ -35,9 +35,10 @@
 #include <common/objectid.h>
 #include <common/remoteviewframe.h>
 
-#include <QWidget>
-#include <QTouchEvent>
+#include <QElapsedTimer>
 #include <QPointer>
+#include <QTouchEvent>
+#include <QWidget>
 
 QT_BEGIN_NAMESPACE
 class QAbstractItemModel;
@@ -168,6 +169,7 @@ private:
     void updateActions();
 
     void drawRuler(QPainter *p);
+    void drawFPS(QPainter *p);
     int sourceTickLabelDistance(int viewDistance);
     int viewTickLabelDistance() const;
     void drawMeasureOverlay(QPainter *p);
@@ -188,11 +190,14 @@ private:
     int horizontalRulerHeight() const;
     int verticalRulerWidth() const;
 
+
+
 private slots:
     void interactionActionTriggered(QAction *action);
     void pickElementId(const QModelIndex &index);
     void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
     void frameUpdated(const GammaRay::RemoteViewFrame &frame);
+    void enableFPS(const bool showFPS);
 
 private:
     RemoteViewFrame m_frame;
@@ -204,6 +209,7 @@ private:
     QActionGroup *m_interactionModeActions;
     QAction *m_zoomInAction;
     QAction *m_zoomOutAction;
+    QAction *m_toggleFPSAction;
     QPointer<RemoteViewInterface> m_interface;
     double m_zoom;
     int m_x; // view translation before zoom
@@ -220,6 +226,9 @@ private:
     bool m_initialZoomDone;
     int m_flagRole;
     int m_invisibleMask;
+    QElapsedTimer m_fpsTimer;
+    bool m_showFps;
+    qreal m_fps;
 };
 }
 


### PR DESCRIPTION
This branch is the sum of a bit of work I invested in improving the frame transmission from weak embedded targets.

It features:
* LZ4-Compression by default, but still possible to disable on boards with a really weak CPU
* Categorized, enable-able Network traffic logging.
* A bugfix removing an artificial gap between frames
* A new method of reading frames (glReadPixels) 
  Which allows flipping GPU-read-images on the more powerful host instead of the weak target
* A supersecret (CTRL-Shift-RightClick) option in Quickinspector Contextmenu to output and visualize achieved  FPS rates

Many Thanks to Volker for that awesome debugging session :)