### PR TITLE
Property filtering

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(gammaray_srcs
   propertyadaptor.cpp
   propertyaggregator.cpp
   propertydata.cpp
+  propertyfilter.cpp
   dynamicpropertyadaptor.cpp
   qmetapropertyadaptor.cpp
   metapropertyadaptor.cpp

--- a/core/propertyfilter.cpp
+++ b/core/propertyfilter.cpp
@@ -50,7 +50,7 @@ GammaRay::PropertyFilter::PropertyFilter(
 
 GammaRay::PropertyFilter GammaRay::PropertyFilter::classAndPropertyName(QString className, QString propertyName)
 {
-    return PropertyFilter { className, propertyName };
+    return PropertyFilter(className, propertyName);
 }
 
 bool GammaRay::PropertyFilter::matches(const GammaRay::PropertyData& prop) const

--- a/core/propertyfilter.cpp
+++ b/core/propertyfilter.cpp
@@ -1,0 +1,87 @@
+/*
+  propertyfilter.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2015-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreukamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "propertyfilter.h"
+#include <QVector>
+
+using namespace GammaRay;
+
+Q_GLOBAL_STATIC(QVector<PropertyFilter>, s_propertyFilters)
+
+GammaRay::PropertyFilter::PropertyFilter(
+        QString className,
+        QString name,
+        QString typeName,
+        PropertyData::AccessFlags accessFlags,
+        PropertyModel::PropertyFlags propertyFlags
+    )
+    : m_name(name)
+    , m_typeName(typeName)
+    , m_className(className)
+    , m_accessFlags(accessFlags)
+    , m_propertyFlags(propertyFlags)
+{
+}
+
+GammaRay::PropertyFilter GammaRay::PropertyFilter::classAndPropertyName(QString className, QString propertyName)
+{
+    return PropertyFilter { className, propertyName };
+}
+
+bool GammaRay::PropertyFilter::matches(const GammaRay::PropertyData& prop) const
+{
+    if (!m_className.isEmpty() && prop.className() != m_className) {
+        return false;
+    }
+    if (!m_name.isEmpty() && prop.name() != m_name) {
+        return false;
+    }
+    if (!m_typeName.isEmpty() && prop.typeName() != m_typeName) {
+        return false;
+    }
+    if (m_accessFlags && (prop.accessFlags() & m_accessFlags) == m_accessFlags) {
+        return false;
+    }
+    if (m_propertyFlags && (prop.propertyFlags() & m_propertyFlags) == m_propertyFlags) {
+        return false;
+    }
+    return true;
+}
+
+bool GammaRay::PropertyFilters::matches(const GammaRay::PropertyData& prop)
+{
+    return std::any_of(s_propertyFilters()->begin(), s_propertyFilters()->end(), [&prop](const PropertyFilter &filter) { return filter.matches(prop); });
+}
+
+
+void PropertyFilters::registerFilter(const PropertyFilter& filter)
+{
+    s_propertyFilters()->push_back(filter);
+}
+
+

--- a/core/propertyfilter.h
+++ b/core/propertyfilter.h
@@ -1,0 +1,84 @@
+/*
+  propertyfilter.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2015-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROPERTYFILTER_H
+#define GAMMARAY_PROPERTYFILTER_H
+
+#include "gammaray_core_export.h"
+#include "propertydata.h"
+
+#include <QFlags>
+#include <QString>
+#include <QVariant>
+
+namespace GammaRay {
+class GAMMARAY_CORE_EXPORT PropertyFilter
+{
+public:
+    explicit PropertyFilter() = default;
+    explicit PropertyFilter(
+        QString className,
+        QString name,
+        QString typeName = {},
+        PropertyData::AccessFlags accessFlags = {},
+        PropertyModel::PropertyFlags propertyFlags = {}
+    );
+    static PropertyFilter classAndPropertyName(QString className, QString propertyName);
+
+    bool matches(const PropertyData &prop) const;
+
+private:
+
+    QString m_name;
+    QString m_typeName;
+    QString m_className;
+    PropertyData::AccessFlags m_accessFlags;
+    PropertyModel::PropertyFlags m_propertyFlags;
+};
+
+namespace PropertyFilters
+{
+    GAMMARAY_CORE_EXPORT bool matches(const PropertyData &prop);
+
+    /**
+    * Register a filter to remove properties from the property view. Property
+    * adaptors are free to consider or ignore filters.
+    *
+    * Use cases are e.g.:
+    * * Removing a QMetaProperty in order to re-add it from a custom adaptor
+    * * Prohibiting a property getter to be called, if it's known to crash the
+    *   application under certain circumstances (e.g. if a getter requires an
+    *   OpenGL context to be valid)
+    */
+    GAMMARAY_CORE_EXPORT void registerFilter(const PropertyFilter &filter);
+}
+
+
+}
+
+#endif // GAMMARAY_PROPERTYFILTER_H

