### PR TITLE
Added hints to find qdoc and qhelpgenerator

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -5,8 +5,12 @@
 # qdoc toolchain
 # TODO: some of this probably should be upstreamed to Qt's cmake files...
 # TODO replace with Qt5::qhelpgenerator for Qt >= 5.7.1
-find_program(QHELPGEN_EXECUTABLE qhelpgenerator)
-find_program(QDOC_EXECUTABLE qdoc)
+find_program(QHELPGEN_EXECUTABLE qhelpgenerator
+  HINTS ${QT_INSTALL_BINS}
+)
+find_program(QDOC_EXECUTABLE qdoc
+  HINTS ${QT_INSTALL_BINS}
+)
 
 find_file(QDOC_TEMPLATE global/qt-html-templates-offline.qdocconf
   HINTS ${QT_INSTALL_DOCS}


### PR DESCRIPTION
Depending on how Qt is installed and CMake configured, a system
qdoc can be used in place of the version provided by the Qt hinted
to at configuration time. This patch fixes that by adding a hint
entry to find_program so it starts in the same folder as the Qt
configured.