### PR TITLE
Fix multiprobe build if no install prefix is set.

### DIFF
--- a/multibuild/CMakeLists.txt
+++ b/multibuild/CMakeLists.txt
@@ -21,7 +21,6 @@ ExternalProject_Add(
   GammaRay-${_build_type}
   SOURCE_DIR ${CMAKE_SOURCE_DIR}
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/GammaRay-${_build_type}
-  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   EXCLUDE_FROM_ALL 1
   STEP_TARGETS build install
 


### PR DESCRIPTION
Currently cmake tests wheter the install prefix exist and fails if not.
As we use a normal install step, we don't need to set INSTALL_DIR.