### PR TITLE
Fix the library name.

### DIFF
--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -453,7 +453,7 @@ void WidgetInspectorServer::callExternalExportAction(const char *name, QWidget *
 {
     if (!m_externalExportActions->isLoaded()) {
         foreach (const auto &path, Paths::pluginPaths(GAMMARAY_PROBE_ABI)) {
-            m_externalExportActions->setFileName(path + QLatin1String("/libgammaray_widget_export_actions")
+            m_externalExportActions->setFileName(path + QLatin1String("/gammaray_widget_export_actions")
 #if defined(GAMMARAY_INSTALL_QT_LAYOUT)
                 + QStringLiteral("-") + QStringLiteral(GAMMARAY_PROBE_ABI)
 #endif


### PR DESCRIPTION
On MSVC ther lib prefix isnt set.
On all other platforms QLibrary will automatically try to load the
library with the lib prefix.