### PR TITLE
MessageBuffer improvements

### DIFF
--- a/common/message.cpp
+++ b/common/message.cpp
@@ -28,29 +28,28 @@
 
 #include "message.h"
 
+#include "sharedpool.h"
 #include "lz4/lz4.h" // 3rdparty
 
+#include <QBuffer>
 #include <QDebug>
 #include <qendian.h>
 
-inline QByteArray compress(const QByteArray &src)
+inline void compress(const QByteArray &src, QByteArray &dst)
 {
     const qint32 srcSz = src.size();
 
-    QByteArray dst;
     dst.resize(LZ4_compressBound(srcSz + sizeof(srcSz)));
     *(qint32 *)dst.data() = srcSz; // save the source size
 
     const int sz
         = LZ4_compress_default(src.constData(), dst.data() + sizeof(int), srcSz, dst.size());
     dst.resize(sz + sizeof(srcSz));
-    return dst;
 }
 
-inline QByteArray uncompress(const QByteArray &src)
+inline void uncompress(const QByteArray &src, QByteArray &dst)
 {
     const qint32 dstSz = *(const qint32 *)src.constData(); // get the dest size
-    QByteArray dst;
     dst.resize(dstSz);
     const int sz = LZ4_decompress_safe(src.constData() + sizeof(dstSz), dst.data(),
                                        src.size()- sizeof(dstSz), dstSz);
@@ -58,7 +57,6 @@ inline QByteArray uncompress(const QByteArray &src)
         dst.resize(0);
     else
         dst.resize(sz);
-    return dst;
 }
 
 static const QDataStream::Version StreamVersion = QDataStream::Qt_4_8;
@@ -83,24 +81,57 @@ template<typename T> static void writeNumber(QIODevice *device, T value)
 
 using namespace GammaRay;
 
+class MessageBuffer
+{
+public:
+    MessageBuffer()
+        : stream(&data)
+    {
+        stream.setVersion(StreamVersion);
+        data.open(QIODevice::ReadWrite);
+
+        // explicitly reserve memory so a resize() won't shed it
+        data.buffer().reserve(32);
+        scratchSpace.reserve(32);
+    }
+
+    ~MessageBuffer() {}
+
+    void reset()
+    {
+        data.seek(0);
+        scratchSpace.resize(0);
+        stream.resetStatus();
+    }
+
+    QBuffer data;
+    QByteArray scratchSpace;
+    QDataStream stream;
+};
+
+Q_GLOBAL_STATIC_WITH_ARGS(SharedPool<MessageBuffer>, m_sharedMessageBufferPool, (5))
+
 Message::Message()
     : m_objectAddress(Protocol::InvalidObjectAddress)
     , m_messageType(Protocol::InvalidMessageType)
+    , m_buffer(m_sharedMessageBufferPool()->acquire())
 {
+    m_buffer->reset();
 }
 
 Message::Message(Protocol::ObjectAddress objectAddress, Protocol::MessageType type)
     : m_objectAddress(objectAddress)
     , m_messageType(type)
+    , m_buffer(m_sharedMessageBufferPool()->acquire())
 {
+    m_buffer->reset();
 }
 
 Message::Message(Message &&other)
-    : m_buffer(std::move(other.m_buffer))
-    , m_objectAddress(other.m_objectAddress)
+    : m_objectAddress(other.m_objectAddress)
     , m_messageType(other.m_messageType)
+    , m_buffer(std::move(other.m_buffer))
 {
-    m_stream.swap(other.m_stream);
 }
 
 Message::~Message()
@@ -119,14 +150,7 @@ Protocol::MessageType Message::type() const
 
 QDataStream &Message::payload() const
 {
-    if (!m_stream) {
-        if (m_buffer.isEmpty())
-            m_stream.reset(new QDataStream(&m_buffer, QIODevice::WriteOnly));
-        else
-            m_stream.reset(new QDataStream(m_buffer));
-        m_stream->setVersion(StreamVersion);
-    }
-    return *m_stream;
+    return m_buffer->stream;
 }
 
 bool Message::canReadMessage(QIODevice *device)
@@ -163,15 +187,20 @@ Message Message::readMessage(QIODevice *device)
     Q_ASSERT(msg.m_objectAddress != Protocol::InvalidObjectAddress);
     if (payloadSize < 0) {
         payloadSize = abs(payloadSize);
-        QByteArray buff = device->read(payloadSize);
-        msg.m_buffer = uncompress(buff);
-        Q_ASSERT(payloadSize == buff.size());
+        auto& uncompressedData = msg.m_buffer->scratchSpace;
+        uncompressedData.resize(payloadSize);
+        device->read(uncompressedData.data(), payloadSize);
+        uncompress(uncompressedData, msg.m_buffer->data.buffer());
+        Q_ASSERT(payloadSize == uncompressedData.size());
     } else {
         if (payloadSize > 0) {
-            msg.m_buffer = device->read(payloadSize);
-            Q_ASSERT(payloadSize == msg.m_buffer.size());
+            msg.m_buffer->data.buffer() = device->read(payloadSize);
+            Q_ASSERT(payloadSize == msg.m_buffer->data.size());
         }
     }
+
+    msg.m_buffer->reset();
+
     return msg;
 }
 
@@ -180,13 +209,14 @@ void Message::write(QIODevice *device) const
     Q_ASSERT(m_objectAddress != Protocol::InvalidObjectAddress);
     Q_ASSERT(m_messageType != Protocol::InvalidMessageType);
     static const bool compressionEnabled = qgetenv("GAMMARAY_DISABLE_LZ4") != "1";