--- a/core/propertyfilter.h
+++ b/core/propertyfilter.h
@@ -40,13 +40,13 @@ namespace GammaRay {
 class GAMMARAY_CORE_EXPORT PropertyFilter
 {
 public:
-    explicit PropertyFilter() = default;
+    explicit PropertyFilter() {}
     explicit PropertyFilter(
         QString className,
         QString name,
-        QString typeName = {},
-        PropertyData::AccessFlags accessFlags = {},
-        PropertyModel::PropertyFlags propertyFlags = {}
+        QString typeName = QString(),
+        PropertyData::AccessFlags accessFlags = nullptr,
+        PropertyModel::PropertyFlags propertyFlags = nullptr
     );
     static PropertyFilter classAndPropertyName(QString className, QString propertyName);
 

--- a/core/qmetapropertyadaptor.h
+++ b/core/qmetapropertyadaptor.h
@@ -51,12 +51,14 @@ protected:
 
 private:
     QString detailString(const QMetaProperty &prop) const;
+    PropertyData propertyMetaData(int index) const;
 
 private slots:
     void propertyUpdated();
 
 private:
     QHash<int, int> m_notifyToPropertyMap;
+    QVector<int> m_rowToPropertyIndex;
     mutable bool m_notifyGuard;
 };
 }

--- a/core/qmetapropertyadaptor.h
+++ b/core/qmetapropertyadaptor.h
@@ -57,7 +57,7 @@ private slots:
     void propertyUpdated();
 
 private:
