### PR TITLE
Move Top Bar of QuickInspector out of the PreviewWidget

### DIFF
--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -73,6 +73,7 @@ if(Qt5Quick_FOUND AND HAVE_PRIVATE_Qt5Quick_HEADERS AND NOT ${Qt5Quick_VERSION} 
       quickitemdelegate.cpp
       quickitemtreewatcher.cpp
       quickscenepreviewwidget.cpp
+      quickscenecontrolwidget.cpp
       quickoverlaylegend.cpp
       gridsettingswidget.cpp
 

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -116,15 +116,15 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
 
     new QuickItemTreeWatcher(ui->itemTreeView, ui->sgTreeView, this);
 
-    m_previewWidget = new QuickScenePreviewWidget(m_interface, this);
-    m_previewWidget->setPickSourceModel(proxy);
-    m_previewWidget->setFlagRole(QuickItemModelRole::ItemFlags);
-    m_previewWidget->setInvisibleMask(QuickItemModelRole::Invisible | QuickItemModelRole::ZeroSize);
+    m_scenePreviewWidget = new QuickSceneControlWidget(m_interface, this);
+    m_scenePreviewWidget->previewWidget()->setPickSourceModel(proxy);
+    m_scenePreviewWidget->previewWidget()->setFlagRole(QuickItemModelRole::ItemFlags);
+    m_scenePreviewWidget->previewWidget()->setInvisibleMask(QuickItemModelRole::Invisible | QuickItemModelRole::ZeroSize);
 
     ui->itemPropertyWidget->setObjectBaseName(QStringLiteral("com.kdab.GammaRay.QuickItem"));
     ui->sgPropertyWidget->setObjectBaseName(QStringLiteral("com.kdab.GammaRay.QuickSceneGraph"));
 
-    ui->previewTreeSplitter->addWidget(m_previewWidget);
+    ui->previewTreeSplitter->addWidget(m_scenePreviewWidget);
 
     connect(m_interface, SIGNAL(features(GammaRay::QuickInspectorInterface::Features)),
             this, SLOT(setFeatures(GammaRay::QuickInspectorInterface::Features)));
@@ -144,7 +144,7 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
 
     connect(ui->itemPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(resetState()));
     connect(ui->sgPropertyWidget, SIGNAL(tabsUpdated()), this, SLOT(resetState()));
-    connect(m_previewWidget, SIGNAL(stateChanged()), this, SLOT(saveState()));
+    connect(m_scenePreviewWidget, SIGNAL(stateChanged()), this, SLOT(saveState()));
 }
 
 QuickInspectorWidget::~QuickInspectorWidget()
@@ -154,28 +154,28 @@ QuickInspectorWidget::~QuickInspectorWidget()
 void QuickInspectorWidget::saveTargetState(QSettings *settings) const
 {
     settings->setValue("tabIndex", ui->tabWidget->currentIndex());
-    settings->setValue("remoteViewState", m_previewWidget->saveState());
+    settings->setValue("remoteViewState", m_scenePreviewWidget->previewWidget()->saveState());
 }
 
 void QuickInspectorWidget::restoreTargetState(QSettings *settings)
 {
     ui->tabWidget->setCurrentIndex(settings->value("tabIndex", 0).toInt());
-    m_previewWidget->restoreState(settings->value("remoteViewState").toByteArray());
+    m_scenePreviewWidget->previewWidget()->restoreState(settings->value("remoteViewState").toByteArray());
 }
 
 void QuickInspectorWidget::setFeatures(QuickInspectorInterface::Features features)
 {
-    m_previewWidget->setSupportsCustomRenderModes(features);
+    m_scenePreviewWidget->setSupportsCustomRenderModes(features);
 }
 
 void QuickInspectorWidget::setServerSideDecorations(bool enabled)
 {
-    m_previewWidget->setServerSideDecorationsState(enabled);
+    m_scenePreviewWidget->setServerSideDecorationsState(enabled);
 }
 
 void QuickInspectorWidget::setOverlaySettings(const GammaRay::QuickDecorationsSettings &settings)
 {
-    m_previewWidget->setOverlaySettingsState(settings);
+    m_scenePreviewWidget->setOverlaySettingsState(settings);
 }
 
 void QuickInspectorWidget::itemSelectionChanged(const QItemSelection &selection)