-    const int buffSize = m_buffer.size();
-    QByteArray buff;
+    const int buffSize = m_buffer->data.size();
+    auto& compressedData = m_buffer->scratchSpace;
     if (buffSize > minimumUncompressedSize && compressionEnabled)
-        buff = compress(m_buffer);
+        compress(m_buffer->data.buffer(), compressedData);
 
-    if (buff.size() && buff.size() < buffSize)
-        writeNumber<Protocol::PayloadSize>(device, -buff.size()); // send compressed Buffer
+    const bool isCompressed = compressedData.size() && compressedData.size() < buffSize;
+    if (isCompressed)
+        writeNumber<Protocol::PayloadSize>(device, -compressedData.size()); // send compressed Buffer
     else
         writeNumber<Protocol::PayloadSize>(device, buffSize);   // send uncompressed Buffer
 
@@ -194,13 +224,13 @@ void Message::write(QIODevice *device) const
     writeNumber(device, m_messageType);
 
     if (buffSize) {
-        if (buff.size() && buff.size() < buffSize) {
-            const int s = device->write(buff);
-            Q_ASSERT(s == buff.size());
+        if (isCompressed) {
+            const int s = device->write(compressedData);
+            Q_ASSERT(s == compressedData.size());
             Q_UNUSED(s);
         } else {
-            const int s = device->write(m_buffer);
-            Q_ASSERT(s == m_buffer.size());
+            const int s = device->write(m_buffer->data.buffer());
+            Q_ASSERT(s == m_buffer->data.size());
             Q_UNUSED(s);
         }
     }
@@ -208,5 +238,5 @@ void Message::write(QIODevice *device) const
 
 int Message::size() const
 {
-    return m_buffer.size();
+    return m_buffer->data.size();
 }

--- a/common/message.h
+++ b/common/message.h
@@ -35,6 +35,11 @@
 #include <QByteArray>
 #include <QDataStream>
 
+#include <functional>
+#include <memory>
+
+class MessageBuffer;
+
 namespace GammaRay {
 /**
  * Single message send between client and server.
@@ -119,11 +124,10 @@ private:
      */
     QDataStream &payload() const;
 
-    mutable QByteArray m_buffer;
-    mutable QScopedPointer<QDataStream> m_stream;
-
     Protocol::ObjectAddress m_objectAddress;
     Protocol::MessageType m_messageType;
+
+    std::unique_ptr<MessageBuffer, std::function<void(MessageBuffer *)>> m_buffer;
 };
 }
 

--- a/common/sharedpool.h
+++ b/common/sharedpool.h
@@ -1,0 +1,109 @@
+/*
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2017 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Kevin Funk <kevin.funk@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_SHAREDPOOL_H
+#define GAMMARAY_SHAREDPOOL_H
+
+#include <assert.h>
+#include <iostream>
+#include <functional>
+#include <memory>
+#include <stack>
+#include <vector>
+
+#define IF_DEBUG(x)
+
+namespace GammaRay {
+
+template <class T>
+class SharedPool
+{
+public:
+    // no `using a = b;` for MSVC2010 :(
+    typedef std::unique_ptr<T, std::function<void(T*)>> PtrType;
+
+    SharedPool(size_t prealloc = 0)
+        : m_capacity(0)
+    {
+        while (prealloc--) {
+            add(std::unique_ptr<T>(new T));
+        }
+    }
+    ~SharedPool()
+    {
+        assert(m_capacity == size() && "Some objects are still acquired");
+        IF_DEBUG(std::cout << "Acquired objects left in pool on destruction: " << (m_capacity - size()) << std::endl);
+    }
+
+    void add(std::unique_ptr<T> t)
+    {
+        m_pool.push(std::move(t));
+        m_capacity++;
+
+        IF_DEBUG(std::cout << "Adding object to pool: " << m_pool.top().get() << " - current capacity:" << m_capacity << std::endl);
+    }
+
+    PtrType acquire()
+    {
+        // insert more if necessary
+        if (m_pool.empty()) {
+            IF_DEBUG(std::cout << "Growing pool by one" << std::endl);
+            add(std::unique_ptr<T>(new T));
+        }
+
+        auto ptr = m_pool.top().release();
+        IF_DEBUG(std::cout << "Acquire: " << ptr << std::endl);
+        PtrType tmp(ptr, [this](T* ptr) {
+            IF_DEBUG(std::cout << "Release: " << ptr << std::endl);
+            m_pool.push(std::unique_ptr<T>(ptr));
+        });
+        m_pool.pop();
+        return std::move(tmp);
+    }
+
+    bool empty() const
+    {
+        return m_pool.empty();
+    }
+
+    size_t capacity() const
+    {
+        return m_capacity;
+    }
+
+    size_t size() const
+    {
+        return m_pool.size();
+    }
+
+private:
+    size_t m_capacity;
+    std::stack<std::unique_ptr<T>, std::vector<std::unique_ptr<T>>> m_pool;
+};
+
+}
+
+#endif


### PR DESCRIPTION
Introduce a shared object pool for the internal buffers of the Message
class. Message uses a pool of objects to read/write data into, this is
order to cut down the number of allocations done within Message.

Improvements:
- Cut down temporary allocations within QByteArray
- Cut down QDataStream/QBuffer creations to the size of the pool instead
  of the number of Messages created

Task-Id: KDEND-148