-    QHash<int, int> m_notifyToPropertyMap;
+    QHash<int, int> m_notifyToRowMap;
     QVector<int> m_rowToPropertyIndex;
     mutable bool m_notifyGuard;
 };

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -15,6 +15,8 @@ if(Qt5Quick_FOUND)
   if (NOT GAMMARAY_CLIENT_ONLY_BUILD)
   set(gammaray_quickinspector_srcs
     quickinspector.cpp
+
+    quickanchorspropertyadaptor.cpp
     quickitemmodel.cpp
     quickscenegraphmodel.cpp
     quickpaintanalyzerextension.cpp

--- a/plugins/quickinspector/quickanchorspropertyadaptor.cpp
+++ b/plugins/quickinspector/quickanchorspropertyadaptor.cpp
@@ -39,6 +39,8 @@ using namespace GammaRay;
 
 QuickAnchorsPropertyAdaptor::QuickAnchorsPropertyAdaptor(QObject *parent)
     : PropertyAdaptor(parent)
+    , m_anchorsPropertyIndex(-1)
+    , m_notifyGuard(false)
 {
 }
 

--- a/plugins/quickinspector/quickanchorspropertyadaptor.cpp
+++ b/plugins/quickinspector/quickanchorspropertyadaptor.cpp
@@ -1,0 +1,159 @@
+/*
+  quickanchorspropertyadaptor.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "quickanchorspropertyadaptor.h"
+
+#include <core/propertydata.h>
+#include <core/util.h>
+
+#include <private/qquickitem_p.h>
+
+#include <QDebug>
+
+using namespace GammaRay;
+
+QuickAnchorsPropertyAdaptor::QuickAnchorsPropertyAdaptor(QObject *parent)
+    : PropertyAdaptor(parent)
+{
+}
+
+QuickAnchorsPropertyAdaptor::~QuickAnchorsPropertyAdaptor()
+{
+}
+
+void QuickAnchorsPropertyAdaptor::doSetObject(const ObjectInstance &oi)
+{
+    m_anchorsPropertyIndex = -1;
+    auto mo = oi.metaObject();
+    if (!mo || oi.type() != ObjectInstance::QtObject || !oi.qtObject())
+        return;
+
+    int propertyIndex = mo->indexOfProperty("anchors");
+    if (propertyIndex == -1)
+        return;
+
+    const auto prop = mo->property(propertyIndex);
+    if (QString::compare(prop.typeName(), "QQuickAnchors*") != 0)
+        return;
+
+    m_anchorsPropertyIndex = propertyIndex;
+
+}
+
+int QuickAnchorsPropertyAdaptor::count() const
+{
+    if (!object().isValid())
+        return 0;
+
+    return m_anchorsPropertyIndex == -1 ? 0 : 1;
+}
+
+PropertyData QuickAnchorsPropertyAdaptor::propertyData(int index) const
+{
+    Q_ASSERT(index == 0);
+
+    PropertyData data;
+    if (!object().isValid())
+        return data;
+
+    m_notifyGuard = true;
+    const auto mo = object().metaObject();
+    Q_ASSERT(mo);
+
+    const auto prop = mo->property(m_anchorsPropertyIndex);
+
+    data.setName(prop.name());
+    data.setTypeName(prop.typeName());
+
+    auto pmo = mo;
+    while (pmo->propertyOffset() > m_anchorsPropertyIndex)
+        pmo = pmo->superClass();
+    data.setClassName(pmo->className());
+
+    data.setValue(QVariant::fromValue(QQuickItemPrivate::get(qobject_cast<QQuickItem*>(object().qtObject()))->_anchors));
+
+    PropertyModel::PropertyFlags f(PropertyModel::None);
+    if (prop.isConstant())
+        f |= PropertyModel::Constant;
+    if (prop.isDesignable(object().qtObject()))
+        f |= PropertyModel::Designable;
+    if (prop.isFinal())
+        f |= PropertyModel::Final;
+    if (prop.isResettable())
+        f |= PropertyModel::Resetable;
+    if (prop.isScriptable(object().qtObject()))
+        f |= PropertyModel::Scriptable;
+    if (prop.isStored(object().qtObject()))
+        f |= PropertyModel::Stored;
+    if (prop.isUser(object().qtObject()))
+        f |= PropertyModel::User;
+    if (prop.isWritable())
+        f |= PropertyModel::Writable;
+    data.setPropertyFlags(f);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 1, 0)
+    data.setRevision(prop.revision());
+#endif
+    if (prop.hasNotifySignal())
+        data.setNotifySignal(Util::prettyMethodSignature(prop.notifySignal()));
+
+    PropertyData::AccessFlags flags = PropertyData::Readable;
+    if (prop.isWritable())
+        flags |= PropertyData::Writable;
+    if (prop.isResettable())
+        flags |= PropertyData::Resettable;
+    data.setAccessFlags(flags);
+
+    m_notifyGuard = false;
+    return data;
+}
+
+void QuickAnchorsPropertyAdaptor::writeProperty(int index, const QVariant &value)
+{
+    Q_ASSERT(index == 0);
+}
+
+QuickAnchorsPropertyAdaptorFactory *QuickAnchorsPropertyAdaptorFactory::s_instance = nullptr;
+
+PropertyAdaptor *QuickAnchorsPropertyAdaptorFactory::create(const ObjectInstance &oi,
+                                                          QObject *parent) const
+{
+    if (oi.type() != ObjectInstance::QtObject || !oi.qtObject())
+        return nullptr;
+
+    if (qobject_cast<QQuickItem *>(oi.qtObject()))
+        return new QuickAnchorsPropertyAdaptor(parent);
+
+    return nullptr;
+}
+
+QuickAnchorsPropertyAdaptorFactory *QuickAnchorsPropertyAdaptorFactory::instance()
+{
+    if (!s_instance)
+        s_instance = new QuickAnchorsPropertyAdaptorFactory;
+    return s_instance;
+}

--- a/plugins/quickinspector/quickanchorspropertyadaptor.h
+++ b/plugins/quickinspector/quickanchorspropertyadaptor.h
@@ -50,7 +50,7 @@ protected:
     void doSetObject(const ObjectInstance &oi) override;
 
 private:
-    int m_anchorsPropertyIndex = -1;
+    int m_anchorsPropertyIndex;
     mutable bool m_notifyGuard;
 };
 

--- a/plugins/quickinspector/quickanchorspropertyadaptor.h
+++ b/plugins/quickinspector/quickanchorspropertyadaptor.h
@@ -1,0 +1,67 @@
+/*
+  quickanchorspropertyadaptor.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_QUICKANCHORSPROPERTYADAPTOR_H
+#define GAMMARAY_QUICKANCHORSPROPERTYADAPTOR_H
+
+#include <core/propertyadaptor.h>
+#include <core/propertyadaptorfactory.h>
+
+#include <QVector>
+
+namespace GammaRay {
+class QuickAnchorsPropertyAdaptor : public PropertyAdaptor
+{
+    Q_OBJECT
+public:
+    explicit QuickAnchorsPropertyAdaptor(QObject *parent = nullptr);
+    ~QuickAnchorsPropertyAdaptor();
+
+    int count() const override;
+    PropertyData propertyData(int index) const override;
+    void writeProperty(int index, const QVariant &value) override;
+
+protected:
+    void doSetObject(const ObjectInstance &oi) override;
+
+private:
+    int m_anchorsPropertyIndex = -1;
+    mutable bool m_notifyGuard;
+};
+
+class QuickAnchorsPropertyAdaptorFactory : public AbstractPropertyAdaptorFactory
+{
+public:
+    PropertyAdaptor *create(const ObjectInstance &oi, QObject *parent = nullptr) const override;
+    static QuickAnchorsPropertyAdaptorFactory *instance();
+private:
+    static QuickAnchorsPropertyAdaptorFactory *s_instance;
+};
+}
+
+#endif

--- a/plugins/quickinspector/quickimplicitbindingdependencyprovider.cpp
+++ b/plugins/quickinspector/quickimplicitbindingdependencyprovider.cpp
@@ -72,7 +72,7 @@ std::vector<std::unique_ptr<BindingNode>> QuickImplicitBindingDependencyProvider
         QQuickItemPrivate *itemPriv = QQuickItemPrivate::get(item);
         if (!itemPriv)
             return bindings;
-        QQuickAnchors *anchors = itemPriv->anchors();
+        QQuickAnchors *anchors = itemPriv->_anchors;
         if (!anchors)
             return bindings;
 
@@ -177,12 +177,10 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
     QQuickItemPrivate *itemPriv = QQuickItemPrivate::get(item);
     if (!itemPriv)
         return;
-    QQuickAnchors *anchors = itemPriv->anchors();
-    if (!anchors)
-        return;
+    QQuickAnchors *anchors = itemPriv->_anchors;
 
     // Horizontal
-    if (anchors->fill()) {
+    if (anchors && anchors->fill()) {
         QQuickItem *fill = anchors->fill();
         addDependency("width", fill, "width");
         addDependency("width", item, "anchors.leftMargin");
@@ -195,7 +193,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
         addDependency("right", item, "anchors.rightMargin");
         addDependency("horizontalCenter", item, "left");
         addDependency("horizontalCenter", item, "right");
-    } else if (anchors->centerIn()) {
+    } else if (anchors && anchors->centerIn()) {
         QQuickItem *centerIn = anchors->centerIn();
         addDependency("horizontalCenter", centerIn, "horizontalCenter");
         addDependency("x", centerIn, "horizontalCenter");
@@ -204,7 +202,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
         addDependency("left", item, "width");
         addDependency("right", centerIn, "horizontalCenter");
         addDependency("right", item, "width");
-    } else if (anchors->left().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->left().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("left", item, "anchors.left");
         addDependency("x", item, "anchors.left");
         if (anchors->right().anchorLine != QQuickAnchors::InvalidAnchor) {
@@ -226,7 +224,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
             addDependency("horizontalCenter", item, "anchors.left");
             addDependency("horizontalCenter", item, "width");
         }
-    } else if (anchors->right().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->right().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("right", item, "anchors.right");
         if (anchors->horizontalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
             addDependency("horizontalCenter", item, "anchors.horizontalCenter");
@@ -244,7 +242,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
             addDependency("horizontalCenter", item, "anchors.right");
             addDependency("horizontalCenter", item, "width");
         }
-    } else if (anchors->horizontalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->horizontalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("horizontalCenter", item, "anchors.horizontalCenter");
         addDependency("x", item, "anchors.horizontalCenter");
         addDependency("x", item, "width");
@@ -262,7 +260,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
 
 
     // Vertical TODO: Bottomline
-    if (anchors->fill()) {
+    if (anchors && anchors->fill()) {
         QQuickItem *fill = anchors->fill();
         addDependency("height", fill, "height");
         addDependency("height", item, "anchors.topMargin");
@@ -275,7 +273,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
         addDependency("bottom", item, "anchors.bottomMargin");
         addDependency("verticalCenter", item, "top");
         addDependency("verticalCenter", item, "bottom");
-    } else if (anchors->centerIn()) {
+    } else if (anchors && anchors->centerIn()) {
         QQuickItem *centerIn = anchors->centerIn();
         addDependency("verticalCenter", centerIn, "verticalCenter");
         addDependency("y", centerIn, "verticalCenter");
@@ -284,7 +282,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
         addDependency("top", item, "height");
         addDependency("bottom", centerIn, "verticalCenter");
         addDependency("bottom", item, "height");
-    } else if (anchors->top().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->top().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("top", item, "anchors.top");
         addDependency("y", item, "anchors.top");
         if (anchors->bottom().anchorLine != QQuickAnchors::InvalidAnchor) {
@@ -307,7 +305,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
             addDependency("verticalCenter", item, "anchors.top");
             addDependency("verticalCenter", item, "height");
         }
-    } else if (anchors->bottom().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->bottom().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("bottom", item, "anchors.bottom");
         if (anchors->verticalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
             addDependency("verticalCenter", item, "anchors.verticalCenter");
@@ -325,7 +323,7 @@ void QuickImplicitBindingDependencyProvider::anchoringDependencies(QQuickItem *i
             addDependency("verticalCenter", item, "anchors.bottom");
             addDependency("verticalCenter", item, "height");
         }
-    } else if (anchors->verticalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
+    } else if (anchors && anchors->verticalCenter().anchorLine != QQuickAnchors::InvalidAnchor) {
         addDependency("verticalCenter", item, "anchors.verticalCenter");
         addDependency("y", item, "anchors.verticalCenter");
         addDependency("y", item, "height");

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -27,6 +27,8 @@
 */
 
 #include "quickinspector.h"
+
+#include "quickanchorspropertyadaptor.h"
 #include "quickitemmodel.h"
 #include "quickscenegraphmodel.h"
 #include "quickscreengrabber.h"
@@ -54,6 +56,7 @@
 #include <core/objecttypefilterproxymodel.h>
 #include <core/probeguard.h>
 #include <core/propertycontroller.h>
+#include <core/propertyfilter.h>
 #include <core/remote/server.h>
 #include <core/remote/serverproxymodel.h>
 #include <core/singlecolumnobjectproxymodel.h>
@@ -1158,6 +1161,8 @@ void QuickInspector::registerPCExtensions()
     PropertyController::registerExtension<TextureExtension>();
 
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
+    PropertyAdaptorFactory::registerFactory(QuickAnchorsPropertyAdaptorFactory::instance());
+    PropertyFilters::registerFilter(PropertyFilter {"QQuickAnchors", "anchors"});
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     BindingModel::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -1162,7 +1162,7 @@ void QuickInspector::registerPCExtensions()
 
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
     PropertyAdaptorFactory::registerFactory(QuickAnchorsPropertyAdaptorFactory::instance());
-    PropertyFilters::registerFilter(PropertyFilter {"QQuickAnchors", "anchors"});
+    PropertyFilters::registerFilter(PropertyFilter("QQuickAnchors", "anchors"));
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     BindingModel::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -1162,7 +1162,7 @@ void QuickInspector::registerPCExtensions()
 
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
     PropertyAdaptorFactory::registerFactory(QuickAnchorsPropertyAdaptorFactory::instance());
-    PropertyFilters::registerFilter(PropertyFilter("QQuickAnchors", "anchors"));
+    PropertyFilters::registerFilter(PropertyFilter("QQuickItem", "anchors"));
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     BindingModel::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));

