### PR TITLE
Add new selector to ProbeInterface

### DIFF
--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -990,6 +990,24 @@ void Probe::selectObject(QObject *object, const QString &toolId, const QPoint &p
     emit objectSelected(object, pos);
 }
 
+void Probe::selectObjectProperty(QObject *object, const QByteArray &property)
+{
+    const auto tools = m_toolManager->toolsForObject(object);
+    m_toolManager->selectTool(tools.value(0));
+    emit objectPropertySelected(object, property);
+}
+
+void Probe::selectObjectProperty(QObject *object, const QByteArray &property, const QString &toolId)
+{
+    if (!m_toolManager->hasTool(toolId)) {
+        std::cerr << "Invalid tool id: " << qPrintable(toolId) << std::endl;
+        return;
+    }
+
+    m_toolManager->selectTool(toolId);
+    emit objectPropertySelected(object, property);
+}
+
 void Probe::selectObject(void *object, const QString &typeName)
 {
     const auto tools = m_toolManager->toolsForObject(object, typeName);

--- a/core/probe.h
+++ b/core/probe.h
@@ -112,6 +112,8 @@ public:
     void selectObject(QObject *object, const QPoint &pos = QPoint()) override;
     void selectObject(QObject *object, const QString &toolId,
                       const QPoint &pos = QPoint()) override;
+    void selectObjectProperty(QObject *object, const QByteArray &property) override;
+    void selectObjectProperty(QObject *object, const QByteArray &property, const QString &toolId) override;
     void selectObject(void *object, const QString &typeName) override;
     void registerSignalSpyCallbackSet(const SignalSpyCallbackSet &callbacks) override;
 
@@ -148,6 +150,7 @@ signals:
      * Emitted when the user selected @p object at position @p pos in the probed application.
      */
     void objectSelected(QObject *object, const QPoint &pos);
+    void objectPropertySelected(QObject *object, const QByteArray &property);
     void nonQObjectSelected(void *object, const QString &typeName);
 
     /**

--- a/core/probeinterface.h
+++ b/core/probeinterface.h
@@ -143,6 +143,14 @@ public:
                               const QPoint &pos = QPoint()) = 0;
 
     /**
+     * Notify the probe about the user selecting one of "your" objects property via in-app interaction.
+     *
+     * @since 3.0
+     */
+    virtual void selectObjectProperty(QObject *object, const QByteArray &property) = 0;
+    virtual void selectObjectProperty(QObject *object, const QByteArray &property, const QString &toolId) = 0;
+
+    /**
      * Notify the probe about the user selecting one of "your" objects.
      *
      * @since 2.1

--- a/plugins/qtivi/qtivipropertymodel.cpp
+++ b/plugins/qtivi/qtivipropertymodel.cpp
@@ -101,6 +101,7 @@ QtIviPropertyModel::QtIviPropertyModel(Probe *probe)
     connect(probe, SIGNAL(objectDestroyed(QObject*)), this, SLOT(objectRemoved(QObject*)));
     connect(probe, SIGNAL(objectReparented(QObject*)), this, SLOT(objectReparented(QObject*)));
     connect(probe, SIGNAL(objectSelected(QObject*,QPoint)), this, SLOT(objectSelected(QObject*)));
+    connect(probe, SIGNAL(objectPropertySelected(QObject*,QByteArray)), this, SLOT(objectPropertySelected(QObject*,QByteArray)));
 }
 
 QtIviPropertyModel::IviCarrierProperty::IviCarrierProperty()
@@ -556,6 +557,18 @@ void QtIviPropertyModel::objectSelected(QObject *obj)
 
     QItemSelectionModel *const selectionModel = ObjectBroker::selectionModel(this);
     selectionModel->select(index, QItemSelectionModel::ClearAndSelect |
+                           QItemSelectionModel::Rows | QItemSelectionModel::Current);
+}
+
+void QtIviPropertyModel::objectPropertySelected(QObject *obj, const QByteArray &property)
+{
+    const QModelIndex index = indexOfProperty(obj, property);
+    if (!index.isValid())
+        return;
+
+    QItemSelectionModel *const selectionModel = ObjectBroker::selectionModel(this);
+    selectionModel->select(index,
+                           QItemSelectionModel::Select | QItemSelectionModel::Clear |
                            QItemSelectionModel::Rows | QItemSelectionModel::Current);
 }
 

--- a/plugins/qtivi/qtivipropertymodel.h
+++ b/plugins/qtivi/qtivipropertymodel.h
@@ -92,6 +92,7 @@ private slots:
     void objectRemoved(QObject *obj);
     void objectReparented(QObject *obj);
     void objectSelected(QObject *obj);
+    void objectPropertySelected(QObject *obj, const QByteArray &property);
     void propertyChanged();
 
 private:


### PR DESCRIPTION
Add new selector to ProbeInterface

This allow to select an object property.
Could be used by example to trigger a property selection in the Ivi Inspector.