### PR TITLE
Prevent infinite recursion when tracing plasmashell with gammaray

### DIFF
--- a/plugins/guisupport/guisupport.cpp
+++ b/plugins/guisupport/guisupport.cpp
@@ -582,6 +582,8 @@ void GuiSupport::objectCreated(QObject *object)
 bool GuiSupport::eventFilter(QObject *watched, QEvent *event)
 {
     if (!m_restoringIconsAndTitle) {
+        // prevent recursion, esp. when tracing e.g. plasmashell
+        m_restoringIconsAndTitle = true;
         if (event->type() == QEvent::WindowTitleChange) {
             if (auto w = qobject_cast<QWindow*>(watched)) {
                 if (w->isTopLevel()) {
@@ -595,6 +597,7 @@ bool GuiSupport::eventFilter(QObject *watched, QEvent *event)
                 }
             }
         }
+        m_restoringIconsAndTitle = false;
     }
     return QObject::eventFilter(watched, event);
 }


### PR DESCRIPTION
Fixes stack overflow when running plasmashell through gammaray:

Thread 1 "plasmashell" received signal SIGSEGV, Segmentation fault.
0x00007ffff3ec51fc in ?? () from /usr/lib/libQt5Gui.so.5
(gdb)
(gdb) bt
#0  0x00007ffff3ec51fc in ?? () from /usr/lib/libQt5Gui.so.5
#1  0x00007ffff3eb4c16 in QImage::convertToFormat_helper(QImage::Format, QFlags<Qt::ImageConversionFlag>) const () from /usr/lib/libQt5Gui.so.5
#2  0x00007fffe6d8c185 in QXcbWindow::setWindowIcon(QIcon const&) () from /usr/lib/libQt5XcbQpa.so.5
#3  0x00007ffff3e75ef4 in QWindow::setIcon(QIcon const&) () from /usr/lib/libQt5Gui.so.5
#4  0x00007fffddae596a in GammaRay::GuiSupport::updateWindowIcon (this=0x55555577d8a0, w=0x555555aef4e0) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:539
#5  0x00007fffddae5eff in GammaRay::GuiSupport::eventFilter (this=0x55555577d8a0, watched=0x555555aef4e0, event=0x7fffff801490) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:594
#6  0x00007ffff23d40bf in GammaRay::Probe::eventFilter (this=0x555555705c00, receiver=0x555555aef4e0, event=0x7fffff801490) at /home/milian/projects/src/gammaray/core/probe.cpp:920
#7  0x00007ffff3446bdc in QCoreApplicationPrivate::sendThroughApplicationEventFilters(QObject*, QEvent*) () from /usr/lib/libQt5Core.so.5
#8  0x00007ffff462af6a in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/libQt5Widgets.so.5
#9  0x00007ffff4632a06 in QApplication::notify(QObject*, QEvent*) () from /usr/lib/libQt5Widgets.so.5
#10 0x00007ffff3447060 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/lib/libQt5Core.so.5
#11 0x00007ffff3e75f16 in QWindow::setIcon(QIcon const&) () from /usr/lib/libQt5Gui.so.5
#12 0x00007fffddae596a in GammaRay::GuiSupport::updateWindowIcon (this=0x55555577d8a0, w=0x555555aef4e0) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:539
#13 0x00007fffddae5eff in GammaRay::GuiSupport::eventFilter (this=0x55555577d8a0, watched=0x555555aef4e0, event=0x7fffff801860) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:594
#14 0x00007ffff23d40bf in GammaRay::Probe::eventFilter (this=0x555555705c00, receiver=0x555555aef4e0, event=0x7fffff801860) at /home/milian/projects/src/gammaray/core/probe.cpp:920
#15 0x00007ffff3446bdc in QCoreApplicationPrivate::sendThroughApplicationEventFilters(QObject*, QEvent*) () from /usr/lib/libQt5Core.so.5
#16 0x00007ffff462af6a in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /usr/lib/libQt5Widgets.so.5
#17 0x00007ffff4632a06 in QApplication::notify(QObject*, QEvent*) () from /usr/lib/libQt5Widgets.so.5
#18 0x00007ffff3447060 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () from /usr/lib/libQt5Core.so.5
#19 0x00007ffff3e75f16 in QWindow::setIcon(QIcon const&) () from /usr/lib/libQt5Gui.so.5
#20 0x00007fffddae596a in GammaRay::GuiSupport::updateWindowIcon (this=0x55555577d8a0, w=0x555555aef4e0) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:539
#21 0x00007fffddae5eff in GammaRay::GuiSupport::eventFilter (this=0x55555577d8a0, watched=0x555555aef4e0, event=0x7fffff801c30) at /home/milian/projects/src/gammaray/plugins/guisupport/guisupport.cpp:594
#22 0x00007ffff23d40bf in GammaRay::Probe::eventFilter (this=0x555555705c00, receiver=0x555555aef4e0, event=0x7fffff801c30) at /home/milian/projects/src/gammaray/core/probe.cpp:920