### PR TITLE
Disable old QIviProperty based test on newer versions of QtIVI

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -462,18 +462,20 @@ endif()
 ### Qt IVI property model test
 
 if(Qt5IviCore_FOUND AND Qt5IviVehicleFunctions_FOUND) # requires QHooks
-  add_executable(qtivipropertymodeltest
-    qtivipropertymodeltest.cpp
-    ../plugins/qtivi/qtivipropertyoverrider.cpp
-    ../plugins/qtivi/qtivipropertymodel.cpp
-    $<TARGET_OBJECTS:gammaray_probe_obj>
-    $<TARGET_OBJECTS:modeltestobj>
-  )
-  target_include_directories(qtivipropertymodeltest SYSTEM PRIVATE ${Qt5IviCore_PRIVATE_INCLUDE_DIRS})
-  target_link_libraries(qtivipropertymodeltest gammaray_core Qt5::Test Qt5::Gui Qt5::IviCore Qt5::IviVehicleFunctions)
-  add_test(NAME qtivipropertymodeltest COMMAND qtivipropertymodeltest)
-  if(Qt5IviMedia_FOUND)
+  if(Qt5IviCore_VERSION_STRING VERSION_LESS 1.2)
+    add_executable(qtivipropertymodeltest
+      qtivipropertymodeltest.cpp
+      ../plugins/qtivi/qtivipropertyoverrider.cpp
+      ../plugins/qtivi/qtivipropertymodel.cpp
+      $<TARGET_OBJECTS:gammaray_probe_obj>
+      $<TARGET_OBJECTS:modeltestobj>
+    )
+    target_include_directories(qtivipropertymodeltest SYSTEM PRIVATE ${Qt5IviCore_PRIVATE_INCLUDE_DIRS})
+    target_link_libraries(qtivipropertymodeltest gammaray_core Qt5::Test Qt5::Gui Qt5::IviCore Qt5::IviVehicleFunctions)
+    add_test(NAME qtivipropertymodeltest COMMAND qtivipropertymodeltest)
+    if(Qt5IviMedia_FOUND)
       target_link_libraries(qtivipropertymodeltest Qt5::IviMedia)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
needs to be replaced with a newer test