### PR TITLE
Restore compatibility with CMake 3.0

### DIFF
--- a/plugins/qmlsupport/CMakeLists.txt
+++ b/plugins/qmlsupport/CMakeLists.txt
@@ -11,15 +11,15 @@ set(gammaray_qmlsupport_srcs
   qmltypeextension.cpp
 )
 
+if(NOT Qt5Qml_VERSION VERSION_LESS 5.10)
+    set(gammaray_qmlsupport_srcs ${gammaray_qmlsupport_srcs} qmlbindingprovider.cpp)
+endif()
+
 gammaray_add_plugin(gammaray_qmlsupport JSON gammaray_qmlsupport.json SOURCES ${gammaray_qmlsupport_srcs})
 target_include_directories(gammaray_qmlsupport SYSTEM PRIVATE ${Qt5Qml_PRIVATE_INCLUDE_DIRS})
 target_link_libraries(gammaray_qmlsupport gammaray_core Qt5::Qml)
 endif()
 
-
-if(NOT Qt5Qml_VERSION VERSION_LESS 5.10)
-    target_sources(gammaray_qmlsupport PUBLIC qmlbindingprovider.cpp)
-endif()
 
 # ui plugin
 if(GAMMARAY_BUILD_UI)

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -28,14 +28,14 @@ if(Qt5Quick_FOUND)
     textureextension/qsgtexturegrabber.cpp
   )
 
+  if(NOT Qt5Quick_VERSION VERSION_LESS 5.7)
+    set(gammaray_quickinspector_srcs ${gammaray_quickinspector_srcs} quickimplicitbindingdependencyprovider.cpp)
+  endif()
+
   gammaray_add_plugin(gammaray_quickinspector
     JSON gammaray_quickinspector.json
     SOURCES ${gammaray_quickinspector_srcs}
   )
-
-  if(NOT Qt5Quick_VERSION VERSION_LESS 5.7)
-    target_sources(gammaray_quickinspector PUBLIC quickimplicitbindingdependencyprovider.cpp)
-  endif()
 
   target_include_directories(gammaray_quickinspector SYSTEM PRIVATE ${Qt5Quick_PRIVATE_INCLUDE_DIRS})
   target_link_libraries(gammaray_quickinspector

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -425,19 +425,18 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD AND Qt5Core_FOUND AND NOT Qt5Core_VERSION_MINO
   endif()
 
   if(Qt5Quick_FOUND AND NOT Qt5Quick_VERSION VERSION_LESS 5.7) # requires MSVC 2013 or higher
-    gammaray_add_quick_test(bindinginspectortest
+    set(bindinginspectortest_srcs
       bindinginspectortest.cpp
       $<TARGET_OBJECTS:modeltestobj>
-    )
-    target_include_directories(bindinginspectortest SYSTEM PRIVATE ${Qt5Quick_PRIVATE_INCLUDE_DIRS})
-    target_link_libraries(bindinginspectortest gammaray_core Qt5::Quick)
-    target_sources(bindinginspectortest PUBLIC
       ${CMAKE_SOURCE_DIR}/plugins/quickinspector/quickimplicitbindingdependencyprovider.cpp
     )
     if(NOT Qt5Qml_VERSION VERSION_LESS 5.10)
-      target_sources(bindinginspectortest PUBLIC
+      set(bindinginspectortest_srcs ${bindinginspectortest_srcs}
         ${CMAKE_SOURCE_DIR}/plugins/qmlsupport/qmlbindingprovider.cpp)
     endif()
+    gammaray_add_quick_test(bindinginspectortest ${bindinginspectortest_srcs})
+    target_include_directories(bindinginspectortest SYSTEM PRIVATE ${Qt5Quick_PRIVATE_INCLUDE_DIRS})
+    target_link_libraries(bindinginspectortest gammaray_core Qt5::Quick)
   endif()
 
   if(Qt5Quick_FOUND)


### PR DESCRIPTION
Might be obsolete already, but 2.9 doesn't mention cmake 3.1 as requirement.