--- a/plugins/quickinspector/quickinspectorwidget.h
+++ b/plugins/quickinspector/quickinspectorwidget.h
@@ -45,7 +45,7 @@ class QItemSelection;
 QT_END_NAMESPACE
 
 namespace GammaRay {
-class QuickScenePreviewWidget;
+class QuickSceneControlWidget;
 struct QuickDecorationsSettings;
 
 namespace Ui {
@@ -76,7 +76,7 @@ private slots:
 private:
     QScopedPointer<Ui::QuickInspectorWidget> ui;
     UIStateManager m_stateManager;
-    QuickScenePreviewWidget *m_previewWidget;
+    QuickSceneControlWidget *m_scenePreviewWidget;
     QuickInspectorInterface *m_interface;
 };
 

--- a/plugins/quickinspector/quickscenecontrolwidget.cpp
+++ b/plugins/quickinspector/quickscenecontrolwidget.cpp
@@ -1,0 +1,315 @@
+/*
+  quickscenepreviewwidget.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2014-2017 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Christoph Sterz <christoph.sterz@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "quickscenecontrolwidget.h"
+
+#include "quickoverlaylegend.h"
+#include "quickscenepreviewwidget.h"
+#include "gridsettingswidget.h"
+
+#include <QAction>
+#include <QComboBox>
+#include <QLabel>
+#include <QMenu>
+#include <QToolBar>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <QWidgetAction>
+
+using namespace GammaRay;
+
+QuickSceneControlWidget::QuickSceneControlWidget(QuickInspectorInterface *inspector, QWidget *parent)
+    : QWidget(parent)
+    , m_gridSettingsWidget(new GridSettingsWidget(this))
+    , m_legendTool(new QuickOverlayLegend(this))
+    , m_inspectorInterface(inspector)
+{
+    m_layout = new QVBoxLayout();
+    setLayout(m_layout);
+
+    m_previewWidget = new QuickScenePreviewWidget(m_inspectorInterface, this, this);
+
+    m_toolBar = new QToolBar(this);
+    m_toolBar->setAutoFillBackground(true);
+
+    m_visualizeGroup = new QActionGroup(this);
+    m_visualizeGroup->setExclusive(false); // we need 0 or 1 selected, not exactly 1
+
+    m_visualizeClipping = new QAction(QIcon(QStringLiteral(":/gammaray/plugins/quickinspector/visualize-clipping.png")),
+                                      tr("Visualize Clipping"),
+                                      this);
+    m_visualizeClipping->setActionGroup(m_visualizeGroup);
+    m_visualizeClipping->setData(QuickInspectorInterface::VisualizeClipping);
+    m_visualizeClipping->setCheckable(true);
+    m_visualizeClipping->setToolTip(tr("<b>Visualize Clipping</b><br/>"
+                                       "Items with the property <i>clip</i> set to true, will cut off their and their "
+                                       "children's rendering at the items' bounds. While this is a handy feature it "
+                                       "comes with quite some cost, like disabling some performance optimizations.<br/>"
+                                       "With this tool enabled the QtQuick renderer highlights items, that have clipping "
+                                       "enabled, so you can check for items, that have clipping enabled unnecessarily. "));
+
+    m_visualizeOverdraw
+            = new QAction(QIcon(QStringLiteral(
+                                    ":/gammaray/plugins/quickinspector/visualize-overdraw.png")),
+                          tr("Visualize Overdraw"),
+                          this);
+    m_visualizeOverdraw->setActionGroup(m_visualizeGroup);
+    m_visualizeOverdraw->setData(QuickInspectorInterface::VisualizeOverdraw);
+    m_visualizeOverdraw->setCheckable(true);
+    m_visualizeOverdraw->setToolTip(tr("<b>Visualize Overdraw</b><br/>"
+                                       "The QtQuick renderer doesn't detect if an item is obscured by another "
+                                       "opaque item, is completely outside the scene or outside a clipped ancestor and "
+                                       "thus doesn't need to be rendered. You thus need to take care of setting "
+                                       "<i>visible: false</i> for hidden items, yourself.<br/>"
+                                       "With this tool enabled the QtQuick renderer draws a 3D-Box visualizing the "
+                                       "layers of items that are drawn."));
+
+    m_visualizeBatches = new QAction(QIcon(QStringLiteral(
+                                               ":/gammaray/plugins/quickinspector/visualize-batches.png")),
+                                     tr("Visualize Batches"), this);
+    m_visualizeBatches->setActionGroup(m_visualizeGroup);
+    m_visualizeBatches->setData(QuickInspectorInterface::VisualizeBatches);
+    m_visualizeBatches->setCheckable(true);
+    m_visualizeBatches->setToolTip(tr("<b>Visualize Batches</b><br/>"
+                                      "Where a traditional 2D API, such as QPainter, Cairo or Context2D, is written to "
+                                      "handle thousands of individual draw calls per frame, OpenGL is a pure hardware "
+                                      "API and performs best when the number of draw calls is very low and state "
+                                      "changes are kept to a minimum. Therefore the QtQuick renderer combines the "
+                                      "rendering of similar items into single batches.<br/>"
+                                      "Some settings (like <i>clip: true</i>) will cause the batching to fail, though, "
+                                      "causing items to be rendered separately. With this tool enabled the QtQuick "
+                                      "renderer visualizes those batches, by drawing all items that are batched using "
+                                      "the same color. The fewer colors you see in this mode the better."));
+
+    m_visualizeChanges = new QAction(QIcon(QStringLiteral(
+                                               ":/gammaray/plugins/quickinspector/visualize-changes.png")),
+                                     tr("Visualize Changes"), this);
+    m_visualizeChanges->setActionGroup(m_visualizeGroup);
+    m_visualizeChanges->setData(QuickInspectorInterface::VisualizeChanges);
+    m_visualizeChanges->setCheckable(true);
+    m_visualizeChanges->setToolTip(tr("<b>Visualize Changes</b><br>"
+                                      "The QtQuick scene is only repainted, if some item changes in a visual manner. "
+                                      "Unnecessary repaints can have a bad impact on the performance. With this tool "
+                                      "enabled, the QtQuick renderer will thus on each repaint highlight the item(s), "
+                                      "that caused the repaint."));
+
+    m_visualizeTraces
+            = new QAction(QIcon(QStringLiteral(
+                                    ":/gammaray/plugins/quickinspector/visualize-traces.png")),
+                          tr("Visualize Traces"), this);
+    m_visualizeTraces->setActionGroup(m_visualizeGroup);
+    m_visualizeTraces->setData(QuickInspectorInterface::VisualizeTraces);
+    m_visualizeTraces->setCheckable(true);
+    m_visualizeTraces->setToolTip(tr("<b>Visualize Traces</b><br>"
+                                     "The QtQuick scene is rendered normaly, in addition overlay rects will "
+                                     "cover any QQ2 components. Overlay include random border and foreground "
+                                     "colors as well as item id string."));
+
+    m_serverSideDecorationsEnabled = new QAction(QIcon(QStringLiteral(
+                                                           ":/gammaray/plugins/quickinspector/decorations.png")),
+                                                 tr("Target Decorations"), this);
+    m_serverSideDecorationsEnabled->setCheckable(true);
+    m_serverSideDecorationsEnabled->setToolTip(tr("<b>Target Decorations</b><br>"
+                                                  "This enable or not the decorations on the target application."));
+
+    QWidgetAction *gridSettingsAction = new QWidgetAction(this);
+    gridSettingsAction->setDefaultWidget(m_gridSettingsWidget);
+
+    m_gridSettings = new QMenu(tr("Grid Settings"), this);
+    m_gridSettings->setIcon(QIcon(QStringLiteral(
+                                      ":/gammaray/plugins/quickinspector/grid-settings.png")));
+    m_gridSettings->setToolTip(tr("<b>Grid Settings</b><br>"
+                                  "This popup a small widget to configure the grid settings."));
+    m_gridSettings->setToolTipsVisible(true);
+    m_gridSettings->addAction(gridSettingsAction);
+
+    m_toolBar->addActions(m_visualizeGroup->actions());
+    connect(m_visualizeGroup, SIGNAL(triggered(QAction*)), this,
+            SLOT(visualizeActionTriggered(QAction*)));
+
+    m_toolBar->addSeparator();
+
+    foreach (auto action, m_previewWidget->interactionModeActions()->actions()) {
+        m_toolBar->addAction(action);
+    }
+    m_toolBar->addSeparator();
+
+    m_toolBar->addAction(m_serverSideDecorationsEnabled);
+    connect(m_serverSideDecorationsEnabled, SIGNAL(triggered(bool)), this,
+            SLOT(serverSideDecorationsTriggered(bool)));
+    m_toolBar->addSeparator();
+
+    m_toolBar->addAction(m_previewWidget->zoomOutAction());
+    m_zoomCombobox = new QComboBox(this);
+    m_zoomCombobox->setModel(m_previewWidget->zoomLevelModel());
+    connect(m_zoomCombobox, SIGNAL(currentIndexChanged(int)), m_previewWidget,
+            SLOT(setZoomLevel(int)));
+    connect(m_previewWidget, &RemoteViewWidget::zoomLevelChanged, m_zoomCombobox,
+            &QComboBox::setCurrentIndex);
+    m_zoomCombobox->setCurrentIndex(m_previewWidget->zoomLevelIndex());
+
+    m_toolBar->addWidget(m_zoomCombobox);
+    m_toolBar->addAction(m_previewWidget->zoomInAction());
+
+    m_toolBar->addSeparator();
+    m_toolBar->addAction(m_legendTool->visibilityAction());
+    m_toolBar->addAction(m_gridSettings->menuAction());
+
+    QToolButton *b = qobject_cast<QToolButton *>(m_toolBar->widgetForAction(m_gridSettings->menuAction()));
+    b->setPopupMode(QToolButton::InstantPopup);
+
+    connect(m_gridSettingsWidget, SIGNAL(offsetChanged(QPoint)), this, SLOT(gridOffsetChanged(QPoint)));
+    connect(m_gridSettingsWidget, SIGNAL(cellSizeChanged(QSize)), this, SLOT(gridCellSizeChanged(QSize)));
+
+    setMinimumWidth(std::max(minimumWidth(), m_toolBar->sizeHint().width()));
+
+
+    m_layout->addWidget(m_toolBar);
+    m_layout->addWidget(m_previewWidget);
+}
+
+void QuickSceneControlWidget::resizeEvent(QResizeEvent *e)
+{
+    m_toolBar->setGeometry(0, 0, width(), m_toolBar->sizeHint().height());
+    QWidget::resizeEvent(e);
+}
+
+void QuickSceneControlWidget::visualizeActionTriggered(QAction *current)
+{
+    if (!current || !current->isChecked()) {
+        m_inspectorInterface->setCustomRenderMode(QuickInspectorInterface::NormalRendering);
+    } else {
+        // QActionGroup requires exactly one selected, but we need 0 or 1 selected
+        foreach (auto action, m_visualizeGroup->actions()) {
+            if (action != current)
+                action->setChecked(false);
+        }
+
+        m_inspectorInterface->setCustomRenderMode(static_cast<QuickInspectorInterface::RenderMode>(current->data().toInt()));
+    }
+    emit m_previewWidget->stateChanged();
+}
+
+
+void QuickSceneControlWidget::serverSideDecorationsTriggered(bool enabled)
+{
+    m_serverSideDecorationsEnabled->setChecked(enabled);
+    m_inspectorInterface->setServerSideDecorationsEnabled(enabled);
+    emit m_previewWidget->stateChanged();
+}
+
+void QuickSceneControlWidget::gridOffsetChanged(const QPoint &value)
+{
+    m_previewWidget->m_overlaySettings.gridOffset = value;
+    m_legendTool->setOverlaySettings(m_previewWidget->m_overlaySettings);
+    update();
+    setOverlaySettings(m_previewWidget->m_overlaySettings);
+}
+
+void QuickSceneControlWidget::gridCellSizeChanged(const QSize &value)
+{
+    m_previewWidget->m_overlaySettings.gridCellSize = value;
+    m_legendTool->setOverlaySettings(m_previewWidget->m_overlaySettings);
+    update();
+    setOverlaySettings(m_previewWidget->m_overlaySettings);
+}
+
+void QuickSceneControlWidget::setOverlaySettings(const QuickDecorationsSettings &settings)
+{
+    m_inspectorInterface->setOverlaySettings(settings);
+    emit m_previewWidget->stateChanged();
+}
+
+void QuickSceneControlWidget::setSupportsCustomRenderModes(
+        QuickInspectorInterface::Features supportedCustomRenderModes)
+{
+    m_visualizeClipping->setEnabled(
+                supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeClipping);
+    m_visualizeBatches->setEnabled(
+                supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeBatches);
+    m_visualizeOverdraw->setEnabled(
+                supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeOverdraw);
+    m_visualizeChanges->setEnabled(
+                supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeChanges);
+    m_visualizeTraces->setEnabled(
+                supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeTraces);
+}
+
+void QuickSceneControlWidget::setServerSideDecorationsState(bool enabled)
+{
+    m_serverSideDecorationsEnabled->setChecked(enabled);
+}
+
+void QuickSceneControlWidget::setOverlaySettingsState(const QuickDecorationsSettings &settings)
+{
+    m_previewWidget->m_overlaySettings = settings;
+    m_gridSettingsWidget->setOverlaySettings(settings);
+    m_legendTool->setOverlaySettings(settings);
+}
+
+QuickInspectorInterface::RenderMode QuickSceneControlWidget::customRenderMode() const
+{
+    const QAction *checkedAction = m_visualizeGroup->checkedAction();
+
+    if (checkedAction) {
+        return static_cast<QuickInspectorInterface::RenderMode>(checkedAction->data().toInt());
+    }
+
+    return QuickInspectorInterface::NormalRendering;
+}
+
+void QuickSceneControlWidget::setCustomRenderMode(QuickInspectorInterface::RenderMode customRenderMode)
+{
+    if (this->customRenderMode() == customRenderMode)
+        return;
+
+    foreach (auto action, m_visualizeGroup->actions()) {
+        if (action)
+            action->setChecked(static_cast<QuickInspectorInterface::RenderMode>(action->data().toInt()) == customRenderMode);
+    }
+
+    visualizeActionTriggered(m_visualizeGroup->checkedAction());
+}
+
+QuickScenePreviewWidget *QuickSceneControlWidget::previewWidget()
+{
+    return m_previewWidget;
+}
+
+bool QuickSceneControlWidget::serverSideDecorationsEnabled() const
+{
+    return m_serverSideDecorationsEnabled->isChecked();
+}
+
+void QuickSceneControlWidget::setServerSideDecorationsEnabled(bool enabled)
+{
+    if (m_serverSideDecorationsEnabled->isChecked() == enabled)
+        return;
+    m_serverSideDecorationsEnabled->setChecked(enabled);
+    serverSideDecorationsTriggered(enabled);
+}

--- a/plugins/quickinspector/quickscenecontrolwidget.h
+++ b/plugins/quickinspector/quickscenecontrolwidget.h
@@ -1,0 +1,112 @@
+/*
+  quickscenepreviewwidget.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2014-2017 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Christoph Sterz <christoph.sterz@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef QUICKSCENECONTROLWIDGET_H
+#define QUICKSCENECONTROLWIDGET_H
+
+#include <QWidget>
+
+#include "quickinspectorinterface.h"
+#include "quickoverlay.h"
+
+
+QT_BEGIN_NAMESPACE
+class QAction;
+class QActionGroup;
+class QComboBox;
+class QLabel;
+class QMenu;
+class QToolBar;
+class QVBoxLayout;
+QT_END_NAMESPACE
+
+namespace GammaRay {
+class QuickInspectorInterface;
+class GridSettingsWidget;
+class QuickScenePreviewWidget;
+class QuickOverlayLegend;
+
+
+class QuickSceneControlWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit QuickSceneControlWidget(QuickInspectorInterface *inspector, QWidget *parent = nullptr);
+
+    void setOverlaySettings(const QuickDecorationsSettings &settings);
+    void setSupportsCustomRenderModes(QuickInspectorInterface::Features supportedCustomRenderModes);
+    void setServerSideDecorationsState(bool enabled);
+
+    void setOverlaySettingsState(const QuickDecorationsSettings &settings);
+
+    bool serverSideDecorationsEnabled() const;
+    void setServerSideDecorationsEnabled(bool enabled);
+
+    QuickInspectorInterface::RenderMode customRenderMode() const;
+    void setCustomRenderMode(QuickInspectorInterface::RenderMode customRenderMode);
+
+    QuickScenePreviewWidget *previewWidget();
+
+
+signals:
+
+private Q_SLOTS:
+    void visualizeActionTriggered(QAction* current);
+    void serverSideDecorationsTriggered(bool enabled);
+    void gridOffsetChanged(const QPoint &value);
+    void gridCellSizeChanged(const QSize &value);
+
+private:
+
+    void resizeEvent(QResizeEvent *e) override;
+
+    QVBoxLayout *m_layout;
+
+    QToolBar *m_toolBar;
+    QComboBox *m_zoomCombobox;
+    QActionGroup *m_visualizeGroup;
+    QAction *m_visualizeClipping;
+    QAction *m_visualizeOverdraw;
+    QAction *m_visualizeBatches;
+    QAction *m_visualizeChanges;
+    QAction *m_visualizeTraces;
+    QAction *m_serverSideDecorationsEnabled;
+    QMenu *m_gridSettings;
+
+    QuickScenePreviewWidget *m_previewWidget;
+
+    GridSettingsWidget *m_gridSettingsWidget;
+    QuickOverlayLegend *m_legendTool;
+
+    QuickInspectorInterface *m_inspectorInterface;
+
+};
+} // namespace GammaRay
+
+#endif // QUICKSCENECONTROLWIDGET_H

--- a/plugins/quickinspector/quickscenepreviewwidget.cpp
+++ b/plugins/quickinspector/quickscenepreviewwidget.cpp
@@ -28,23 +28,11 @@
 
 #include "quickscenepreviewwidget.h"
 #include "quickinspectorinterface.h"
-#include "quickoverlaylegend.h"
-#include "gridsettingswidget.h"
 
 #include <common/streamoperators.h>
 
-#include <QDebug>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QWidgetAction>
-#include <QAction>
-#include <QMenu>
-#include <QComboBox>
-#include <QLabel>
-#include <QToolBar>
-#include <QToolButton>
-
-#include <cmath>
 
 using namespace GammaRay;
 static qint32 QuickScenePreviewWidgetStateVersion = 2;
@@ -54,156 +42,14 @@ GAMMARAY_ENUM_STREAM_OPERATORS(GammaRay::QuickInspectorInterface::RenderMode)
 QT_END_NAMESPACE
 
 QuickScenePreviewWidget::QuickScenePreviewWidget(QuickInspectorInterface *inspector,
+                                                 QuickSceneControlWidget *control,
                                                  QWidget *parent)
     : RemoteViewWidget(parent)
-    , m_gridSettingsWidget(new GridSettingsWidget(this))
-    , m_legendTool(new QuickOverlayLegend(this))
     , m_inspectorInterface(inspector)
+    , m_control(control)
 {
     setName(QStringLiteral("com.kdab.GammaRay.QuickRemoteView"));
-
-    // Toolbar
-    m_toolBar.toolbarWidget = new QToolBar(this);
-    m_toolBar.toolbarWidget->setAutoFillBackground(true);
-
-    m_toolBar.visualizeGroup = new QActionGroup(this);
-    m_toolBar.visualizeGroup->setExclusive(false); // we need 0 or 1 selected, not exactly 1
-
-    m_toolBar.visualizeClipping
-        = new QAction(QIcon(QStringLiteral(
-                                ":/gammaray/plugins/quickinspector/visualize-clipping.png")),
-                      tr("Visualize Clipping"),
-                      this);
-    m_toolBar.visualizeClipping->setActionGroup(m_toolBar.visualizeGroup);
-    m_toolBar.visualizeClipping->setData(QuickInspectorInterface::VisualizeClipping);
-    m_toolBar.visualizeClipping->setCheckable(true);
-    m_toolBar.visualizeClipping->setToolTip(tr("<b>Visualize Clipping</b><br/>"
-                                               "Items with the property <i>clip</i> set to true, will cut off their and their "
-                                               "children's rendering at the items' bounds. While this is a handy feature it "
-                                               "comes with quite some cost, like disabling some performance optimizations.<br/>"
-                                               "With this tool enabled the QtQuick renderer highlights items, that have clipping "
-                                               "enabled, so you can check for items, that have clipping enabled unnecessarily. "));
-
-    m_toolBar.visualizeOverdraw
-        = new QAction(QIcon(QStringLiteral(
-                                ":/gammaray/plugins/quickinspector/visualize-overdraw.png")),
-                      tr("Visualize Overdraw"),
-                      this);
-    m_toolBar.visualizeOverdraw->setActionGroup(m_toolBar.visualizeGroup);
-    m_toolBar.visualizeOverdraw->setData(QuickInspectorInterface::VisualizeOverdraw);
-    m_toolBar.visualizeOverdraw->setCheckable(true);
-    m_toolBar.visualizeOverdraw->setToolTip(tr("<b>Visualize Overdraw</b><br/>"
-                                               "The QtQuick renderer doesn't detect if an item is obscured by another "
-                                               "opaque item, is completely outside the scene or outside a clipped ancestor and "
-                                               "thus doesn't need to be rendered. You thus need to take care of setting "
-                                               "<i>visible: false</i> for hidden items, yourself.<br/>"
-                                               "With this tool enabled the QtQuick renderer draws a 3D-Box visualizing the "
-                                               "layers of items that are drawn."));
-
-    m_toolBar.visualizeBatches
-        = new QAction(QIcon(QStringLiteral(
-                                ":/gammaray/plugins/quickinspector/visualize-batches.png")),
-                      tr("Visualize Batches"), this);
-    m_toolBar.visualizeBatches->setActionGroup(m_toolBar.visualizeGroup);
-    m_toolBar.visualizeBatches->setData(QuickInspectorInterface::VisualizeBatches);
-    m_toolBar.visualizeBatches->setCheckable(true);
-    m_toolBar.visualizeBatches->setToolTip(tr("<b>Visualize Batches</b><br/>"
-                                              "Where a traditional 2D API, such as QPainter, Cairo or Context2D, is written to "
-                                              "handle thousands of individual draw calls per frame, OpenGL is a pure hardware "
-                                              "API and performs best when the number of draw calls is very low and state "
-                                              "changes are kept to a minimum. Therefore the QtQuick renderer combines the "
-                                              "rendering of similar items into single batches.<br/>"
-                                              "Some settings (like <i>clip: true</i>) will cause the batching to fail, though, "
-                                              "causing items to be rendered separately. With this tool enabled the QtQuick "
-                                              "renderer visualizes those batches, by drawing all items that are batched using "
-                                              "the same color. The fewer colors you see in this mode the better."));
-
-    m_toolBar.visualizeChanges
-        = new QAction(QIcon(QStringLiteral(
-                                ":/gammaray/plugins/quickinspector/visualize-changes.png")),
-                      tr("Visualize Changes"), this);
-    m_toolBar.visualizeChanges->setActionGroup(m_toolBar.visualizeGroup);
-    m_toolBar.visualizeChanges->setData(QuickInspectorInterface::VisualizeChanges);
-    m_toolBar.visualizeChanges->setCheckable(true);
-    m_toolBar.visualizeChanges->setToolTip(tr("<b>Visualize Changes</b><br>"
-                                              "The QtQuick scene is only repainted, if some item changes in a visual manner. "
-                                              "Unnecessary repaints can have a bad impact on the performance. With this tool "
-                                              "enabled, the QtQuick renderer will thus on each repaint highlight the item(s), "
-                                              "that caused the repaint."));
-
-
-    m_toolBar.visualizeTraces
-        = new QAction(QIcon(QStringLiteral(
-                                ":/gammaray/plugins/quickinspector/visualize-traces.png")),
-                      tr("Visualize Traces"), this);
-    m_toolBar.visualizeTraces->setActionGroup(m_toolBar.visualizeGroup);
-    m_toolBar.visualizeTraces->setData(QuickInspectorInterface::VisualizeTraces);
-    m_toolBar.visualizeTraces->setCheckable(true);
-    m_toolBar.visualizeTraces->setToolTip(tr("<b>Visualize Traces</b><br>"
-                                             "The QtQuick scene is rendered normaly, in addition overlay rects will "
-                                             "cover any QQ2 components. Overlay include random border and foreground "
-                                             "colors as well as item id string."));
-
-    m_toolBar.serverSideDecorationsEnabled = new QAction(QIcon(QStringLiteral(
-                                                               ":/gammaray/plugins/quickinspector/decorations.png")),
-                                                     tr("Target Decorations"), this);
-    m_toolBar.serverSideDecorationsEnabled->setCheckable(true);
-    m_toolBar.serverSideDecorationsEnabled->setToolTip(tr("<b>Target Decorations</b><br>"
-                                              "This enable or not the decorations on the target application."));
-
-    QWidgetAction *gridSettingsAction = new QWidgetAction(this);
-    gridSettingsAction->setDefaultWidget(m_gridSettingsWidget);
-
-    m_toolBar.gridSettings = new QMenu(tr("Grid Settings"), this);
-    m_toolBar.gridSettings->setIcon(QIcon(QStringLiteral(
-                                              ":/gammaray/plugins/quickinspector/grid-settings.png")));
-    m_toolBar.gridSettings->setToolTip(tr("<b>Grid Settings</b><br>"
-                                              "This popup a small widget to configure the grid settings."));
-    m_toolBar.gridSettings->setToolTipsVisible(true);
-    m_toolBar.gridSettings->addAction(gridSettingsAction);
-
-    m_toolBar.toolbarWidget->addActions(m_toolBar.visualizeGroup->actions());
-    connect(m_toolBar.visualizeGroup, SIGNAL(triggered(QAction*)), this,
-            SLOT(visualizeActionTriggered(QAction*)));
-
-    m_toolBar.toolbarWidget->addSeparator();
-
-    foreach (auto action, interactionModeActions()->actions()) {
-        m_toolBar.toolbarWidget->addAction(action);
-    }
-    m_toolBar.toolbarWidget->addSeparator();
-
-    m_toolBar.toolbarWidget->addAction(m_toolBar.serverSideDecorationsEnabled);
-    connect(m_toolBar.serverSideDecorationsEnabled, SIGNAL(triggered(bool)), this,
-            SLOT(serverSideDecorationsTriggered(bool)));
-    m_toolBar.toolbarWidget->addSeparator();
-
-    m_toolBar.toolbarWidget->addAction(zoomOutAction());
-    m_toolBar.zoomCombobox = new QComboBox(this);
-    m_toolBar.zoomCombobox->setModel(zoomLevelModel());
-    connect(m_toolBar.zoomCombobox, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(setZoomLevel(int)));
-    connect(this, &RemoteViewWidget::zoomLevelChanged, m_toolBar.zoomCombobox,
-            &QComboBox::setCurrentIndex);
-    m_toolBar.zoomCombobox->setCurrentIndex(zoomLevelIndex());
-
-    m_toolBar.toolbarWidget->addWidget(m_toolBar.zoomCombobox);
-    m_toolBar.toolbarWidget->addAction(zoomInAction());
-
-    m_toolBar.toolbarWidget->addSeparator();
-    m_toolBar.toolbarWidget->addAction(m_legendTool->visibilityAction());
-    m_toolBar.toolbarWidget->addAction(m_toolBar.gridSettings->menuAction());
-
-    QToolButton *b = qobject_cast<QToolButton *>(m_toolBar.toolbarWidget->widgetForAction(m_toolBar.gridSettings->menuAction()));
-    b->setPopupMode(QToolButton::InstantPopup);
-
-    connect(m_gridSettingsWidget, SIGNAL(offsetChanged(QPoint)), this, SLOT(gridOffsetChanged(QPoint)));
-    connect(m_gridSettingsWidget, SIGNAL(cellSizeChanged(QSize)), this, SLOT(gridCellSizeChanged(QSize)));
-
-    setUnavailableText(tr(
-                           "No remote view available.\n(This happens e.g. when the window is minimized or the scene is hidden)"));
-
-    setMinimumWidth(std::max(minimumWidth(), m_toolBar.toolbarWidget->sizeHint().width()));
+    setUnavailableText(tr("No remote view available.\n(This happens e.g. when the window is minimized or the scene is hidden)"));
 }
 
 QuickScenePreviewWidget::~QuickScenePreviewWidget()
@@ -217,8 +63,8 @@ void QuickScenePreviewWidget::restoreState(const QByteArray &state)
 
     QDataStream stream(state);
     qint32 version;
-    QuickInspectorInterface::RenderMode mode = customRenderMode();
-    bool drawDecorations = serverSideDecorationsEnabled();
+    QuickInspectorInterface::RenderMode mode = m_control->customRenderMode();
+    bool drawDecorations = m_control->serverSideDecorationsEnabled();
     RemoteViewWidget::restoreState(stream);
 
     stream >> version;
@@ -227,20 +73,20 @@ void QuickScenePreviewWidget::restoreState(const QByteArray &state)
     case 1: {
         stream
                 >> mode
-        ;
+                ;
         break;
     }
     case 2: {
         stream
                 >> mode
                 >> drawDecorations
-        ;
+                ;
         break;
     }
     }
 
-    setCustomRenderMode(mode);
-    setServerSideDecorationsEnabled(drawDecorations);
+    m_control->setCustomRenderMode(mode);
+    m_control->setServerSideDecorationsEnabled(drawDecorations);
 }
 
 QByteArray QuickScenePreviewWidget::saveState() const
@@ -256,15 +102,15 @@ QByteArray QuickScenePreviewWidget::saveState() const
         switch (QuickScenePreviewWidgetStateVersion) {
         case 1: {
             stream
-                    << customRenderMode()
-            ;
+                    << m_control->customRenderMode()
+                       ;
             break;
         }
         case 2: {
             stream
-                    << customRenderMode()
-                    << serverSideDecorationsEnabled()
-            ;
+                    << m_control->customRenderMode()
+                    << m_control->serverSideDecorationsEnabled()
+                       ;
             break;
         }
         }
@@ -275,8 +121,6 @@ QByteArray QuickScenePreviewWidget::saveState() const
 
 void QuickScenePreviewWidget::resizeEvent(QResizeEvent *e)
 {
-    m_toolBar.toolbarWidget->setGeometry(0, 0, width(),
-                                         m_toolBar.toolbarWidget->sizeHint().height());
     RemoteViewWidget::resizeEvent(e);
 }
 
@@ -298,116 +142,10 @@ void QuickScenePreviewWidget::drawDecoration(QPainter *p)
     }
 }
 
-void QuickScenePreviewWidget::visualizeActionTriggered(QAction *current)
-{
-    if (!current || !current->isChecked()) {
-        m_inspectorInterface->setCustomRenderMode(QuickInspectorInterface::NormalRendering);
-    } else {
-        // QActionGroup requires exactly one selected, but we need 0 or 1 selected
-        foreach (auto action, m_toolBar.visualizeGroup->actions()) {
-            if (action != current)
-                action->setChecked(false);
-        }
-
-        m_inspectorInterface->setCustomRenderMode(static_cast<QuickInspectorInterface::RenderMode>(current->data().toInt()));
-    }
-    emit stateChanged();
-}
-
-void QuickScenePreviewWidget::serverSideDecorationsTriggered(bool enabled)
-{
-    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
-    m_inspectorInterface->setServerSideDecorationsEnabled(enabled);
-    emit stateChanged();
-}
-
-void QuickScenePreviewWidget::gridOffsetChanged(const QPoint &value)
-{
-    m_overlaySettings.gridOffset = value;
-    m_legendTool->setOverlaySettings(m_overlaySettings);
-    update();
-    setOverlaySettings(m_overlaySettings);
-}
-
-void QuickScenePreviewWidget::gridCellSizeChanged(const QSize &value)
-{
-    m_overlaySettings.gridCellSize = value;
-    m_legendTool->setOverlaySettings(m_overlaySettings);
-    update();
-    setOverlaySettings(m_overlaySettings);
-}
-
-void GammaRay::QuickScenePreviewWidget::setSupportsCustomRenderModes(
-    QuickInspectorInterface::Features supportedCustomRenderModes)
-{
-    m_toolBar.visualizeClipping->setEnabled(
-        supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeClipping);
-    m_toolBar.visualizeBatches->setEnabled(
-        supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeBatches);
-    m_toolBar.visualizeOverdraw->setEnabled(
-        supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeOverdraw);
-    m_toolBar.visualizeChanges->setEnabled(
-        supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeChanges);
-    m_toolBar.visualizeTraces->setEnabled(
-        supportedCustomRenderModes & QuickInspectorInterface::CustomRenderModeTraces);
-}
-
-void QuickScenePreviewWidget::setServerSideDecorationsState(bool enabled)
-{
-    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
-}
-
-void QuickScenePreviewWidget::setOverlaySettingsState(const QuickDecorationsSettings &settings)
-{
-    m_overlaySettings = settings;
-    m_gridSettingsWidget->setOverlaySettings(settings);
-    m_legendTool->setOverlaySettings(settings);
-}
-
-QuickInspectorInterface::RenderMode QuickScenePreviewWidget::customRenderMode() const
-{
-    const QAction *checkedAction = m_toolBar.visualizeGroup->checkedAction();
-
-    if (checkedAction) {
-        return static_cast<QuickInspectorInterface::RenderMode>(checkedAction->data().toInt());
-    }
-
-    return QuickInspectorInterface::NormalRendering;
-}
-
-void QuickScenePreviewWidget::setCustomRenderMode(QuickInspectorInterface::RenderMode customRenderMode)
-{
-    if (this->customRenderMode() == customRenderMode)
-        return;
-
-    foreach (auto action, m_toolBar.visualizeGroup->actions()) {
-        if (action)
-            action->setChecked(static_cast<QuickInspectorInterface::RenderMode>(action->data().toInt()) == customRenderMode);
-    }
-
-    visualizeActionTriggered(m_toolBar.visualizeGroup->checkedAction());
-}
-
 QuickDecorationsSettings QuickScenePreviewWidget::overlaySettings() const
 {
     return m_overlaySettings;
 }
 
-void QuickScenePreviewWidget::setOverlaySettings(const QuickDecorationsSettings &settings)
-{
-    m_inspectorInterface->setOverlaySettings(settings);
-    emit stateChanged();
-}
 
-bool QuickScenePreviewWidget::serverSideDecorationsEnabled() const
-{
-    return m_toolBar.serverSideDecorationsEnabled->isChecked();
-}
 
-void QuickScenePreviewWidget::setServerSideDecorationsEnabled(bool enabled)
-{
-    if (m_toolBar.serverSideDecorationsEnabled->isChecked() == enabled)
-        return;
-    m_toolBar.serverSideDecorationsEnabled->setChecked(enabled);
-    serverSideDecorationsTriggered(enabled);
-}

--- a/plugins/quickinspector/quickscenepreviewwidget.h
+++ b/plugins/quickinspector/quickscenepreviewwidget.h
@@ -32,75 +32,36 @@
 #include "quickitemgeometry.h"
 #include "quickinspectorinterface.h"
 #include "quickoverlay.h"
+#include "quickscenecontrolwidget.h"
 
 #include <ui/remoteviewwidget.h>
 
-QT_BEGIN_NAMESPACE
-class QAction;
-class QActionGroup;
-class QMenu;
-class QComboBox;
-class QLabel;
-class QToolBar;
-QT_END_NAMESPACE
-
 namespace GammaRay {
 class QuickInspectorInterface;
-class GridSettingsWidget;
-class QuickOverlayLegend;
 
 class QuickScenePreviewWidget : public RemoteViewWidget
 {
     Q_OBJECT
 
+    friend class QuickSceneControlWidget;
+
 public:
-    explicit QuickScenePreviewWidget(QuickInspectorInterface *inspector, QWidget *parent = nullptr);
+    explicit QuickScenePreviewWidget(QuickInspectorInterface *inspector, QuickSceneControlWidget *control, QWidget *parent = nullptr);
     ~QuickScenePreviewWidget();
 
     void restoreState(const QByteArray &state) override;
     QByteArray saveState() const override;
 
-    void setSupportsCustomRenderModes(QuickInspectorInterface::Features supportedCustomRenderModes);
-    void setServerSideDecorationsState(bool enabled);
-    void setOverlaySettingsState(const QuickDecorationsSettings &settings);
-
-    QuickInspectorInterface::RenderMode customRenderMode() const;
-    void setCustomRenderMode(QuickInspectorInterface::RenderMode customRenderMode);
-
     QuickDecorationsSettings overlaySettings() const;
-    void setOverlaySettings(const QuickDecorationsSettings &settings);
-
-    bool serverSideDecorationsEnabled() const;
-    void setServerSideDecorationsEnabled(bool enabled);
-
-private Q_SLOTS:
-    void visualizeActionTriggered(QAction* current);
-    void serverSideDecorationsTriggered(bool enabled);
-    void gridOffsetChanged(const QPoint &value);
-    void gridCellSizeChanged(const QSize &value);
 
 private:
     void drawDecoration(QPainter *p) override;
     void resizeEvent(QResizeEvent *e) override;
 
-    struct {
-        QToolBar *toolbarWidget;
-        QComboBox *zoomCombobox;
-        QActionGroup *visualizeGroup;
-        QAction *visualizeClipping;
-        QAction *visualizeOverdraw;
-        QAction *visualizeBatches;
-        QAction *visualizeChanges;
-        QAction *visualizeTraces;
-        QAction *serverSideDecorationsEnabled;
-        QMenu *gridSettings;
-    } m_toolBar;
+    QuickInspectorInterface *m_inspectorInterface;
+    QuickSceneControlWidget *m_control;
 
     QuickDecorationsSettings m_overlaySettings;
-    GridSettingsWidget *m_gridSettingsWidget;
-    QuickOverlayLegend *m_legendTool;
-
-    QuickInspectorInterface *m_inspectorInterface;
 };
 } // namespace GammaRay
 


### PR DESCRIPTION
This fixes an issue about wrong previewAlignment in the preview Widget, due to the top bar being rendered inside the preview Widget.

I moved the toolbar and the preview into a vertically layouted widget I named quickSceneControlWidget.