### PR TITLE
Correctly handle IP when provided with --listen

### DIFF
--- a/client/messagestatisticsmodel.cpp
+++ b/client/messagestatisticsmodel.cpp
@@ -74,7 +74,8 @@ static const MetaEnum::Value<Protocol::MessageType> message_type_table[] = {
     M(PropertyValuesChanged),
     M(ServerInfo),
     M(ProbeSettings),
-    M(ServerAddress)
+    M(ServerAddress),
+    M(ServerLaunchError)
 };
 #undef M
 Q_STATIC_ASSERT(Protocol::MESSAGE_TYPE_COUNT - 1 == (sizeof(message_type_table) / sizeof(MetaEnum::Value<Protocol::MessageType>)));

--- a/common/protocol.cpp
+++ b/common/protocol.cpp
@@ -55,7 +55,7 @@ QModelIndex toQModelIndex(const QAbstractItemModel *model, const Protocol::Model
 
 qint32 version()
 {
-    return 34;
+    return 35;
 }
 
 qint32 broadcastFormatVersion()

--- a/common/protocol.h
+++ b/common/protocol.h
@@ -101,6 +101,7 @@ enum BuildInMessageType {
     // probe settings provided by the launcher
     ProbeSettings,
     ServerAddress,
+    ServerLaunchError,
 
     MESSAGE_TYPE_COUNT // NOTE when changing this enum, also update MessageStatisticsModel!
 };

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -416,8 +416,12 @@ void Probe::delayedInit()
     // The applicationName might be translated, so let's go with the application file base name
     m_server->setKey(QFileInfo(qApp->applicationFilePath()).completeBaseName());
     m_server->setPid(qApp->applicationPid());
-    m_server->listen();
-    ProbeSettings::sendServerAddress(m_server->externalAddress());
+    bool serverStarted = m_server->listen();
+    if (serverStarted) {
+        ProbeSettings::sendServerAddress(m_server->externalAddress());
+    } else {
+        ProbeSettings::sendServerLaunchError(m_server->errorString());
+    }
 
     if (ProbeSettings::value(QStringLiteral("InProcessUi"), false).toBool())
         showInProcessUi();

--- a/core/probesettings.h
+++ b/core/probesettings.h
@@ -55,6 +55,9 @@ void resetLauncherIdentifier();
 
 /** Sends the server address used for communication with the client back to the launcher. */
 void sendServerAddress(const QUrl &addr);
+
+/** Sends an error message if no server could be launched back to the launcher */
+void sendServerLaunchError(const QString &reason);
 }
 }
 

--- a/core/remote/server.cpp
+++ b/core/remote/server.cpp
@@ -94,7 +94,6 @@ bool Server::listen()
 {
     Q_ASSERT(!m_serverDevice->isListening());
     if (!m_serverDevice->listen()) {
-        qWarning() << "Failed to start server:" << m_serverDevice->errorString();
         return false;
     }
 

--- a/core/remote/server.cpp
+++ b/core/remote/server.cpp
@@ -356,3 +356,10 @@ QUrl Server::externalAddress() const
         return QUrl();
     return m_serverDevice->externalAddress();
 }
+
+QString Server::errorString() const
+{
+    if (!m_serverDevice)
+        return QString();
+    return m_serverDevice->errorString();
+}

--- a/core/remote/server.h
+++ b/core/remote/server.h
@@ -103,6 +103,11 @@ public:
      * be identical for all protocols (such as TCP).
      */
     QUrl externalAddress() const;
+    /**
+     * Returns the current error of the device to be displayed to the user.
+     */
+     QString errorString() const;
+
 protected:
     void messageReceived(const Message &msg) override;
     void handlerDestroyed(Protocol::ObjectAddress objectAddress,

--- a/core/remote/tcpserverdevice.h
+++ b/core/remote/tcpserverdevice.h
@@ -53,6 +53,7 @@ public:
 
 private:
     QUdpSocket *m_broadcastSocket;
+    QString bestAvailableIP(const QHostAddress address) const;
 };
 }
 

--- a/launcher/cli/main.cpp
+++ b/launcher/cli/main.cpp
@@ -340,6 +340,13 @@ int main(int argc, char **argv)
         options.setProbeABI(availableProbes.first());
     }
 
+    // use a local connection when starting gui locally with this launcher
+    if (!options.probeSettings().contains(QStringLiteral("ServerAddress").toUtf8())
+        && options.uiMode() != LaunchOptions::NoUi
+        && !LauncherFinder::findLauncher(LauncherFinder::LauncherUI).isEmpty()) {
+        options.setProbeSetting(QStringLiteral("ServerAddress"), "tcp://127.0.0.1");
+    }
+
     Launcher launcher(options);
     QObject::connect(&launcher, SIGNAL(finished()), &app, SLOT(quit()));
     QObject::connect(&launcher, SIGNAL(attached()), &app, SLOT(quit()));

--- a/launcher/core/launcher.cpp
+++ b/launcher/core/launcher.cpp
@@ -329,6 +329,12 @@ void Launcher::readyRead()
             msg >> d->serverAddress;
             break;
         }
+        case Protocol::ServerLaunchError:
+        {
+            QString reason;
+            msg >> reason;
+            break;
+        }
         default:
             continue;
         }

--- a/launcher/core/launcher.cpp
+++ b/launcher/core/launcher.cpp
@@ -333,6 +333,9 @@ void Launcher::readyRead()
         {
             QString reason;
             msg >> reason;
+            std::cerr << "Failed to start server: " << qPrintable(reason)
+                      << std::endl;
+            // TODO emit error signal to also notify qtcreator, etc
             break;
         }
         default:

--- a/launcher/core/launcher.h
+++ b/launcher/core/launcher.h
@@ -86,6 +86,7 @@ private slots:
 private:
     void sendLauncherId();
     void setupProbeSettingsServer();
+    void printAllAvailableIPs();
     void checkDone();
 
 private:

--- a/tests/probesettingsclient.cpp
+++ b/tests/probesettingsclient.cpp
@@ -41,7 +41,6 @@ int main(int argc, char **argv)
     ProbeSettings::receiveSettings();
 
     QUrl addr = QUrl::fromUserInput(ProbeSettings::value("TestValue").toString());
-    qDebug() << addr;
     ProbeSettings::sendServerAddress(addr);
 
     QTimer::singleShot(1000, &app, SLOT(quit()));


### PR DESCRIPTION
* If IP cannot be used, send a message back to the Launcher
* Scan All devices for the user-specified IP, dont just take the first IP available on the first interface
* Avoids Printing bogus IPs on startup (sometimes 'Server is running on tcp:' was printed)