### PR TITLE
Use zero-based numbering in SourceLocation

### DIFF
--- a/common/sourcelocation.cpp
+++ b/common/sourcelocation.cpp
@@ -94,13 +94,13 @@ QString SourceLocation::displayString() const
     else
         result = m_url.toString();
 
-    if (m_line < 1)
+    if (m_line < 0)
         return result;
 
-    result += QString::fromLatin1(":%1").arg(m_line);
+    result += QString::fromLatin1(":%1").arg(m_line + 1);
 
-    if (m_column >= 1)
-        result += QString::fromLatin1(":%1").arg(m_column);
+    if (m_column >= 0)
+        result += QString::fromLatin1(":%1").arg(m_column + 1);
 
     return result;
 }

--- a/common/sourcelocation.h
+++ b/common/sourcelocation.h
@@ -36,12 +36,28 @@
 #include <QUrl>
 
 namespace GammaRay {
-/** @brief Specifies a source code location. */
+/**
+ * @brief Specifies a source code location.
+ *
+ * A source location consists of a document and cursor position
+ *
+ * A Cursor represents a position in a Document through a tuple
+ * of two int%s, namely the @ref line() and @ref column().
+ *
+ * Notes
+ * - Lines and columns start a 0 (=> zero-based numbering)
+ */
 class GAMMARAY_COMMON_EXPORT SourceLocation
 {
 public:
+    /**
+     * The default constructor creates a (invalid) cursor at position (-1, -1) with an invalid url
+     */
     SourceLocation();
-    explicit SourceLocation(const QUrl &url, int line = -1, int column = -1);
+    /**
+     * This constructor creates a (valid) cursor at position (0, 0) with @p url
+     */
+    explicit SourceLocation(const QUrl &url, int line = 0, int column = 0);
     ~SourceLocation();
 
     bool isValid() const;
@@ -55,6 +71,18 @@ public:
     int column() const;
     void setColumn(int column);
 
+    /**
+     * Returns a human-readable version of this source location
+     *
+     * @code
+     * SourceLocation loc(QUrl::fromLocalFile("file.cpp", 0, 0);
+     * qDebug() << loc.displayString();
+     *
+     * => Prints: file.cpp:1:1
+     * @endcode
+     *
+     * @note This will user one-based numbering
+     */
     QString displayString() const;
 
 private:

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -1054,8 +1054,8 @@ SourceLocation Probe::objectCreationSourceLocation(QObject* object)
 
   SourceLocation loc;
   loc.setUrl(QUrl::fromLocalFile(QString::fromStdString(trace.source.filename)));
-  loc.setLine(trace.source.line);
-  loc.setColumn(trace.source.col);
+  loc.setLine(trace.source.line - 1);
+  loc.setColumn(trace.source.col - 1);
 
   return loc;
 #else

--- a/plugins/qmlsupport/qmlsupport.cpp
+++ b/plugins/qmlsupport/qmlsupport.cpp
@@ -248,8 +248,8 @@ SourceLocation QmlObjectDataProvider::creationLocation(QObject *obj) const
     loc.setUrl(context->url);
 #endif
 
-    loc.setLine(objectData->lineNumber);
-    loc.setColumn(objectData->columnNumber);
+    loc.setLine(static_cast<int>(objectData->lineNumber) - 1);
+    loc.setColumn(static_cast<int>(objectData->columnNumber) - 1);
     return loc;
 }
 

--- a/tests/sourcelocationtest.cpp
+++ b/tests/sourcelocationtest.cpp
@@ -49,19 +49,19 @@ private slots:
         QTest::newRow("invalid 2") << QUrl() << 42 << 23 << QString() << false;
         QTest::newRow("url only") << QUrl(QStringLiteral("file:///some/file")) << -1 << -1
                                   << QStringLiteral("/some/file") << true;
-        QTest::newRow("url and line") << QUrl(QStringLiteral("file:///some/file")) << 23 << -1
+        QTest::newRow("url and line") << QUrl(QStringLiteral("file:///some/file")) << 22 << -1
                                       << QStringLiteral("/some/file:23") << true;
-        QTest::newRow("complete") << QUrl(QStringLiteral("file:///some/file")) << 23 << 42
+        QTest::newRow("complete") << QUrl(QStringLiteral("file:///some/file")) << 22 << 41
                                   << QStringLiteral("/some/file:23:42") << true;
         QTest::newRow("url and column") << QUrl(QStringLiteral("file:///some/file")) << -1 << 42
                                         << QStringLiteral("/some/file") << true;
-        QTest::newRow("complete but 0 column") << QUrl(QStringLiteral("file:///some/file")) << 23
-                                               << 0 << QStringLiteral("/some/file:23") << true;
-        QTest::newRow("complete but 1 column") << QUrl(QStringLiteral("file:///some/file")) << 23
-                                               << 1 << QStringLiteral("/some/file:23:1") << true;
-        QTest::newRow("url") << QUrl::fromLocalFile(QStringLiteral("/some/file")) << 1 << 1
+        QTest::newRow("complete but 0 column") << QUrl(QStringLiteral("file:///some/file")) << 22
+                                               << -1 << QStringLiteral("/some/file:23") << true;
+        QTest::newRow("complete but 1 column") << QUrl(QStringLiteral("file:///some/file")) << 22
+                                               << 0 << QStringLiteral("/some/file:23:1") << true;
+        QTest::newRow("url") << QUrl::fromLocalFile(QStringLiteral("/some/file")) << 0 << 0
                              << QStringLiteral("/some/file:1:1") << true;
-        QTest::newRow("qrc") << QUrl(QStringLiteral("qrc:///main.qml")) << 1 << 1 << QStringLiteral(
+        QTest::newRow("qrc") << QUrl(QStringLiteral("qrc:///main.qml")) << 0 << 0 << QStringLiteral(
             "qrc:///main.qml:1:1") << true;
     }
 

--- a/ui/contextmenuextension.cpp
+++ b/ui/contextmenuextension.cpp
@@ -78,7 +78,7 @@ bool ContextMenuExtension::discoverSourceLocation(ContextMenuExtension::Location
     if (url.isEmpty())
         return false;
 
-    setLocation(location, SourceLocation(url, 0));
+    setLocation(location, SourceLocation(url));
     return true;
 }
 

--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -490,8 +490,8 @@ void MainWindow::navigateToCode(const QUrl &url, int lineNumber, int columnNumbe
 
         const QString filePath = url.isLocalFile() ? url.toLocalFile() : url.toString();
         command.replace(QStringLiteral("%f"), filePath);
-        command.replace(QStringLiteral("%l"), QString::number(std::max(1, lineNumber)));
-        command.replace(QStringLiteral("%c"), QString::number(std::max(1, columnNumber)));
+        command.replace(QStringLiteral("%l"), QString::number(std::max(1, lineNumber + 1)));
+        command.replace(QStringLiteral("%c"), QString::number(std::max(1, columnNumber + 1)));
 
         if (!command.isEmpty()) {
             std::cout << "Detaching: " << qPrintable(command) << std::endl;

--- a/ui/tools/messagehandler/messagehandlerwidget.cpp
+++ b/ui/tools/messagehandler/messagehandlerwidget.cpp
@@ -195,7 +195,7 @@ void MessageHandlerWidget::messageContextMenu(const QPoint &pos)
 
     QMenu contextMenu;
     ContextMenuExtension cme;
-    cme.setLocation(ContextMenuExtension::ShowSource, SourceLocation(QUrl(fileName), line, 0));
+    cme.setLocation(ContextMenuExtension::ShowSource, SourceLocation(QUrl(fileName), line - 1));
     cme.populateMenu(&contextMenu);
     contextMenu.exec(ui->messageView->viewport()->mapToGlobal(pos));
 }


### PR DESCRIPTION
Makes a few things easier to handle and removes the uncertain state of
`SourceLocation(0, 0)`.

Add more apidocs