--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -67,7 +67,6 @@ public:
     explicit QQuickItemPropertyCache(const QMetaObject *meta)
         : background(property(meta, "background"))
         , contentItem(property(meta, "contentItem"))
-        , anchors(property(meta, "anchors"))
         , padding(property(meta, "padding"))
     {
         if (padding.isValid()) {
@@ -80,7 +79,6 @@ public:
 
     QMetaProperty background;
     QMetaProperty contentItem;
-    QMetaProperty anchors;
     QMetaProperty padding;
     QMetaProperty leftPadding;
     QMetaProperty rightPadding;
@@ -390,7 +388,8 @@ QuickItemGeometry AbstractScreenGrabber::initFromItem(QQuickItem *item)
         itemGeometry.contentItemRect = contentItem->mapRectToScene(contentItem->boundingRect());
     itemGeometry.transformOriginPoint = item->mapToScene(item->transformOriginPoint());
 
-    QQuickAnchors *anchors = cache.anchors.read(item).value<QQuickAnchors *>();
+    QQuickItemPrivate *itemPriv = QQuickItemPrivate::get(item);
+    QQuickAnchors *anchors = itemPriv->_anchors;
 
     if (anchors) {
         QQuickAnchors::Anchors usedAnchors = anchors->usedAnchors();
@@ -429,7 +428,6 @@ QuickItemGeometry AbstractScreenGrabber::initFromItem(QQuickItem *item)
         itemGeometry.bottomPadding = qQNaN();
     }
 
-    QQuickItemPrivate *itemPriv = QQuickItemPrivate::get(item);
     itemGeometry.transform = itemPriv->itemToWindowTransform();
     if (parent) {
         QQuickItemPrivate *parentPriv = QQuickItemPrivate::get(parent);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -446,6 +446,7 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD AND Qt5Core_FOUND AND NOT Qt5Core_VERSION_MINO
       quickinspectortest.qrc
         $<TARGET_OBJECTS:modeltestobj>
     )
+    target_include_directories(quickinspectortest SYSTEM PRIVATE ${Qt5Quick_PRIVATE_INCLUDE_DIRS})
     target_link_libraries(quickinspectortest gammaray_core gammaray_quickinspector_shared Qt5::Quick)
 
     gammaray_add_quick_test(quickinspectortest2

--- a/tests/manual/anchorspropertyfiltertest.qml
+++ b/tests/manual/anchorspropertyfiltertest.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.0
+
+Rectangle {
+    id: root
+    objectName: "AnchorsPropertyFilterTest"
+    color: "lightsteelblue"
+    width: 200; height: 100
+
+    Rectangle {
+        id: left
+        objectName: "rectWithoutAnchors"
+        width: 50; height: 50
+        x: 25; y: 25
+        color: "red"
+    }
+
+    Rectangle {
+        id: right
+        objectName: "rectWithAnchors"
+        width: 50; height: 50
+       anchors.verticalCenter: parent.verticalCenter
+       anchors.right: parent.right
+       anchors.rightMargin: 25
+//         x: 125; y: 25
+        color: "yellow"
+    }
+
+}

--- a/tests/quickinspectortest.cpp
+++ b/tests/quickinspectortest.cpp
@@ -28,10 +28,12 @@
 #include "testhelpers.h"
 
 #include <plugins/quickinspector/quickinspectorinterface.h>
-#include <core/toolmanager.h>
 #include <common/objectbroker.h>
 #include <common/remoteviewinterface.h>
 #include <common/remoteviewframe.h>
+#include <core/propertydata.h>
+#include <core/propertyfilter.h>
+#include <core/toolmanager.h>
 
 #include <3rdparty/qt/modeltest.h>
 
@@ -276,6 +278,14 @@ private slots:
 
     void testAnchorsPropertyFilter()
     {
+        PropertyData testData;
+        testData.setName("something");
+        testData.setClassName("QQuickItem");
+        testData.setTypeName("QQuickAnchors");
+        QVERIFY(!PropertyFilters::matches(testData));
+        testData.setName("anchors");
+        QVERIFY(PropertyFilters::matches(testData));
+
         QVERIFY(showSource(QStringLiteral("qrc:/manual/anchorspropertyfiltertest.qml")));
 
         auto rectWithoutAnchors = view()->rootObject()->findChild<QQuickItem*>("rectWithoutAnchors");

--- a/tests/quickinspectortest.qrc
+++ b/tests/quickinspectortest.qrc
@@ -6,6 +6,7 @@
         <file>manual/lsd.png</file>
         <file>manual/rotationinvariant.qml</file>
         <file>manual/shadereffect.qml</file>
+        <file>manual/anchorspropertyfiltertest.qml</file>
         <file>manual/picking/invisibleoverlay.qml</file>
         <file>manual/picking/negativezordering.qml</file>
         <file>manual/picking/opacityzerooverlay.qml</file>


### PR DESCRIPTION
Adds the filtering infrastructure, Filters for anchors and a anchors-property adaptor to add the anchors the way, QtQuick wants us to.

This is the first step to implement the new censorship infrastructure required by the new EU copyright regulation.