### PR TITLE
Problem reporter

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -82,6 +82,7 @@ set(gammaray_common_internal_srcs
   tools/objectinspector/connectionsextensioninterface.cpp
   tools/messagehandler/messagehandlerinterface.cpp
   tools/metatypebrowser/metatypebrowserinterface.cpp
+  tools/problemreporter/problemreporterinterface.cpp
   tools/resourcebrowser/resourcebrowserinterface.cpp
 )
 

--- a/common/metatypedeclarations.h
+++ b/common/metatypedeclarations.h
@@ -101,8 +101,4 @@ Q_DECLARE_METATYPE(QSurfaceFormat)
 Q_DECLARE_METATYPE(Qt::ApplicationState)
 #endif
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
-Q_DECLARE_METATYPE(Qt::CheckState)
-#endif
-
 #endif

--- a/common/metatypedeclarations.h
+++ b/common/metatypedeclarations.h
@@ -101,4 +101,8 @@ Q_DECLARE_METATYPE(QSurfaceFormat)
 Q_DECLARE_METATYPE(Qt::ApplicationState)
 #endif
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
+Q_DECLARE_METATYPE(Qt::CheckState)
+#endif
+
 #endif

--- a/common/problem.h
+++ b/common/problem.h
@@ -63,7 +63,7 @@ struct Problem {
     Severity severity;
     ObjectId object;
     QString description;
-    SourceLocation location;
+    QVector<SourceLocation> locations;
     QString reportingTool; ///< Tool which reported the issue
     QString problemId; ///< tool-specific unique id for the problem
     FindingCategory findingCategory;

--- a/common/problem.h
+++ b/common/problem.h
@@ -1,0 +1,70 @@
+/*
+  problem.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROBLEM_H
+#define GAMMARAY_PROBLEM_H
+
+// Own
+#include "objectid.h"
+#include "common/sourcelocation.h"
+
+// Qt
+#include <QAbstractItemModel>
+
+// Std
+#include <memory>
+#include <vector>
+
+namespace GammaRay {
+
+struct Problem {
+    enum Severity {
+        Info = 1,
+        Warning,
+        Error
+    };
+
+    Severity severity;
+    ObjectId object;
+    QString description;
+    SourceLocation location;
+    QString reportingTool; ///< Tool which reported the issue
+    QString problemId; ///< tool-specific unique id for the problem
+
+    bool operator==(const Problem &other) const
+    {
+        return problemId == other.problemId;
+    }
+};
+
+}
+
+Q_DECLARE_METATYPE(GammaRay::Problem::Severity)
+
+#endif // GAMMARAY_PROBLEM_H
+

--- a/common/problem.h
+++ b/common/problem.h
@@ -50,9 +50,9 @@ struct Problem {
     };
     enum FindingCategory {
         Unknown,
-        Opportunistic,
-        Scan,
-        Permanent
+        Live, ///< is added and removed as the problem arises/vanishes by the reporting tool
+        Scan, ///< is added in response to a scan request and removed by the problem collector in advance to the next scan
+        Permanent ///< is valid during the whole application lifetime and not meant to be removed at all
     };
 
     Problem()

--- a/common/problem.h
+++ b/common/problem.h
@@ -48,6 +48,17 @@ struct Problem {
         Warning,
         Error
     };
+    enum FindingCategory {
+        Unknown,
+        Opportunistic,
+        Scan,
+        Permanent
+    };
+
+    Problem()
+        : severity(Error)
+        , findingCategory(Unknown)
+    {}
 
     Severity severity;
     ObjectId object;
@@ -55,6 +66,7 @@ struct Problem {
     SourceLocation location;
     QString reportingTool; ///< Tool which reported the issue
     QString problemId; ///< tool-specific unique id for the problem
+    FindingCategory findingCategory;
 
     bool operator==(const Problem &other) const
     {

--- a/common/sourcelocation.cpp
+++ b/common/sourcelocation.cpp
@@ -64,6 +64,11 @@ GammaRay::SourceLocation GammaRay::SourceLocation::fromOneBased(const QUrl& url,
     return SourceLocation(url, line - 1, column - 1);
 }
 
+bool SourceLocation::operator==(const SourceLocation &other) const
+{
+    return m_url == other.m_url && m_line == other.m_line && m_column == other.m_column;
+}
+
 bool SourceLocation::isValid() const
 {
     return m_url.isValid();

--- a/common/sourcelocation.h
+++ b/common/sourcelocation.h
@@ -34,6 +34,7 @@
 #include <QMetaType>
 #include <QDataStream>
 #include <QUrl>
+#include <QVector>
 
 namespace GammaRay {
 /*!
@@ -60,6 +61,8 @@ public:
     ~SourceLocation();
     static SourceLocation fromZeroBased(const QUrl &url, int line, int column = 0);
     static SourceLocation fromOneBased(const QUrl &url, int line, int column = 1);
+
+    bool operator==(const SourceLocation &other) const;
 
     bool isValid() const;
 
@@ -117,5 +120,6 @@ GAMMARAY_COMMON_EXPORT QDataStream &operator>>(QDataStream &in, SourceLocation &
 }
 
 Q_DECLARE_METATYPE(GammaRay::SourceLocation)
+Q_DECLARE_METATYPE(QVector<GammaRay::SourceLocation>)
 
 #endif // GAMMARAY_SOURCELOCATION_H

--- a/common/streamoperators.cpp
+++ b/common/streamoperators.cpp
@@ -71,6 +71,7 @@ void StreamOperators::registerOperators()
 
     qRegisterMetaTypeStreamOperators<GammaRay::VariantWrapper>();
     qRegisterMetaTypeStreamOperators<GammaRay::SourceLocation>();
+    qRegisterMetaTypeStreamOperators<QVector<SourceLocation>>();
     qRegisterMetaTypeStreamOperators<GammaRay::QMetaObjectValidatorResult::Results>();
     qRegisterMetaTypeStreamOperators<GammaRay::PropertyModel::PropertyFlags>();
 

--- a/common/tools/problemreporter/problemmodelroles.h
+++ b/common/tools/problemreporter/problemmodelroles.h
@@ -36,7 +36,8 @@ namespace ProblemModelRoles {
 
 enum Roles {
     SeverityRole = ObjectModel::UserRole + 1,
-    SourceLocationRole
+    SourceLocationRole,
+    ProblemIdRole
 };
 
 }

--- a/common/tools/problemreporter/problemmodelroles.h
+++ b/common/tools/problemreporter/problemmodelroles.h
@@ -1,0 +1,45 @@
+/*
+  problemmodelroles.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROBLEMMODELROLES_H
+#define GAMMARAY_PROBLEMMODELROLES_H
+
+#include <common/objectmodel.h>
+
+namespace GammaRay {
+namespace ProblemModelRoles {
+
+enum Roles {
+    SeverityRole = ObjectModel::UserRole + 1,
+    SourceLocationRole
+};
+
+}
+}
+
+#endif

--- a/common/tools/problemreporter/problemreporterinterface.cpp
+++ b/common/tools/problemreporter/problemreporterinterface.cpp
@@ -1,5 +1,5 @@
 /*
-  problemcollector.h
+  problemreporterinterface.cpp
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -26,56 +26,18 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBLEMCOLLECTOR_H
-#define GAMMARAY_PROBLEMCOLLECTOR_H
+#include "problemreporterinterface.h"
 
-// Own
-#include "gammaray_core_export.h"
+#include <common/objectbroker.h>
 
-#include <common/problem.h>
-#include <common/objectid.h>
-#include <common/sourcelocation.h>
+using namespace GammaRay;
 
-// Qt
-#include <QAbstractItemModel>
-
-// Std
-#include <memory>
-#include <vector>
-
-namespace GammaRay {
-
-class ProblemModel;
-
-class GAMMARAY_CORE_EXPORT ProblemCollector : public QObject
+ProblemReporterInterface::ProblemReporterInterface(QObject* parent)
+    : QObject(parent)
 {
-    Q_OBJECT
-
-public:
-    static void addProblem(const Problem &problem);
-    static void removeProblem(const QString &problemId);
-    static ProblemCollector *instance();
-
-    const QVector<Problem> &problems();
-
-signals:
-    void aboutToAddProblem(int row);
-    void problemAdded();
-    void aboutToRemoveProblems(int first, int count = 1);
-    void problemsRemoved();
-    void problemScanRequested();
-
-public slots:
-    void requestScan();
-
-private:
-    explicit ProblemCollector(QObject *parent);
-
-    QVector<Problem> m_problems;
-
-    friend class Probe;
-};
+    ObjectBroker::registerObject<ProblemReporterInterface*>(this);
 }
 
-#endif // GAMMARAY_PROBLEMCOLLECTOR_H
-
+ProblemReporterInterface::~ProblemReporterInterface()
+{
+}

--- a/common/tools/problemreporter/problemreporterinterface.h
+++ b/common/tools/problemreporter/problemreporterinterface.h
@@ -41,6 +41,9 @@ public:
     explicit ProblemReporterInterface(QObject *parent = nullptr);
     virtual ~ProblemReporterInterface();
 
+signals:
+    void problemScansFinished();
+
 public slots:
     virtual void requestScan() = 0;
 };

--- a/common/tools/problemreporter/problemreporterinterface.h
+++ b/common/tools/problemreporter/problemreporterinterface.h
@@ -39,7 +39,7 @@ class ProblemReporterInterface : public QObject
     Q_OBJECT
 public:
     explicit ProblemReporterInterface(QObject *parent = nullptr);
-    ~ProblemReporterInterface();
+    virtual ~ProblemReporterInterface();
 
 public slots:
     virtual void requestScan() = 0;

--- a/common/tools/problemreporter/problemreporterinterface.h
+++ b/common/tools/problemreporter/problemreporterinterface.h
@@ -1,5 +1,5 @@
 /*
-  problemcollector.h
+  problemreporterinterface.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -26,56 +26,28 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBLEMCOLLECTOR_H
-#define GAMMARAY_PROBLEMCOLLECTOR_H
+#ifndef GAMMARAY_PROBLEMREPORTERINTERFACE_H
+#define GAMMARAY_PROBLEMREPORTERINTERFACE_H
 
-// Own
-#include "gammaray_core_export.h"
-
-#include <common/problem.h>
-#include <common/objectid.h>
-#include <common/sourcelocation.h>
-
-// Qt
-#include <QAbstractItemModel>
-
-// Std
-#include <memory>
-#include <vector>
+#include <QObject>
 
 namespace GammaRay {
 
-class ProblemModel;
-
-class GAMMARAY_CORE_EXPORT ProblemCollector : public QObject
+/*! communication interface for the problem reporter tool. */
+class ProblemReporterInterface : public QObject
 {
     Q_OBJECT
-
 public:
-    static void addProblem(const Problem &problem);
-    static void removeProblem(const QString &problemId);
-    static ProblemCollector *instance();
-
-    const QVector<Problem> &problems();
-
-signals:
-    void aboutToAddProblem(int row);
-    void problemAdded();
-    void aboutToRemoveProblems(int first, int count = 1);
-    void problemsRemoved();
-    void problemScanRequested();
+    explicit ProblemReporterInterface(QObject *parent = nullptr);
+    ~ProblemReporterInterface();
 
 public slots:
-    void requestScan();
-
-private:
-    explicit ProblemCollector(QObject *parent);
-
-    QVector<Problem> m_problems;
-
-    friend class Probe;
+    virtual void requestScan() = 0;
 };
 }
 
-#endif // GAMMARAY_PROBLEMCOLLECTOR_H
+QT_BEGIN_NAMESPACE
+Q_DECLARE_INTERFACE(GammaRay::ProblemReporterInterface, "com.kdab.GammaRay.ProblemReporterInterface")
+QT_END_NAMESPACE
 
+#endif // GAMMARAY_PROBLEMREPORTERINTERFACE_H

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -79,6 +79,7 @@ set(gammaray_srcs
   tools/objectinspector/bindingextension.cpp
   tools/objectinspector/bindingmodel.cpp
   tools/objectinspector/stacktraceextension.cpp
+  tools/problemreporter/availablecheckersmodel.cpp
   tools/problemreporter/problemmodel.cpp
   tools/problemreporter/problemreporter.cpp
   tools/resourcebrowser/resourcebrowser.cpp

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,6 +18,7 @@ set(gammaray_srcs
   objectenummodel.cpp
   objecttreemodel.cpp
   objecttypefilterproxymodel.cpp
+  problemcollector.cpp
   methodargumentmodel.cpp
   multisignalmapper.cpp
   signalspycallbackset.cpp
@@ -77,6 +78,8 @@ set(gammaray_srcs
   tools/objectinspector/bindingextension.cpp
   tools/objectinspector/bindingmodel.cpp
   tools/objectinspector/stacktraceextension.cpp
+  tools/problemreporter/problemmodel.cpp
+  tools/problemreporter/problemreporter.cpp
   tools/resourcebrowser/resourcebrowser.cpp
   tools/resourcebrowser/resourcefiltermodel.cpp
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,7 @@ set(gammaray_srcs
 
   abstractbindingprovider.cpp
   aggregatedpropertymodel.cpp
+  bindingaggregator.cpp
   bindingnode.cpp
   metaobject.cpp
   metaobjectregistry.cpp

--- a/core/bindingaggregator.cpp
+++ b/core/bindingaggregator.cpp
@@ -1,0 +1,132 @@
+/*
+  bindingaggregator.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2017-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Authors: Volker Krause <volker.krause@kdab.com>
+           Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Own
+#include "bindingaggregator.h"
+
+#include <core/abstractbindingprovider.h>
+#include <core/bindingnode.h>
+#include <core/objectdataprovider.h>
+#include <core/probe.h>
+#include <core/problemcollector.h>
+#include <core/propertycontroller.h>
+#include <common/objectbroker.h>
+
+// Qt
+#include <QMetaProperty>
+#include <QMetaObject>
+
+using namespace GammaRay;
+
+static std::vector<std::unique_ptr<AbstractBindingProvider>> s_providers;
+
+void BindingAggregator::registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider)
+{
+    s_providers.push_back(std::move(provider));
+}
+
+bool GammaRay::BindingAggregator::providerAvailableFor(QObject* object)
+{
+    return std::find_if(s_providers.begin(), s_providers.end(),
+                                        [object](const std::unique_ptr<AbstractBindingProvider>& provider) {
+                                            return provider->canProvideBindingsFor(object);
+                                        }) != s_providers.end();
+}
+
+std::vector<std::unique_ptr<BindingNode>> BindingAggregator::findDependenciesFor(BindingNode* node)
+{
+    std::vector<std::unique_ptr<BindingNode>> allDependencies;
+    if (node->isPartOfBindingLoop())
+        return allDependencies;
+
+    for (auto providerIt = s_providers.cbegin(); providerIt != s_providers.cend(); ++providerIt) {
+        auto &&provider = *providerIt;
+        auto providerDependencies = provider->findDependenciesFor(node);
+        for (auto dependencyIt = providerDependencies.begin(); dependencyIt != providerDependencies.end(); ++dependencyIt) {
+            dependencyIt->get()->dependencies() = findDependenciesFor(dependencyIt->get());
+            allDependencies.push_back(std::move(*dependencyIt));
+        }
+    }
+    std::sort(
+        allDependencies.begin(),
+        allDependencies.end(),
+        [](const std::unique_ptr<BindingNode> &a, const std::unique_ptr<BindingNode> &b) {
+            return a->object() < b->object() || (a->object() == b->object() && a->propertyIndex() < b->propertyIndex());
+        }
+    );
+    return allDependencies;
+}
+
+std::vector<std::unique_ptr<BindingNode>> BindingAggregator::bindingTreeForObject(QObject* obj)
+{
+    std::vector<std::unique_ptr<BindingNode>> bindings;
+    if (obj) {
+        for (auto providerIt = s_providers.begin(); providerIt != s_providers.cend(); ++providerIt) {
+            auto newBindings = (*providerIt)->findBindingsFor(obj);
+            for (auto nodeIt = newBindings.begin(); nodeIt != newBindings.end(); ++nodeIt) {
+                BindingNode *node = nodeIt->get();
+                if (std::find_if(bindings.begin(), bindings.end(),
+                    [node](const std::unique_ptr<BindingNode> &other){ return *node == *other; }) != bindings.end()) {
+                    continue; // apparantly this is a duplicate.
+                }
+                node->dependencies() = findDependenciesFor(node);
+
+                bindings.push_back(std::move(*nodeIt));
+            }
+
+        }
+    }
+    return bindings;
+}
+
+void BindingAggregator::scanForBindingLoops()
+{
+    ProblemCollector::reportScanStarted();
+
+    const QVector<QObject*> &allObjects = Probe::instance()->allQObjects();
+
+    foreach (QObject *obj, allObjects) {
+        auto bindings = bindingTreeForObject(obj);
+        for (auto it = bindings.begin(); it != bindings.end(); ++it) {
+            auto &&bindingNode = *it;
+            if (bindingNode->isPartOfBindingLoop()) {
+                Problem p;
+                p.severity = Problem::Error;
+                p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(bindingNode->object())).arg(bindingNode->canonicalName());
+                p.object = ObjectId(bindingNode->object());
+                p.location = bindingNode->sourceLocation();
+                p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
+                p.findingCategory = Problem::Scan;
+                ProblemCollector::addProblem(p);
+            }
+        }
+    }
+
+    ProblemCollector::reportScanFinished();
+}

--- a/core/bindingaggregator.cpp
+++ b/core/bindingaggregator.cpp
@@ -108,8 +108,6 @@ std::vector<std::unique_ptr<BindingNode>> BindingAggregator::bindingTreeForObjec
 
 void BindingAggregator::scanForBindingLoops()
 {
-    ProblemCollector::reportScanStarted();
-
     const QVector<QObject*> &allObjects = Probe::instance()->allQObjects();
 
     QMutexLocker lock(Probe::objectLock());
@@ -126,12 +124,10 @@ void BindingAggregator::scanForBindingLoops()
                 p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(bindingNode->object())).arg(bindingNode->canonicalName());
                 p.object = ObjectId(bindingNode->object());
                 p.location = bindingNode->sourceLocation();
-                p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
+                p.problemId = QString("com.kdab.GammaRay.ObjectInspector.BindingLoopScan:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
                 p.findingCategory = Problem::Scan;
                 ProblemCollector::addProblem(p);
             }
         }
     }
-
-    ProblemCollector::reportScanFinished();
 }

--- a/core/bindingaggregator.cpp
+++ b/core/bindingaggregator.cpp
@@ -44,19 +44,19 @@
 
 using namespace GammaRay;
 
-static std::vector<std::unique_ptr<AbstractBindingProvider>> s_providers;
+Q_GLOBAL_STATIC(std::vector<std::unique_ptr<AbstractBindingProvider>>, s_providers)
 
 void BindingAggregator::registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider)
 {
-    s_providers.push_back(std::move(provider));
+    s_providers()->push_back(std::move(provider));
 }
 
 bool GammaRay::BindingAggregator::providerAvailableFor(QObject* object)
 {
-    return std::find_if(s_providers.begin(), s_providers.end(),
+    return std::find_if(s_providers()->begin(), s_providers()->end(),
                                         [object](const std::unique_ptr<AbstractBindingProvider>& provider) {
                                             return provider->canProvideBindingsFor(object);
-                                        }) != s_providers.end();
+                                        }) != s_providers()->end();
 }
 
 std::vector<std::unique_ptr<BindingNode>> BindingAggregator::findDependenciesFor(BindingNode* node)
@@ -65,7 +65,7 @@ std::vector<std::unique_ptr<BindingNode>> BindingAggregator::findDependenciesFor
     if (node->isPartOfBindingLoop())
         return allDependencies;
 
-    for (auto providerIt = s_providers.cbegin(); providerIt != s_providers.cend(); ++providerIt) {
+    for (auto providerIt = s_providers()->cbegin(); providerIt != s_providers()->cend(); ++providerIt) {
         auto &&provider = *providerIt;
         auto providerDependencies = provider->findDependenciesFor(node);
         for (auto dependencyIt = providerDependencies.begin(); dependencyIt != providerDependencies.end(); ++dependencyIt) {
@@ -87,7 +87,7 @@ std::vector<std::unique_ptr<BindingNode>> BindingAggregator::bindingTreeForObjec
 {
     std::vector<std::unique_ptr<BindingNode>> bindings;
     if (obj) {
-        for (auto providerIt = s_providers.begin(); providerIt != s_providers.cend(); ++providerIt) {
+        for (auto providerIt = s_providers()->begin(); providerIt != s_providers()->cend(); ++providerIt) {
             auto newBindings = (*providerIt)->findBindingsFor(obj);
             for (auto nodeIt = newBindings.begin(); nodeIt != newBindings.end(); ++nodeIt) {
                 BindingNode *node = nodeIt->get();

--- a/core/bindingaggregator.cpp
+++ b/core/bindingaggregator.cpp
@@ -123,7 +123,7 @@ void BindingAggregator::scanForBindingLoops()
                 p.severity = Problem::Error;
                 p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(bindingNode->object())).arg(bindingNode->canonicalName());
                 p.object = ObjectId(bindingNode->object());
-                p.location = bindingNode->sourceLocation();
+                p.locations.push_back(bindingNode->sourceLocation());
                 p.problemId = QString("com.kdab.GammaRay.ObjectInspector.BindingLoopScan:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
                 p.findingCategory = Problem::Scan;
                 ProblemCollector::addProblem(p);

--- a/core/bindingaggregator.cpp
+++ b/core/bindingaggregator.cpp
@@ -41,6 +41,7 @@
 // Qt
 #include <QMetaProperty>
 #include <QMetaObject>
+#include <QMutexLocker>
 
 using namespace GammaRay;
 
@@ -111,7 +112,11 @@ void BindingAggregator::scanForBindingLoops()
 
     const QVector<QObject*> &allObjects = Probe::instance()->allQObjects();
 
+    QMutexLocker lock(Probe::objectLock());
     foreach (QObject *obj, allObjects) {
+        if (!Probe::instance()->isValidObject(obj))
+            continue;
+
         auto bindings = bindingTreeForObject(obj);
         for (auto it = bindings.begin(); it != bindings.end(); ++it) {
             auto &&bindingNode = *it;

--- a/core/bindingaggregator.h
+++ b/core/bindingaggregator.h
@@ -1,5 +1,5 @@
 /*
-  bindingextension.h
+  bindingaggregator.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -27,8 +27,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_BINDINGEXTENSION_H
-#define GAMMARAY_BINDINGEXTENSION_H
+#ifndef GAMMARAY_BINDINGAGGREGATOR_H
+#define GAMMARAY_BINDINGAGGREGATOR_H
 
 // Own
 #include <core/propertycontrollerextension.h>
@@ -43,31 +43,18 @@
 #include <vector>
 
 namespace GammaRay {
-
-class BindingModel;
+class AbstractBindingProvider;
 class BindingNode;
 
-class GAMMARAY_CORE_EXPORT BindingExtension : public QObject, public PropertyControllerExtension
+namespace BindingAggregator
 {
-    Q_OBJECT
-public:
-    explicit BindingExtension(PropertyController *controller);
-    ~BindingExtension();
+    GAMMARAY_CORE_EXPORT bool providerAvailableFor(QObject *object);
+    GAMMARAY_CORE_EXPORT std::vector<std::unique_ptr<BindingNode>> findDependenciesFor(BindingNode* node);
+    GAMMARAY_CORE_EXPORT std::vector<std::unique_ptr<BindingNode>> bindingTreeForObject(QObject* obj);
+    GAMMARAY_CORE_EXPORT void scanForBindingLoops();
 
-    bool setQObject(QObject *object) override;
-
-    BindingModel *model() const;
-
-private slots:
-    void propertyChanged();
-    void clear();
-
-private:
-    QPointer<QObject> m_object;
-    std::vector<std::unique_ptr<BindingNode>> m_bindings;
-
-    BindingModel *m_bindingModel;
-};
+    GAMMARAY_CORE_EXPORT void registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider);
+}
 }
 
-#endif // GAMMARAY_BINDINGEXTENSION_H
+#endif // GAMMARAY_BINDINGAGGREGATOR_H

--- a/core/bindingnode.cpp
+++ b/core/bindingnode.cpp
@@ -51,6 +51,11 @@ BindingNode::BindingNode(QObject *obj, int propIndex, BindingNode *parent)
     checkForLoops();
 }
 
+bool BindingNode::operator==(const BindingNode& other) const
+{
+    return m_object == other.m_object && m_propertyIndex == other.m_propertyIndex;
+}
+
 void BindingNode::checkForLoops()
 {
     BindingNode *ancestor = m_parent;

--- a/core/bindingnode.h
+++ b/core/bindingnode.h
@@ -50,6 +50,8 @@ class GAMMARAY_CORE_EXPORT BindingNode
 public:
     BindingNode (QObject *object, int propertyIndex, BindingNode *parent = nullptr);
 
+    bool operator==(const BindingNode &other) const;
+
     BindingNode *parent() const;
     QObject *object() const;
     int propertyIndex() const;

--- a/core/bindingnode.h
+++ b/core/bindingnode.h
@@ -56,7 +56,14 @@ public:
     QMetaProperty property() const;
 
     const QString &canonicalName() const;
-    bool isBindingLoop() const;
+    /**
+     * This function returns true, if checkForLoops() found a loop.
+     * It usually only returns true for one node in a binding loop.
+     *
+     * \sa isPartOfBindingLoop()
+     */
+    bool hasFoundBindingLoop() const;
+    bool isPartOfBindingLoop() const;
     SourceLocation sourceLocation() const;
     uint depth() const;
     QVariant cachedValue() const;
@@ -79,7 +86,7 @@ private:
     int m_propertyIndex;
     QString m_canonicalName;
     QVariant m_value;
-    bool m_isBindingLoop;
+    bool m_foundBindingLoop;
     SourceLocation m_sourceLocation;
     std::vector<std::unique_ptr<BindingNode>> m_dependencies;
 

--- a/core/objectlistmodel.cpp
+++ b/core/objectlistmodel.cpp
@@ -117,3 +117,8 @@ void ObjectListModel::objectRemoved(QObject *obj)
     m_objects.erase(it);
     endRemoveRows();
 }
+
+const QVector<QObject *> &ObjectListModel::objects() const
+{
+    return m_objects;
+}

--- a/core/objectlistmodel.h
+++ b/core/objectlistmodel.h
@@ -60,6 +60,14 @@ public:
 
     Q_INVOKABLE QPair<int, QVariant> defaultSelectedItem() const;
 
+    /*!
+     * Returns a list of all objects.
+     *
+     * FIXME: This is a dirty hack. Instead of offering a getter to the internal data
+     * here, we should move it out and only give the model a view of the data.
+     */
+    const QVector<QObject*> &objects() const;
+
 private slots:
     void objectAdded(QObject *obj);
     void objectRemoved(QObject *obj);

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -522,6 +522,11 @@ QAbstractItemModel *Probe::objectListModel() const
     return m_objectListModel;
 }
 
+const QVector<QObject *> &Probe::allQObjects() const
+{
+    return m_objectListModel->objects();
+}
+
 QAbstractItemModel *Probe::objectTreeModel() const
 {
     return m_objectTreeModel;

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -537,7 +537,7 @@ ProblemCollector *Probe::problemCollector() const
     return m_problemCollector;
 }
 
-bool Probe::isValidObject(QObject *obj) const
+bool Probe::isValidObject(const QObject *obj) const
 {
     ///TODO: can we somehow assert(s_lock().isLocked()) ?!
     ///  -> Not with a recursive mutex. Make it non-recursive, and you can do Q_ASSERT(!s_lock().tryLock());

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -39,6 +39,7 @@
 #include "objecttreemodel.h"
 #include "probesettings.h"
 #include "probecontroller.h"
+#include "problemcollector.h"
 #include "toolmanager.h"
 #include "toolpluginmodel.h"
 #include "util.h"
@@ -230,6 +231,8 @@ Probe::Probe(QObject *parent)
     ObjectBroker::registerObject<ProbeControllerInterface *>(new ProbeController(this));
     m_toolManager = new ToolManager(this);
     ObjectBroker::registerObject<ToolManagerInterface *>(m_toolManager);
+
+    m_problemCollector = new ProblemCollector(this);
 
     ObjectBroker::registerObject<EnumRepository*>(EnumRepositoryServer::create(this));
     ClassesIconsRepositoryServer::create(this);
@@ -522,6 +525,11 @@ QAbstractItemModel *Probe::objectListModel() const
 QAbstractItemModel *Probe::objectTreeModel() const
 {
     return m_objectTreeModel;
+}
+
+ProblemCollector *Probe::problemCollector() const
+{
+    return m_problemCollector;
 }
 
 bool Probe::isValidObject(QObject *obj) const

--- a/core/probe.h
+++ b/core/probe.h
@@ -98,6 +98,15 @@ public:
     ///@endcond
 
     /*!
+     * Returns a list of all QObjects we know about.
+     *
+     * @note This getter can be used without the object lock. Do acquire the
+     * object lock and check the pointer with @e isValidObject though, before
+     * dereferencing any of the QObject pointers.
+     */
+    const QVector<QObject*> &allQObjects() const;
+
+    /*!
      * Returns the object list model.
      * @return a pointer to a QAbstractItemModel instance.
      */

--- a/core/probe.h
+++ b/core/probe.h
@@ -198,7 +198,7 @@ public:
      *
      * @note The objectLock must be locked when this is called!
      */
-    bool isValidObject(QObject *obj) const;
+    bool isValidObject(const QObject *obj) const;
 
     /*!
      * Determines if the specified QObject belongs to the GammaRay Probe or Window.
@@ -312,7 +312,7 @@ private:
     ProblemCollector *m_problemCollector;
     ToolManager *m_toolManager;
     QObject *m_window;
-    QSet<QObject *> m_validObjects;
+    QSet<const QObject *> m_validObjects;
     MetaObjectRegistry *m_metaObjectRegistry;
 
     // all delayed object changes need to go through a single queue, as the order is crucial

--- a/core/probe.h
+++ b/core/probe.h
@@ -59,6 +59,7 @@ class MainWindow;
 class BenchSuite;
 class Server;
 class ToolManager;
+class ProblemCollector;
 class MetaObjectRegistry;
 namespace Execution { class Trace; }
 
@@ -207,6 +208,8 @@ public:
     template<typename Func> static void executeSignalCallback(const Func &func);
     ///@endcond
 
+    ProblemCollector *problemCollector() const;
+
 signals:
     /*!
      * Emitted when the user selected @p object at position @p pos in the probed application.
@@ -297,6 +300,7 @@ private:
 
     ObjectListModel *m_objectListModel;
     ObjectTreeModel *m_objectTreeModel;
+    ProblemCollector *m_problemCollector;
     ToolManager *m_toolManager;
     QObject *m_window;
     QSet<QObject *> m_validObjects;

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -53,26 +53,7 @@ void ProblemCollector::registerProblemChecker(const QString& id,
 
 void GammaRay::ProblemCollector::requestScan()
 {
-    // Remove all elements which originate from a previous scan, before doing a new scan
-    // and do so, properly informing the model about all changes.
-    auto firstToDeleteIt = m_problems.begin();
-    auto it = firstToDeleteIt;
-    while (true) {
-        if (it != m_problems.end() && it->findingCategory == Problem::Scan) {
-            ++it;
-        } else if (firstToDeleteIt != it) { // this is supposed to be called also if `it == m_problems.end()`
-            auto firstRow = std::distance(m_problems.begin(), firstToDeleteIt);
-            auto count = std::distance(m_problems.begin(), it) - firstRow;
-            emit aboutToRemoveProblems(firstRow, count);
-            firstToDeleteIt = it = m_problems.erase(firstToDeleteIt, it);
-            emit problemsRemoved();
-        } else if (it != m_problems.end()) {
-            ++it;
-            ++firstToDeleteIt;
-        } else {
-            break;
-        }
-    }
+    clearScans();
 
     foreach (const auto &checker, m_availableCheckers) {
         if (checker.enabled)
@@ -109,6 +90,30 @@ void ProblemCollector::removeProblem(const QString& problemId)
     emit self->aboutToRemoveProblems(row);
     self->m_problems.erase(it);
     emit self->problemsRemoved();
+}
+
+void ProblemCollector::clearScans()
+{
+    // Remove all elements which originate from a previous scan, before doing a new scan
+    // and do so, properly informing the model about all changes.
+    auto firstToDeleteIt = m_problems.begin();
+    auto it = firstToDeleteIt;
+    while (true) {
+        if (it != m_problems.end() && it->findingCategory == Problem::Scan) {
+            ++it;
+        } else if (firstToDeleteIt != it) { // this is supposed to be called also if `it == m_problems.end()`
+            auto firstRow = std::distance(m_problems.begin(), firstToDeleteIt);
+            auto count = std::distance(m_problems.begin(), it) - firstRow;
+            emit aboutToRemoveProblems(firstRow, count);
+            firstToDeleteIt = it = m_problems.erase(firstToDeleteIt, it);
+            emit problemsRemoved();
+        } else if (it != m_problems.end()) {
+            ++it;
+            ++firstToDeleteIt;
+        } else {
+            break;
+        }
+    }
 }
 
 const QVector<Problem> & ProblemCollector::problems()

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -47,7 +47,8 @@ void ProblemCollector::registerProblemChecker(const QString& id,
                                            const QString& name, const QString& description,
                                            const std::function<void ()>& callback)
 {
-    instance()->m_availableCheckers.push_back({id, name, description, callback, true});
+    Checker c = {id, name, description, callback, true};
+    instance()->m_availableCheckers.push_back(c);
 }
 
 void GammaRay::ProblemCollector::requestScan()

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -58,6 +58,8 @@ void ProblemCollector::removeProblem(const QString& problemId)
 {
     auto self = instance();
     auto it = std::find_if(self->m_problems.begin(), self->m_problems.end(), [&](const Problem &problem) { return problem.problemId == problemId; });
+    if (it == self->m_problems.end())
+        return;
     auto row = std::distance(self->m_problems.begin(), it);
 
     emit self->aboutToRemoveProblem(row);

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -45,9 +45,9 @@ ProblemCollector * ProblemCollector::instance()
 
 void ProblemCollector::registerProblemChecker(const QString& id,
                                            const QString& name, const QString& description,
-                                           const std::function<void ()>& callback)
+                                           const std::function<void ()>& callback, bool enabled)
 {
-    Checker c = {id, name, description, callback, true};
+    Checker c = {id, name, description, callback, enabled};
     instance()->m_availableCheckers.push_back(c);
 }
 

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -1,0 +1,72 @@
+/*
+  problemcollector.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Own
+#include "problemcollector.h"
+
+#include "probe.h"
+
+using namespace GammaRay;
+
+ProblemCollector::ProblemCollector(QObject *parent)
+    : QObject(parent)
+{
+}
+
+ProblemCollector * ProblemCollector::instance()
+{
+    return Probe::instance()->problemCollector();
+}
+
+void ProblemCollector::addProblem(const Problem& problem)
+{
+    auto self = instance();
+
+    if (self->m_problems.contains(problem))
+        return;
+
+    emit self->aboutToAddProblem(self->m_problems.size());
+    self->m_problems.push_back(problem);
+    emit self->problemAdded();
+}
+void ProblemCollector::removeProblem(const QString& problemId)
+{
+    auto self = instance();
+    auto it = std::find_if(self->m_problems.begin(), self->m_problems.end(), [&](const Problem &problem) { return problem.problemId == problemId; });
+    auto row = std::distance(self->m_problems.begin(), it);
+
+    emit self->aboutToRemoveProblem(row);
+    self->m_problems.erase(it);
+    emit self->problemRemoved();
+}
+
+const QVector<Problem> & ProblemCollector::problems()
+{
+    return m_problems;
+}
+

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -43,6 +43,32 @@ ProblemCollector * ProblemCollector::instance()
     return Probe::instance()->problemCollector();
 }
 
+void GammaRay::ProblemCollector::requestScan()
+{
+    // Remove all elements which originate from a previous scan, before doing a new scan
+    // and do so, properly informing the model about all changes.
+    auto firstToDeleteIt = m_problems.begin();
+    auto it = firstToDeleteIt;
+    while (true) {
+        if (it != m_problems.end() && it->findingCategory == Problem::Scan) {
+            ++it;
+        } else if (firstToDeleteIt != it) { // this is supposed to be called also if `it == m_problems.end()`
+            auto firstRow = std::distance(m_problems.begin(), firstToDeleteIt);
+            auto count = std::distance(m_problems.begin(), it) - firstRow;
+            emit aboutToRemoveProblems(firstRow, count);
+            firstToDeleteIt = it = m_problems.erase(firstToDeleteIt, it);
+            emit problemsRemoved();
+        } else if (it != m_problems.end()) {
+            ++it;
+            ++firstToDeleteIt;
+        } else {
+            break;
+        }
+    }
+
+    emit problemScanRequested();
+}
+
 void ProblemCollector::addProblem(const Problem& problem)
 {
     auto self = instance();
@@ -62,9 +88,9 @@ void ProblemCollector::removeProblem(const QString& problemId)
         return;
     auto row = std::distance(self->m_problems.begin(), it);
 
-    emit self->aboutToRemoveProblem(row);
+    emit self->aboutToRemoveProblems(row);
     self->m_problems.erase(it);
-    emit self->problemRemoved();
+    emit self->problemsRemoved();
 }
 
 const QVector<Problem> & ProblemCollector::problems()

--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -85,8 +85,14 @@ void ProblemCollector::addProblem(const Problem& problem)
 {
     auto self = instance();
 
-    if (self->m_problems.contains(problem))
+    auto i = std::find(self->m_problems.begin(), self->m_problems.end(), problem);
+    if (i != self->m_problems.end()) {
+        // if an already reported problem is reported a second time, but with a different source location,
+        // then the problem involves multiple source locations. So let's keep all of them.
+        std::remove_copy_if(problem.locations.begin(), problem.locations.end(), std::back_inserter(i->locations),
+                            [&](const SourceLocation &loc) { return i->locations.contains(loc); });
         return;
+    }
 
     emit self->aboutToAddProblem(self->m_problems.size());
     self->m_problems.push_back(problem);

--- a/core/problemcollector.h
+++ b/core/problemcollector.h
@@ -118,12 +118,14 @@ public slots:
 
 private:
     explicit ProblemCollector(QObject *parent);
+    void clearScans();
 
     QVector<Checker> m_availableCheckers;
     QVector<Problem> m_problems;
 
     friend class Probe;
     friend class AvailableCheckersModel;
+    friend class ProblemReporterTest;
 };
 }
 

--- a/core/problemcollector.h
+++ b/core/problemcollector.h
@@ -38,6 +38,7 @@
 
 // Qt
 #include <QAbstractItemModel>
+#include <QTimer>
 
 // Std
 #include <memory>
@@ -58,20 +59,55 @@ public:
 
     const QVector<Problem> &problems();
 
+    /**
+     * Use this method from a problem provider as a response to a scan request
+     * to inform the problem collector and thereby the client that you started
+     * to scan for problems. This information will i.a. be used to show a busy
+     * indicator to the user.
+     */
+    static void reportScanStarted();
+    /**
+     * Use this method from a problem provider as a response to a scan request
+     * to inform the problem collector and thereby the client that your scan
+     * finished, no matter if you found any problems or not. This information
+     * will i.a. be used to operate a busy indicator in the client.
+     */
+    static void reportScanFinished();
+
 signals:
+    /**
+     * These signals are directed at the problem model to inform about changes
+     * in the result set.
+     */
     void aboutToAddProblem(int row);
     void problemAdded();
     void aboutToRemoveProblems(int first, int count = 1);
     void problemsRemoved();
+
+    /**
+     * This signal is directed at tools that can provide scans for problems
+     * and shall be used as a trigger to start a scan.
+     */
     void problemScanRequested();
+
+    /**
+     * This signal is directed at the Problem Reporter tool to inform that
+     * the problem providing tools have started scanning for problems.
+     */
+    void problemScansFinished();
 
 public slots:
     void requestScan();
+
+private slots:
+    void maybeEmitScansFinished();
 
 private:
     explicit ProblemCollector(QObject *parent);
 
     QVector<Problem> m_problems;
+    uint16_t m_runningScanCount;
+    QTimer *m_reportFinishedTimer;
 
     friend class Probe;
 };

--- a/core/problemcollector.h
+++ b/core/problemcollector.h
@@ -1,0 +1,77 @@
+/*
+  problemcollector.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROBLEMCOLLECTOR_H
+#define GAMMARAY_PROBLEMCOLLECTOR_H
+
+// Own
+#include "gammaray_core_export.h"
+
+#include <common/problem.h>
+#include <common/objectid.h>
+#include <common/sourcelocation.h>
+
+// Qt
+#include <QAbstractItemModel>
+
+// Std
+#include <memory>
+#include <vector>
+
+namespace GammaRay {
+
+class ProblemModel;
+
+class GAMMARAY_CORE_EXPORT ProblemCollector : public QObject
+{
+    Q_OBJECT
+
+public:
+    static void addProblem(const Problem &problem);
+    static void removeProblem(const QString &problemId);
+    static ProblemCollector *instance();
+
+    const QVector<Problem> &problems();
+
+signals:
+    void aboutToAddProblem(int row);
+    void problemAdded();
+    void aboutToRemoveProblem(int row);
+    void problemRemoved();
+
+private:
+    explicit ProblemCollector(QObject *parent);
+
+    QVector<Problem> m_problems;
+
+    friend class Probe;
+};
+}
+
+#endif // GAMMARAY_PROBLEMCOLLECTOR_H
+

--- a/core/problemcollector.h
+++ b/core/problemcollector.h
@@ -78,7 +78,8 @@ public:
      */
     static void registerProblemChecker(const QString &id,
                                     const QString &name, const QString &description,
-                                    const std::function<void()> &callback);
+                                    const std::function<void()> &callback,
+                                    bool enabled = true);
 
 private:
     struct Checker {

--- a/core/qmetaobjectvalidator.cpp
+++ b/core/qmetaobjectvalidator.cpp
@@ -30,6 +30,9 @@
 
 #include "qmetaobjectvalidator.h"
 #include "execution.h"
+#include "metaobjectregistry.h"
+#include "probe.h"
+#include "problemcollector.h"
 
 #include <QDebug>
 #include <QMetaMethod>

--- a/core/toolmanager.cpp
+++ b/core/toolmanager.cpp
@@ -36,6 +36,7 @@
 
 #include "tools/metatypebrowser/metatypebrowser.h"
 #include "tools/objectinspector/objectinspector.h"
+#include "tools/problemreporter/problemreporter.h"
 #include "tools/resourcebrowser/resourcebrowser.h"
 #include "tools/messagehandler/messagehandler.h"
 #include "tools/metaobjectbrowser/metaobjectbrowser.h"
@@ -59,6 +60,7 @@ ToolManager::ToolManager(QObject *parent)
     addToolFactory(new MetaObjectBrowserFactory(this));
     addToolFactory(new MetaTypeBrowserFactory(this));
     addToolFactory(new MessageHandlerFactory(this));
+    addToolFactory(new ProblemReporterFactory(this));
 
     Q_FOREACH (ToolFactory *factory, m_toolPluginManager->plugins())
         addToolFactory(factory);

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -148,6 +148,9 @@ void MetaObjectBrowser::doProblemScan(const QMetaObject *parent)
     QVector<const QMetaObject *> metaObjects = registry->childrenOf(parent);
 
     foreach(const QMetaObject *mo, metaObjects) {
+        if (!registry->isValid(mo))
+            continue;
+
         auto results = QMetaObjectValidator::check(mo);
         if (results != QMetaObjectValidatorResult::NoIssue) {
             //TODO do we want the Problem descriptions have more detail, i.e. have one problem listed
@@ -159,7 +162,7 @@ void MetaObjectBrowser::doProblemScan(const QMetaObject *parent)
             if (results & QMetaObjectValidatorResult::SignalOverride)
                 issueList.push_back(QStringLiteral("overrides base class signal"));
             if (results & QMetaObjectValidatorResult::UnknownMethodParameterType)
-                issueList.push_back(QStringLiteral("uses a parameter type not registerd with the meta type system"));
+                issueList.push_back(QStringLiteral("uses a parameter type not registered with the meta type system"));
             if (results & QMetaObjectValidatorResult::PropertyOverride)
                 issueList.push_back(QStringLiteral("overrides base class property"));
             if (results & QMetaObjectValidatorResult::UnknownPropertyType)

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -77,7 +77,8 @@ MetaObjectBrowser::MetaObjectBrowser(Probe *probe, QObject *parent)
     ProblemCollector::registerProblemChecker("com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator",
                                              "QMetaObject Validator",
                                              "Checks for common errors with meta objects, like invocable functions with unregistered parameter types.",
-                                             &MetaObjectBrowser::scanForMetaObjectProblems
+                                             &MetaObjectBrowser::scanForMetaObjectProblems,
+                                             /*enabled=*/ false
                                             );
 }
 

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.h
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.h
@@ -58,6 +58,9 @@ private Q_SLOTS:
 private:
     void metaObjectSelected(const QMetaObject *mo);
 
+    static void scanForMetaObjectProblems();
+    static void doProblemScan(const QMetaObject *parent);
+
     PropertyController *m_propertyController;
     MetaObjectTreeModel *m_motm;
     QAbstractProxyModel *m_model;

--- a/core/tools/objectinspector/abstractconnectionsmodel.cpp
+++ b/core/tools/objectinspector/abstractconnectionsmodel.cpp
@@ -157,9 +157,9 @@ QMap< int, QVariant > AbstractConnectionsModel::itemData(const QModelIndex &inde
     return d;
 }
 
-bool AbstractConnectionsModel::isDuplicate(const Connection &conn) const
+bool AbstractConnectionsModel::isDuplicate(const QVector<Connection> &connections, const AbstractConnectionsModel::Connection& conn)
 {
-    foreach (const Connection &c, m_connections) {
+    foreach (const Connection &c, connections) {
         if (&c == &conn)
             continue;
         if (c.endpoint == conn.endpoint
@@ -170,11 +170,22 @@ bool AbstractConnectionsModel::isDuplicate(const Connection &conn) const
     return false;
 }
 
-bool AbstractConnectionsModel::isDirectCrossThreadConnection(const Connection &conn) const
+bool AbstractConnectionsModel::isDuplicate(const Connection &conn) const
 {
-    if (!conn.endpoint || !m_object || conn.endpoint->thread() == m_object->thread())
+    return isDuplicate(m_connections, conn);
+}
+
+bool AbstractConnectionsModel::isDirectCrossThreadConnection(QObject *object, const AbstractConnectionsModel::Connection &conn)
+{
+    if (!conn.endpoint || !object || conn.endpoint->thread() == object->thread())
         return false;
     return conn.type == 1; // direct
+}
+
+
+bool AbstractConnectionsModel::isDirectCrossThreadConnection(const Connection &conn) const
+{
+    return isDirectCrossThreadConnection(m_object, conn);
 }
 
 void AbstractConnectionsModel::clear()

--- a/core/tools/objectinspector/abstractconnectionsmodel.h
+++ b/core/tools/objectinspector/abstractconnectionsmodel.h
@@ -52,7 +52,6 @@ public:
                         int role = Qt::DisplayRole) const override;
     QMap< int, QVariant > itemData(const QModelIndex &index) const override;
 
-protected:
     struct Connection {
         QPointer<QObject> endpoint;
         int signalIndex;
@@ -60,6 +59,7 @@ protected:
         int type;
     };
 
+protected:
     static QString displayString(QObject *object, int methodIndex);
     static QString displayString(QObject *object);
 
@@ -67,6 +67,10 @@ protected:
 
     void clear();
     void setConnections(const QVector<Connection> &connections);
+
+public:
+    static bool isDuplicate(const QVector<Connection> &connections, const Connection &conn);
+    static bool isDirectCrossThreadConnection(QObject *object, const Connection &conn);
 
 protected:
     QPointer<QObject> m_object;

--- a/core/tools/objectinspector/bindingextension.cpp
+++ b/core/tools/objectinspector/bindingextension.cpp
@@ -32,6 +32,7 @@
 #include "bindingmodel.h"
 
 #include <core/abstractbindingprovider.h>
+#include <core/bindingaggregator.h>
 #include <core/bindingnode.h>
 #include <core/objectdataprovider.h>
 #include <core/probe.h>
@@ -45,13 +46,6 @@
 
 using namespace GammaRay;
 
-std::vector<std::unique_ptr<AbstractBindingProvider>> BindingExtension::s_providers;
-
-void BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider)
-{
-    s_providers.push_back(std::move(provider));
-}
-
 BindingExtension::BindingExtension(PropertyController* controller)
     : QObject(controller)
     , PropertyControllerExtension(controller->objectBaseName() + ".bindings")
@@ -60,8 +54,6 @@ BindingExtension::BindingExtension(PropertyController* controller)
 {
     ObjectBroker::registerObject(controller->objectBaseName() + ".bindingsExtension", this);
     controller->registerModel(m_bindingModel, QStringLiteral("bindingModel"));
-
-    connect(ProblemCollector::instance(), SIGNAL(problemScanRequested()), this, SLOT(scanForBindingLoops()));
 }
 
 BindingExtension::~BindingExtension()
@@ -85,17 +77,14 @@ bool BindingExtension::setQObject(QObject* object)
         disconnect(m_object, nullptr, this, nullptr);
 
     if (object) {
-        if (std::find_if(s_providers.begin(), s_providers.end(),
-                                        [object](const std::unique_ptr<AbstractBindingProvider>& provider) {
-                                            return provider->canProvideBindingsFor(object);
-                                        }) == s_providers.end()) {
+        if (!BindingAggregator::providerAvailableFor(object)) {
             m_bindings.clear();
             m_bindingModel->setObject(nullptr, m_bindings);
             m_object = nullptr;
             return false;
         }
 
-        m_bindings = bindingTreeForObject(object);
+        m_bindings = BindingAggregator::bindingTreeForObject(object);
         for (size_t i = 0; i < m_bindings.size(); ++i) {
             const auto &node = m_bindings[i];
             int signalIndex = node->property().notifySignalIndex();
@@ -111,29 +100,6 @@ bool BindingExtension::setQObject(QObject* object)
     return true;
 }
 
-std::vector<std::unique_ptr<BindingNode>> BindingExtension::findDependenciesFor(BindingNode* node) const
-{
-    std::vector<std::unique_ptr<BindingNode>> allDependencies;
-    if (node->isPartOfBindingLoop())
-        return allDependencies;
-
-    for (auto providerIt = s_providers.cbegin(); providerIt != s_providers.cend(); ++providerIt) {
-        auto &&provider = *providerIt;
-        auto providerDependencies = provider->findDependenciesFor(node);
-        for (auto dependencyIt = providerDependencies.begin(); dependencyIt != providerDependencies.end(); ++dependencyIt) {
-            dependencyIt->get()->dependencies() = findDependenciesFor(dependencyIt->get());
-            allDependencies.push_back(std::move(*dependencyIt));
-        }
-    }
-    std::sort(
-        allDependencies.begin(),
-        allDependencies.end(),
-        [](const std::unique_ptr<BindingNode> &a, const std::unique_ptr<BindingNode> &b) {
-            return a->object() < b->object() || (a->object() == b->object() && a->propertyIndex() < b->propertyIndex());
-        }
-    );
-    return allDependencies;
-}
 
 void BindingExtension::propertyChanged()
 {
@@ -142,59 +108,11 @@ void BindingExtension::propertyChanged()
     for (size_t i = 0; i < m_bindings.size(); ++i) {
         const auto &bindingNode = m_bindings[i].get();
         if (bindingNode->property().notifySignalIndex() == senderSignalIndex()) {
-            m_bindingModel->refresh(i, findDependenciesFor(bindingNode));
+            m_bindingModel->refresh(i, BindingAggregator::findDependenciesFor(bindingNode));
             // There can be more than one property with the same notify signal,
             // so no break here...
         }
     }
-}
-
-std::vector<std::unique_ptr<BindingNode>> BindingExtension::bindingTreeForObject(QObject* obj) const
-{
-    std::vector<std::unique_ptr<BindingNode>> bindings;
-    if (obj) {
-        for (auto providerIt = s_providers.begin(); providerIt != s_providers.cend(); ++providerIt) {
-            auto newBindings = (*providerIt)->findBindingsFor(obj);
-            for (auto nodeIt = newBindings.begin(); nodeIt != newBindings.end(); ++nodeIt) {
-                BindingNode *node = nodeIt->get();
-                if (std::find_if(bindings.begin(), bindings.end(),
-                    [node](const std::unique_ptr<BindingNode> &other){ return *node == *other; }) != bindings.end()) {
-                    continue; // apparantly this is a duplicate.
-                }
-                node->dependencies() = findDependenciesFor(node);
-
-                bindings.push_back(std::move(*nodeIt));
-            }
-
-        }
-    }
-    return bindings;
-}
-
-void GammaRay::BindingExtension::scanForBindingLoops() const
-{
-    ProblemCollector::reportScanStarted();
-
-    const QVector<QObject*> &allObjects = Probe::instance()->allQObjects();
-
-    foreach (QObject *obj, allObjects) {
-        auto bindings = bindingTreeForObject(obj);
-        for (auto it = bindings.begin(); it != bindings.end(); ++it) {
-            auto &&bindingNode = *it;
-            if (bindingNode->isPartOfBindingLoop()) {
-                Problem p;
-                p.severity = Problem::Error;
-                p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(bindingNode->object())).arg(bindingNode->canonicalName());
-                p.object = ObjectId(bindingNode->object());
-                p.location = bindingNode->sourceLocation();
-                p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
-                p.findingCategory = Problem::Scan;
-                ProblemCollector::addProblem(p);
-            }
-        }
-    }
-
-    ProblemCollector::reportScanFinished();
 }
 
 BindingModel *BindingExtension::model() const

--- a/core/tools/objectinspector/bindingextension.cpp
+++ b/core/tools/objectinspector/bindingextension.cpp
@@ -173,6 +173,8 @@ std::vector<std::unique_ptr<BindingNode>> BindingExtension::bindingTreeForObject
 
 void GammaRay::BindingExtension::scanForBindingLoops() const
 {
+    ProblemCollector::reportScanStarted();
+
     const QVector<QObject*> &allObjects = Probe::instance()->allQObjects();
 
     foreach (QObject *obj, allObjects) {
@@ -191,6 +193,8 @@ void GammaRay::BindingExtension::scanForBindingLoops() const
             }
         }
     }
+
+    ProblemCollector::reportScanFinished();
 }
 
 BindingModel *BindingExtension::model() const

--- a/core/tools/objectinspector/bindingextension.cpp
+++ b/core/tools/objectinspector/bindingextension.cpp
@@ -31,14 +31,31 @@
 #include "bindingextension.h"
 #include "bindingmodel.h"
 
+#include <core/abstractbindingprovider.h>
+#include <core/bindingnode.h>
 #include <core/propertycontroller.h>
+#include <common/objectbroker.h>
+
+// Qt
+#include <QMetaProperty>
+#include <QMetaObject>
 
 using namespace GammaRay;
 
-BindingExtension::BindingExtension(PropertyController* controller)
-    : PropertyControllerExtension(controller->objectBaseName() + ".bindings")
-    , m_bindingModel(new BindingModel(controller))
+std::vector<std::unique_ptr<AbstractBindingProvider>> BindingExtension::s_providers;
+
+void BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider)
 {
+    s_providers.push_back(std::move(provider));
+}
+
+BindingExtension::BindingExtension(PropertyController* controller)
+    : QObject(controller)
+    , PropertyControllerExtension(controller->objectBaseName() + ".bindings")
+    , m_object(nullptr)
+    , m_bindingModel(new BindingModel(this))
+{
+    ObjectBroker::registerObject(controller->objectBaseName() + ".bindingsExtension", this);
     controller->registerModel(m_bindingModel, QStringLiteral("bindingModel"));
 }
 
@@ -46,7 +63,110 @@ BindingExtension::~BindingExtension()
 {
 }
 
+void BindingExtension::clear()
+{
+    if (m_object)
+        disconnect(m_object, nullptr, this, nullptr);
+
+    m_bindingModel->aboutToClear();
+    m_bindings.clear();
+    m_object = nullptr;
+    m_bindingModel->cleared();
+}
+
 bool BindingExtension::setQObject(QObject* object)
 {
-    return m_bindingModel->setObject(object);
+    if (m_object)
+        disconnect(m_object, nullptr, this, nullptr);
+
+    if (object) {
+        if (std::find_if(s_providers.begin(), s_providers.end(),
+                                        [object](const std::unique_ptr<AbstractBindingProvider>& provider) {
+                                            return provider->canProvideBindingsFor(object);
+                                        }) == s_providers.end()) {
+            m_bindings.clear();
+            m_bindingModel->setObject(nullptr, m_bindings);
+            m_object = nullptr;
+            return false;
+        }
+
+        m_bindings = bindingTreeForObject(object);
+        for (size_t i = 0; i < m_bindings.size(); ++i) {
+            const auto &node = m_bindings[i];
+            int signalIndex = node->property().notifySignalIndex();
+            if (signalIndex != -1) {
+                QMetaObject::connect(object, signalIndex, this, metaObject()->indexOfMethod("propertyChanged()"), Qt::UniqueConnection);
+            }
+        }
+        connect(object, SIGNAL(destroyed()), this, SLOT(clear()));
+    }
+
+    m_bindingModel->setObject(object, m_bindings);
+    m_object = object;
+    return true;
+}
+
+std::vector<std::unique_ptr<BindingNode>> BindingExtension::findDependenciesFor(BindingNode* node) const
+{
+    std::vector<std::unique_ptr<BindingNode>> allDependencies;
+    if (node->isPartOfBindingLoop())
+        return allDependencies;
+
+    for (auto providerIt = s_providers.cbegin(); providerIt != s_providers.cend(); ++providerIt) {
+        auto &&provider = *providerIt;
+        auto providerDependencies = provider->findDependenciesFor(node);
+        for (auto dependencyIt = providerDependencies.begin(); dependencyIt != providerDependencies.end(); ++dependencyIt) {
+            dependencyIt->get()->dependencies() = findDependenciesFor(dependencyIt->get());
+            allDependencies.push_back(std::move(*dependencyIt));
+        }
+    }
+    std::sort(
+        allDependencies.begin(),
+        allDependencies.end(),
+        [](const std::unique_ptr<BindingNode> &a, const std::unique_ptr<BindingNode> &b) {
+            return a->object() < b->object() || (a->object() == b->object() && a->propertyIndex() < b->propertyIndex());
+        }
+    );
+    return allDependencies;
+}
+
+void BindingExtension::propertyChanged()
+{
+    Q_ASSERT(sender() == m_object);
+
+    for (size_t i = 0; i < m_bindings.size(); ++i) {
+        const auto &bindingNode = m_bindings[i].get();
+        if (bindingNode->property().notifySignalIndex() == senderSignalIndex()) {
+            m_bindingModel->refresh(i, findDependenciesFor(bindingNode));
+            // There can be more than one property with the same notify signal,
+            // so no break here...
+        }
+    }
+}
+
+std::vector<std::unique_ptr<BindingNode>> BindingExtension::bindingTreeForObject(QObject* obj) const
+{
+    std::vector<std::unique_ptr<BindingNode>> bindings;
+    if (obj) {
+        for (auto providerIt = s_providers.begin(); providerIt != s_providers.cend(); ++providerIt) {
+            auto newBindings = (*providerIt)->findBindingsFor(obj);
+            for (auto nodeIt = newBindings.begin(); nodeIt != newBindings.end(); ++nodeIt) {
+                BindingNode *node = nodeIt->get();
+                if (std::find_if(bindings.begin(), bindings.end(),
+                    [node](const std::unique_ptr<BindingNode> &other){ return *node == *other; }) != bindings.end()) {
+                    continue; // apparantly this is a duplicate.
+                }
+                node->dependencies() = findDependenciesFor(node);
+
+                bindings.push_back(std::move(*nodeIt));
+            }
+
+        }
+    }
+    return bindings;
+}
+
+BindingModel *BindingExtension::model() const
+{
+    return m_bindingModel;
 }

--- a/core/tools/objectinspector/bindingextension.cpp
+++ b/core/tools/objectinspector/bindingextension.cpp
@@ -185,7 +185,7 @@ void GammaRay::BindingExtension::scanForBindingLoops() const
                 p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(bindingNode->object())).arg(bindingNode->canonicalName());
                 p.object = ObjectId(bindingNode->object());
                 p.location = bindingNode->sourceLocation();
-                p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<qintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
+                p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<quintptr>(bindingNode->object())).arg(bindingNode->propertyIndex());
                 p.findingCategory = Problem::Scan;
                 ProblemCollector::addProblem(p);
             }

--- a/core/tools/objectinspector/bindingextension.h
+++ b/core/tools/objectinspector/bindingextension.h
@@ -67,6 +67,7 @@ public:
 private slots:
     void propertyChanged();
     void clear();
+    void scanForBindingLoops() const;
 
 private:
     QPointer<QObject> m_object;

--- a/core/tools/objectinspector/bindingextension.h
+++ b/core/tools/objectinspector/bindingextension.h
@@ -32,21 +32,48 @@
 
 // Own
 #include <core/propertycontrollerextension.h>
+#include "gammaray_core_export.h"
+
+// Qt
+#include <QObject>
+#include <QPointer>
+
+// Std
+#include <memory>
+#include <vector>
 
 namespace GammaRay {
 
+class AbstractBindingProvider;
 class BindingModel;
+class BindingNode;
 
-class BindingExtension : public PropertyControllerExtension
+class GAMMARAY_CORE_EXPORT BindingExtension : public QObject, public PropertyControllerExtension
 {
+    Q_OBJECT
 public:
     explicit BindingExtension(PropertyController *controller);
     ~BindingExtension();
 
     bool setQObject(QObject *object) override;
 
+    std::vector<std::unique_ptr<BindingNode>> findDependenciesFor(BindingNode* node) const;
+    std::vector<std::unique_ptr<BindingNode>> bindingTreeForObject(QObject* obj) const;
+
+    static void registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider);
+
+    BindingModel *model() const;
+
+private slots:
+    void propertyChanged();
+    void clear();
+
 private:
+    QPointer<QObject> m_object;
+    std::vector<std::unique_ptr<BindingNode>> m_bindings;
+
     BindingModel *m_bindingModel;
+    static std::vector<std::unique_ptr<AbstractBindingProvider>> s_providers;
 };
 }
 

--- a/core/tools/objectinspector/bindingmodel.cpp
+++ b/core/tools/objectinspector/bindingmodel.cpp
@@ -156,18 +156,6 @@ void BindingModel::refresh(BindingNode *oldBindingNode, std::vector<std::unique_
     if (oldBindingNode->depth() != oldDepth) {
         emit dataChanged(createIndex(index.row(), DepthColumn, oldBindingNode), createIndex(index.row(), DepthColumn, oldBindingNode));
     }
-
-    if (oldBindingNode->isPartOfBindingLoop()) {
-        Problem p;
-        p.severity = Problem::Error;
-        p.description = QStringLiteral("Object %1 / Property %2 has a binding loop.").arg(ObjectDataProvider::typeName(oldBindingNode->object())).arg(oldBindingNode->canonicalName());
-        p.object = ObjectId(oldBindingNode->object());
-        p.location = oldBindingNode->sourceLocation();
-        p.problemId = QString("BindingLoop:%1.%2").arg(reinterpret_cast<qintptr>(oldBindingNode->object())).arg(oldBindingNode->propertyIndex());
-        ProblemCollector::addProblem(p);
-    } else {
-        ProblemCollector::removeProblem(QString("BindingLoop:%1.%2").arg(reinterpret_cast<qintptr>(oldBindingNode->object())).arg(oldBindingNode->propertyIndex()));
-    }
 }
 
 int BindingModel::columnCount(const QModelIndex& parent) const

--- a/core/tools/objectinspector/bindingmodel.h
+++ b/core/tools/objectinspector/bindingmodel.h
@@ -31,7 +31,6 @@
 #define GAMMARAY_BINDINGMODEL_H
 
 // Own
-#include "gammaray_core_export.h"
 
 // Qt
 #include <QAbstractItemModel>
@@ -48,7 +47,7 @@ namespace GammaRay {
 class BindingNode;
 class AbstractBindingProvider;
 
-class GAMMARAY_CORE_EXPORT BindingModel : public QAbstractItemModel
+class BindingModel : public QAbstractItemModel
 {
     Q_OBJECT
 public:
@@ -62,7 +61,9 @@ public:
     explicit BindingModel (QObject *parent = nullptr);
     ~BindingModel();
 
-    bool setObject(QObject *obj);
+    void setObject(QObject *obj, std::vector<std::unique_ptr<BindingNode>> &bindings);
+
+    void refresh(int row, std::vector<std::unique_ptr<BindingNode>> &&newDependencies);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -72,23 +73,18 @@ public:
     QModelIndex parent(const QModelIndex &child) const override;
     QMap<int, QVariant> itemData(const QModelIndex &index) const override;
 
-    static void registerBindingProvider(std::unique_ptr<AbstractBindingProvider> provider);
-    //FIXME: ^ Move this function out of here, this class should purely be an implementation detail
-
-private slots:
-    void propertyChanged();
-    void clear();
+    void aboutToClear();
+    void cleared();
 
 private:
     QModelIndex findEquivalent(const std::vector<std::unique_ptr<BindingNode>> &container, BindingNode *bindingNode) const;
-    void refresh(BindingNode *oldBindingNode, const QModelIndex &index);
+    void refresh(BindingNode *oldBindingNode, std::vector<std::unique_ptr<BindingNode>> &&newDependencies, const QModelIndex &index);
     void bindingChanged(BindingNode *node);
     void findDependenciesFor(BindingNode *node);
     static bool lessThan(const std::unique_ptr<BindingNode> &a, const std::unique_ptr<BindingNode> &b);
 
     QPointer<QObject> m_obj;
-    std::vector<std::unique_ptr<BindingNode>> m_bindings;
-    static std::vector<std::unique_ptr<AbstractBindingProvider>> s_providers;
+    std::vector<std::unique_ptr<BindingNode>> *m_bindings;
 };
 
 }

--- a/core/tools/objectinspector/inboundconnectionsmodel.cpp
+++ b/core/tools/objectinspector/inboundconnectionsmodel.cpp
@@ -77,6 +77,11 @@ void InboundConnectionsModel::setObject(QObject *object)
     if (!object)
         return;
 
+    setConnections(inboundConnectionsForObject(object));
+}
+
+QVector<AbstractConnectionsModel::Connection> InboundConnectionsModel::inboundConnectionsForObject(QObject* object)
+{
     QVector<Connection> connections;
 #ifdef HAVE_PRIVATE_QT_HEADERS
     QObjectPrivate *d = QObjectPrivate::get(object);
@@ -104,7 +109,8 @@ void InboundConnectionsModel::setObject(QObject *object)
         }
     }
 #endif
-    setConnections(connections);
+
+    return connections;
 }
 
 QVariant InboundConnectionsModel::data(const QModelIndex &index, int role) const

--- a/core/tools/objectinspector/inboundconnectionsmodel.h
+++ b/core/tools/objectinspector/inboundconnectionsmodel.h
@@ -42,6 +42,8 @@ public:
 
     void setObject(QObject *object) override;
 
+    static QVector<Connection> inboundConnectionsForObject(QObject *object);
+
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -72,6 +72,11 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
             SLOT(objectSelected(QObject*)));
 
     connect(ProblemCollector::instance(), SIGNAL(problemScanRequested()), this, SLOT(scanForBindingLoops()));
+    ProblemCollector::registerProblemChecker("com.kdab.GammaRay.ObjectInspector.BindingLoopScan",
+                                          "Binding Loops",
+                                          "Scans all QObjects for binding loops",
+                                          &BindingAggregator::scanForBindingLoops);
+
 }
 
 void ObjectInspector::objectSelectionChanged(const QItemSelection &selection)
@@ -111,11 +116,6 @@ void ObjectInspector::objectSelected(QObject *object)
     // TODO: move this to the client side!
     // ui->objectTreeView->scrollTo(index);
     objectSelected(index);
-}
-
-void ObjectInspector::scanForBindingLoops()
-{
-    BindingAggregator::scanForBindingLoops();
 }
 
 void ObjectInspector::registerPCExtensions()

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -162,8 +162,13 @@ void ObjectInspector::scanForConnectionIssues()
                     return;
                 }
 
+#if QT_VERSION < QT_VERSION_CHECK(5,0,0)
+                QString signalName = sender->metaObject()->method(connection.signalIndex).signature();
+                QString slotName = connection.slotIndex < 0 ? tr("<slot object>") : receiver->metaObject()->method(connection.slotIndex).signature();
+#else
                 QString signalName = sender->metaObject()->method(connection.signalIndex).name();
                 QString slotName = connection.slotIndex < 0 ? tr("<slot object>") : receiver->metaObject()->method(connection.slotIndex).name();
+#endif
                 QString senderName = Util::displayString(sender);
                 QString receiverName = Util::displayString(receiver);
                 Problem p;

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -39,6 +39,8 @@
 
 #include <common/objectbroker.h>
 #include <common/objectmodel.h>
+#include <core/bindingaggregator.h>
+#include <core/problemcollector.h>
 #include <remote/serverproxymodel.h>
 
 #include <3rdparty/kde/krecursivefilterproxymodel.h>
@@ -68,6 +70,8 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
 
     connect(probe, SIGNAL(objectSelected(QObject*,QPoint)),
             SLOT(objectSelected(QObject*)));
+
+    connect(ProblemCollector::instance(), SIGNAL(problemScanRequested()), this, SLOT(scanForBindingLoops()));
 }
 
 void ObjectInspector::objectSelectionChanged(const QItemSelection &selection)
@@ -107,6 +111,11 @@ void ObjectInspector::objectSelected(QObject *object)
     // TODO: move this to the client side!
     // ui->objectTreeView->scrollTo(index);
     objectSelected(index);
+}
+
+void ObjectInspector::scanForBindingLoops()
+{
+    BindingAggregator::scanForBindingLoops();
 }
 
 void ObjectInspector::registerPCExtensions()

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -164,10 +164,10 @@ void ObjectInspector::scanForConnectionIssues()
 
 #if QT_VERSION < QT_VERSION_CHECK(5,0,0)
                 QString signalName = sender->metaObject()->method(connection.signalIndex).signature();
-                QString slotName = connection.slotIndex < 0 ? tr("<slot object>") : receiver->metaObject()->method(connection.slotIndex).signature();
+                QString slotName = connection.slotIndex < 0 ? QStringLiteral("<slot object>") : receiver->metaObject()->method(connection.slotIndex).signature();
 #else
                 QString signalName = sender->metaObject()->method(connection.signalIndex).name();
-                QString slotName = connection.slotIndex < 0 ? tr("<slot object>") : receiver->metaObject()->method(connection.slotIndex).name();
+                QString slotName = connection.slotIndex < 0 ? QStringLiteral("<slot object>") : receiver->metaObject()->method(connection.slotIndex).name();
 #endif
                 QString senderName = Util::displayString(sender);
                 QString receiverName = Util::displayString(receiver);
@@ -176,7 +176,7 @@ void ObjectInspector::scanForConnectionIssues()
                 p.description = descriptionTemplate.arg(receiverName, slotName, senderName, signalName);
                 p.object = ObjectId(receiver);
 //                 p.location = bindingNode->sourceLocation(); //TODO can we get source locations of connect-statements?
-                p.problemId = QString("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck:%1-%2.%3-%4.%5")
+                p.problemId = QString("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck.%1:%2.%3-%4.%5")
                     .arg(problemType,
                             QString::number(reinterpret_cast<quintptr>(sender)),
                             QString::number(connection.signalIndex),
@@ -194,7 +194,7 @@ void ObjectInspector::scanForConnectionIssues()
                 reportProblem(connection, QStringLiteral("The slot %1->%2 is connected to the signal %3->%4 multiple times."), QStringLiteral("Duplicate"), false);
             }
             if (AbstractConnectionsModel::isDirectCrossThreadConnection(obj, connection)) {
-                reportProblem(connection, QStringLiteral("The connection of slot %1->%2 to the signal %3->%4 is a Direct cross-thread connection."), QStringLiteral("CrossTread"), false);
+                reportProblem(connection, QStringLiteral("The connection of slot %1->%2 to the signal %3->%4 is a direct cross-thread connection."), QStringLiteral("CrossTread"), false);
             }
         }
 
@@ -206,7 +206,7 @@ void ObjectInspector::scanForConnectionIssues()
                 reportProblem(connection, QStringLiteral("The slot %1->%2 is connected to the signal %3->%4 multiple times."), QStringLiteral("Duplicate"), true);
             }
             if (AbstractConnectionsModel::isDirectCrossThreadConnection(obj, connection)) {
-                reportProblem(connection, QStringLiteral("The connection of slot %1->%2 to the signal %3->%4 is a Direct cross-thread connection."), QStringLiteral("CrossTread"), true);
+                reportProblem(connection, QStringLiteral("The connection of slot %1->%2 to the signal %3->%4 is a direct cross-thread connection."), QStringLiteral("CrossTread"), true);
             }
         }
     }

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -71,7 +71,6 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
     connect(probe, SIGNAL(objectSelected(QObject*,QPoint)),
             SLOT(objectSelected(QObject*)));
 
-    connect(ProblemCollector::instance(), SIGNAL(problemScanRequested()), this, SLOT(scanForBindingLoops()));
     ProblemCollector::registerProblemChecker("com.kdab.GammaRay.ObjectInspector.BindingLoopScan",
                                           "Binding Loops",
                                           "Scans all QObjects for binding loops",

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -52,7 +52,6 @@ private slots:
     void objectSelected(const QModelIndex &index);
     void objectSelectionChanged(const QItemSelection &selection);
     void objectSelected(QObject *object);
-    void scanForBindingLoops();
 
 private:
     void registerPCExtensions();

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -52,6 +52,7 @@ private slots:
     void objectSelected(const QModelIndex &index);
     void objectSelectionChanged(const QItemSelection &selection);
     void objectSelected(QObject *object);
+    void scanForBindingLoops();
 
 private:
     void registerPCExtensions();

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -56,6 +56,8 @@ private slots:
 private:
     void registerPCExtensions();
 
+    static void scanForConnectionIssues();
+
     PropertyController *m_propertyController;
     QItemSelectionModel *m_selectionModel;
 };

--- a/core/tools/objectinspector/outboundconnectionsmodel.cpp
+++ b/core/tools/objectinspector/outboundconnectionsmodel.cpp
@@ -52,6 +52,12 @@ void OutboundConnectionsModel::setObject(QObject *object)
     if (!object)
         return;
 
+
+    setConnections(outboundConnectionsForObject(object));
+}
+
+QVector<AbstractConnectionsModel::Connection> OutboundConnectionsModel::outboundConnectionsForObject(QObject* object)
+{
     QVector<Connection> connections;
 #ifdef HAVE_PRIVATE_QT_HEADERS
     QObjectPrivate *d = QObjectPrivate::get(object);
@@ -69,7 +75,7 @@ void OutboundConnectionsModel::setObject(QObject *object)
 
                 Connection conn;
                 conn.endpoint = c->receiver;
-                conn.signalIndex = signalIndexToMethodIndex(m_object, signalIndex);
+                conn.signalIndex = signalIndexToMethodIndex(object, signalIndex);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
                 if (c->isSlotObject)
                     conn.slotIndex = -1;
@@ -83,7 +89,8 @@ void OutboundConnectionsModel::setObject(QObject *object)
         }
     }
 #endif
-    setConnections(connections);
+
+    return connections;
 }
 
 QVariant OutboundConnectionsModel::data(const QModelIndex &index, int role) const

--- a/core/tools/objectinspector/outboundconnectionsmodel.h
+++ b/core/tools/objectinspector/outboundconnectionsmodel.h
@@ -43,6 +43,8 @@ public:
 
     void setObject(QObject *object) override;
 
+    static QVector<Connection> outboundConnectionsForObject(QObject *object);
+
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;

--- a/core/tools/problemreporter/availablecheckersmodel.cpp
+++ b/core/tools/problemreporter/availablecheckersmodel.cpp
@@ -87,6 +87,10 @@ Qt::ItemFlags AvailableCheckersModel::flags(const QModelIndex &index) const
 
 int AvailableCheckersModel::rowCount(const QModelIndex & parent) const
 {
+    if (parent.isValid()) {
+        return 0;
+    }
+
     return m_availableCheckers->size();
 }
 

--- a/core/tools/problemreporter/availablecheckersmodel.cpp
+++ b/core/tools/problemreporter/availablecheckersmodel.cpp
@@ -1,0 +1,101 @@
+/*
+  availablecheckers.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation problem.
+
+  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "availablecheckersmodel.h"
+
+
+using namespace GammaRay;
+
+
+AvailableCheckersModel::AvailableCheckersModel(QObject *parent)
+    : QAbstractListModel(parent)
+    , m_availableCheckers(&ProblemCollector::instance()->availableCheckers())
+{
+    connect(ProblemCollector::instance(), SIGNAL(aboutToAddChecker()), this, SLOT(aboutToAddChecker()));
+    connect(ProblemCollector::instance(), SIGNAL(checkerAdded()), this, SLOT(checkerAdded()));
+}
+
+QVariant AvailableCheckersModel::data(const QModelIndex & index, int role) const
+{
+    if (!index.isValid() || index.column() != 0 || index.row() < 0 || index.row() >= m_availableCheckers->size()) {
+        return QVariant();
+    }
+
+    const ProblemCollector::Checker &checker = m_availableCheckers->at(index.row());
+    if (role == Qt::DisplayRole) {
+        return checker.name;
+    }
+    if (role == Qt::ToolTipRole) {
+        return checker.description;
+    }
+    if (role == Qt::EditRole) {
+        return checker.id;
+    }
+    if (role == Qt::CheckStateRole) {
+        return checker.enabled ? Qt::Checked : Qt::Unchecked;
+    }
+    return QVariant();
+}
+
+bool GammaRay::AvailableCheckersModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if (!index.isValid()
+        || index.column() != 0
+        || index.row() < 0 || index.row() >= m_availableCheckers->size()
+        || role != Qt::CheckStateRole
+        || !value.canConvert<bool>()) {
+        return false;
+    }
+
+    (*m_availableCheckers)[index.row()].enabled = value.toBool();
+    emit dataChanged(index, index);
+    return true;
+}
+
+Qt::ItemFlags AvailableCheckersModel::flags(const QModelIndex &index) const
+{
+    const Qt::ItemFlags flags = QAbstractListModel::flags(index);
+    if (index.column() == 0)
+        return flags | Qt::ItemIsUserCheckable;
+    return flags;
+}
+
+int AvailableCheckersModel::rowCount(const QModelIndex & parent) const
+{
+    return m_availableCheckers->size();
+}
+
+void GammaRay::AvailableCheckersModel::aboutToAddChecker()
+{
+    beginInsertRows(QModelIndex(), m_availableCheckers->size(), m_availableCheckers->size());
+}
+void GammaRay::AvailableCheckersModel::checkerAdded()
+{
+    endInsertRows();
+}
+

--- a/core/tools/problemreporter/availablecheckersmodel.h
+++ b/core/tools/problemreporter/availablecheckersmodel.h
@@ -1,11 +1,11 @@
 /*
-  problemclientmodel.h
+  availablecheckersmodel.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,33 +26,38 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBLEMCLIENTMODEL_H
-#define GAMMARAY_PROBLEMCLIENTMODEL_H
+#ifndef GAMMARAY_AVAILABLECHECKERSMODEL_H
+#define GAMMARAY_AVAILABLECHECKERSMODEL_H
 
-#include <QSortFilterProxyModel>
+#include <QAbstractListModel>
+#include <QItemSelectionModel>
+
+#include <core/problemcollector.h>
 
 namespace GammaRay {
 
-/*! Client-side part of the meta types model. */
-class ProblemClientModel : public QSortFilterProxyModel
+class AvailableCheckersModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    explicit ProblemClientModel(QObject *parent = nullptr);
-    ~ProblemClientModel();
+    AvailableCheckersModel(QObject *parent);
 
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex & index, int role) const override;
 
-    bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const override;
+    int rowCount(const QModelIndex & parent) const override;
 
-    void disableChecker (const QString &id);
-    void enableChecker (const QString &id);
+    bool setData(const QModelIndex & index, const QVariant & value, int role) override;
+
+    Qt::ItemFlags flags(const QModelIndex & index) const override;
+
+private slots:
+    void aboutToAddChecker();
+    void checkerAdded();
 
 private:
-    QVector<QString> m_disabledCheckers; // holds the ids of the disabled checkers
+    QVector<ProblemCollector::Checker> *m_availableCheckers;
 };
 
 }
 
-#endif // GAMMARAY_PROBLEMCLIENTMODEL_H
+#endif // GAMMARAY_AVAILABLECHECKERSMODEL_H

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -57,7 +57,12 @@ QVariant ProblemModel::data(const QModelIndex &index, int role) const
     const Problem &problem = m_problemCollector->problems().at(index.row());
     switch (role) {
         case Qt::DisplayRole:
-            return problem.description;
+            switch (index.column()) {
+            case 0:
+                return problem.description;
+            case 1:
+                return problem.location.displayString();
+            }
         case ObjectModel::ObjectIdRole:
             return QVariant::fromValue(problem.object);
         case ProblemModelRoles::SourceLocationRole:
@@ -82,6 +87,13 @@ int ProblemModel::rowCount(const QModelIndex &parent) const
     if (parent.isValid())
         return 0;
     return m_problemCollector->problems().count();
+}
+int ProblemModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+
+    return 2;
 }
 
 void GammaRay::ProblemModel::aboutToAddProblem(int row)

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -69,7 +69,7 @@ QVariant ProblemModel::data(const QModelIndex &index, int role) const
         case ProblemModelRoles::SourceLocationRole:
             return QVariant::fromValue(problem.locations);
         case ProblemModelRoles::SeverityRole:
-            return problem.severity;
+            return static_cast<int>(problem.severity);
         case ProblemModelRoles::ProblemIdRole:
             return problem.problemId;
     }

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -61,13 +61,13 @@ QVariant ProblemModel::data(const QModelIndex &index, int role) const
             case 0:
                 return problem.description;
             case 1:
-                return problem.location.displayString();
+                return problem.locations.size() ? problem.locations.front().displayString() : QString();
             }
             break;
         case ObjectModel::ObjectIdRole:
             return QVariant::fromValue(problem.object);
         case ProblemModelRoles::SourceLocationRole:
-            return QVariant::fromValue(problem.location);
+            return QVariant::fromValue(problem.locations);
         case ProblemModelRoles::SeverityRole:
             return problem.severity;
         case ProblemModelRoles::ProblemIdRole:

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -1,0 +1,129 @@
+/*
+  problemmodel.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation problem.
+
+  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "problemmodel.h"
+#include "../../problemcollector.h"
+#include <common/problem.h>
+
+#include <common/tools/problemreporter/problemmodelroles.h>
+
+
+using namespace GammaRay;
+
+ProblemModel::ProblemModel(QObject *parent)
+    : QAbstractListModel(parent)
+    , m_problemCollector(ProblemCollector::instance())
+{
+    connect(m_problemCollector, SIGNAL(aboutToAddProblem(int)), this, SLOT(aboutToAddProblem(int)));
+    connect(m_problemCollector, SIGNAL(problemAdded()), this, SLOT(problemAdded()));
+    connect(m_problemCollector, SIGNAL(aboutToRemoveProblem(int)), this, SLOT(aboutToRemoveProblem(int)));
+    connect(m_problemCollector, SIGNAL(problemRemoved()), this, SLOT(problemRemoved()));
+}
+
+ProblemModel::~ProblemModel()
+{
+}
+
+QVariant ProblemModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    const Problem &problem = m_problemCollector->problems().at(index.row());
+    switch (role) {
+        case Qt::DisplayRole:
+            return problem.description;
+        case ObjectModel::ObjectIdRole:
+            return QVariant::fromValue(problem.object);
+        case ProblemModelRoles::SourceLocationRole:
+            return QVariant::fromValue(problem.location);
+        case ProblemModelRoles::SeverityRole:
+            return problem.severity;
+    }
+    return QVariant();
+}
+
+QMap<int, QVariant> ProblemModel::itemData(const QModelIndex &index) const
+{
+    QMap<int, QVariant> d = QAbstractItemModel::itemData(index);
+    d.insert(ObjectModel::ObjectIdRole, data(index, ObjectModel::ObjectIdRole));
+    d.insert(ProblemModelRoles::SourceLocationRole, data(index, ProblemModelRoles::SourceLocationRole));
+    d.insert(ProblemModelRoles::SeverityRole, data(index, ProblemModelRoles::SeverityRole));
+    return d;
+}
+
+int ProblemModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return m_problemCollector->problems().count();
+}
+
+void GammaRay::ProblemModel::aboutToAddProblem(int row)
+{
+    beginInsertRows(QModelIndex(), row, row);
+}
+void GammaRay::ProblemModel::aboutToRemoveProblem(int row)
+{
+    beginRemoveRows(QModelIndex(), row, row);
+}
+void GammaRay::ProblemModel::problemAdded()
+{
+    endInsertRows();
+}
+void GammaRay::ProblemModel::problemRemoved()
+{
+    endRemoveRows();
+}
+
+
+/*
+ClientProblemSelectionModel::ClientProblemSelectionModel(ProblemCollector *manager)
+    : QItemSelectionModel(manager->model())
+    , m_problemCollector(manager)
+{
+    connect(manager, SIGNAL(problemSelectedByIndex(int)), this, SLOT(selectProblem(int)));
+    connect(manager, SIGNAL(problemListAvailable()), this, SLOT(selectDefaultProblem()));
+}
+
+ClientProblemSelectionModel::~ClientProblemSelectionModel()
+{
+}
+
+void ClientProblemSelectionModel::selectProblem(int index)
+{
+    select(model()->index(index, 0), QItemSelectionModel::Select
+           | QItemSelectionModel::Clear
+           | QItemSelectionModel::Rows
+           | QItemSelectionModel::Current);
+}
+
+void ClientProblemSelectionModel::selectDefaultProblem()
+{
+    selectProblem(m_problemCollector->problemIndexForProblemId(QStringLiteral("GammaRay::ObjectInspector")));
+}*/

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -41,8 +41,8 @@ ProblemModel::ProblemModel(QObject *parent)
 {
     connect(m_problemCollector, SIGNAL(aboutToAddProblem(int)), this, SLOT(aboutToAddProblem(int)));
     connect(m_problemCollector, SIGNAL(problemAdded()), this, SLOT(problemAdded()));
-    connect(m_problemCollector, SIGNAL(aboutToRemoveProblem(int)), this, SLOT(aboutToRemoveProblem(int)));
-    connect(m_problemCollector, SIGNAL(problemRemoved()), this, SLOT(problemRemoved()));
+    connect(m_problemCollector, SIGNAL(aboutToRemoveProblems(int, int)), this, SLOT(aboutToRemoveProblems(int, int)));
+    connect(m_problemCollector, SIGNAL(problemsRemoved()), this, SLOT(problemsRemoved()));
 }
 
 ProblemModel::~ProblemModel()
@@ -63,6 +63,7 @@ QVariant ProblemModel::data(const QModelIndex &index, int role) const
             case 1:
                 return problem.location.displayString();
             }
+            break;
         case ObjectModel::ObjectIdRole:
             return QVariant::fromValue(problem.object);
         case ProblemModelRoles::SourceLocationRole:
@@ -100,15 +101,15 @@ void GammaRay::ProblemModel::aboutToAddProblem(int row)
 {
     beginInsertRows(QModelIndex(), row, row);
 }
-void GammaRay::ProblemModel::aboutToRemoveProblem(int row)
+void GammaRay::ProblemModel::aboutToRemoveProblems(int row, int count)
 {
-    beginRemoveRows(QModelIndex(), row, row);
+    beginRemoveRows(QModelIndex(), row, row + count - 1);
 }
 void GammaRay::ProblemModel::problemAdded()
 {
     endInsertRows();
 }
-void GammaRay::ProblemModel::problemRemoved()
+void GammaRay::ProblemModel::problemsRemoved()
 {
     endRemoveRows();
 }

--- a/core/tools/problemreporter/problemmodel.cpp
+++ b/core/tools/problemreporter/problemmodel.cpp
@@ -70,6 +70,8 @@ QVariant ProblemModel::data(const QModelIndex &index, int role) const
             return QVariant::fromValue(problem.location);
         case ProblemModelRoles::SeverityRole:
             return problem.severity;
+        case ProblemModelRoles::ProblemIdRole:
+            return problem.problemId;
     }
     return QVariant();
 }
@@ -80,6 +82,7 @@ QMap<int, QVariant> ProblemModel::itemData(const QModelIndex &index) const
     d.insert(ObjectModel::ObjectIdRole, data(index, ObjectModel::ObjectIdRole));
     d.insert(ProblemModelRoles::SourceLocationRole, data(index, ProblemModelRoles::SourceLocationRole));
     d.insert(ProblemModelRoles::SeverityRole, data(index, ProblemModelRoles::SeverityRole));
+    d.insert(ProblemModelRoles::ProblemIdRole, data(index, ProblemModelRoles::ProblemIdRole));
     return d;
 }
 

--- a/core/tools/problemreporter/problemmodel.h
+++ b/core/tools/problemreporter/problemmodel.h
@@ -54,8 +54,8 @@ public:
 private slots:
     void aboutToAddProblem(int row);
     void problemAdded();
-    void aboutToRemoveProblem(int row);
-    void problemRemoved();
+    void aboutToRemoveProblems(int row, int count = 1);
+    void problemsRemoved();
 
 private:
     ProblemCollector *m_problemCollector;

--- a/core/tools/problemreporter/problemmodel.h
+++ b/core/tools/problemreporter/problemmodel.h
@@ -1,11 +1,11 @@
 /*
-  clienttoolmodel.h
+  problemmodel.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,53 +26,56 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_CLIENTTOOLMODEL_H
-#define GAMMARAY_CLIENTTOOLMODEL_H
+#ifndef GAMMARAY_PROBLEMMODEL_H
+#define GAMMARAY_PROBLEMMODEL_H
 
 #include <QAbstractListModel>
 #include <QItemSelectionModel>
 
+#include <common/objectmodel.h>
+
 namespace GammaRay {
 
-class ClientToolManager;
+class ProblemCollector;
 
 /*! Model of all selectable client tools. */
-class ClientToolModel : public QAbstractListModel
+class ProblemModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
-    explicit ClientToolModel(ClientToolManager *manager);
-    virtual ~ClientToolModel();
+    explicit ProblemModel(QObject *parent);
+    virtual ~ProblemModel();
 
     QVariant data(const QModelIndex &index, int role) const override;
-    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QMap<int, QVariant> itemData(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
 private slots:
-    void startReset();
-    void finishReset();
-    void toolEnabled(int toolIndex);
+    void aboutToAddProblem(int row);
+    void problemAdded();
+    void aboutToRemoveProblem(int row);
+    void problemRemoved();
 
 private:
-    ClientToolManager *m_toolManager;
+    ProblemCollector *m_problemCollector;
 };
 
 /*! Selection model that automatically syncs ClientToolModel with ClientToolManager. */
-class ClientToolSelectionModel : public QItemSelectionModel
-{
-    Q_OBJECT
-public:
-    explicit ClientToolSelectionModel(ClientToolManager *manager);
-    ~ClientToolSelectionModel();
-
-private slots:
-    void selectTool(int index);
-    void selectDefaultTool();
-
-private:
-    ClientToolManager *m_toolManager;
-};
+// class ClientToolSelectionModel : public QItemSelectionModel
+// {
+//     Q_OBJECT
+// public:
+//     explicit ClientToolSelectionModel(ClientToolManager *manager);
+//     ~ClientToolSelectionModel();
+//
+// private slots:
+//     void selectTool(int index);
+//     void selectDefaultTool();
+//
+// private:
+//     ClientToolManager *m_toolManager;
+// };
 
 }
 
-#endif // GAMMARAY_CLIENTTOOLMODEL_H
+#endif // GAMMARAY_PROBLEMMODEL_H

--- a/core/tools/problemreporter/problemmodel.h
+++ b/core/tools/problemreporter/problemmodel.h
@@ -49,6 +49,7 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     QMap<int, QVariant> itemData(const QModelIndex &index) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent) const override;
 
 private slots:
     void aboutToAddProblem(int row);

--- a/core/tools/problemreporter/problemreporter.cpp
+++ b/core/tools/problemreporter/problemreporter.cpp
@@ -1,0 +1,46 @@
+/*
+  problemreporter.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "problemreporter.h"
+#include "problemmodel.h"
+
+using namespace GammaRay;
+
+ProblemReporter::ProblemReporter(Probe *probe, QObject *parent)
+    : QObject(parent)
+    , m_problemModel(new ProblemModel(this))
+{
+//     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
+//     proxy->setSourceModel(m_problemModel);
+//     proxy->addRole(MetaTypeRoles::MetaObjectIdRole);
+    probe->registerModel(QStringLiteral("com.kdab.GammaRay.ProblemModel"), m_problemModel);
+}
+
+ProblemReporter::~ProblemReporter()
+{
+}

--- a/core/tools/problemreporter/problemreporter.cpp
+++ b/core/tools/problemreporter/problemreporter.cpp
@@ -29,10 +29,12 @@
 #include "problemreporter.h"
 #include "problemmodel.h"
 
+#include <core/problemcollector.h>
+
 using namespace GammaRay;
 
 ProblemReporter::ProblemReporter(Probe *probe, QObject *parent)
-    : QObject(parent)
+    : ProblemReporterInterface(parent)
     , m_problemModel(new ProblemModel(this))
 {
 //     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
@@ -43,4 +45,9 @@ ProblemReporter::ProblemReporter(Probe *probe, QObject *parent)
 
 ProblemReporter::~ProblemReporter()
 {
+}
+
+void GammaRay::ProblemReporter::requestScan()
+{
+    ProblemCollector::instance()->requestScan();
 }

--- a/core/tools/problemreporter/problemreporter.cpp
+++ b/core/tools/problemreporter/problemreporter.cpp
@@ -41,6 +41,8 @@ ProblemReporter::ProblemReporter(Probe *probe, QObject *parent)
 //     proxy->setSourceModel(m_problemModel);
 //     proxy->addRole(MetaTypeRoles::MetaObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ProblemModel"), m_problemModel);
+
+    connect(ProblemCollector::instance(), SIGNAL(problemScansFinished()), this, SIGNAL(problemScansFinished()));
 }
 
 ProblemReporter::~ProblemReporter()

--- a/core/tools/problemreporter/problemreporter.cpp
+++ b/core/tools/problemreporter/problemreporter.cpp
@@ -28,6 +28,7 @@
 
 #include "problemreporter.h"
 #include "problemmodel.h"
+#include "availablecheckersmodel.h"
 
 #include <core/problemcollector.h>
 
@@ -37,10 +38,8 @@ ProblemReporter::ProblemReporter(Probe *probe, QObject *parent)
     : ProblemReporterInterface(parent)
     , m_problemModel(new ProblemModel(this))
 {
-//     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
-//     proxy->setSourceModel(m_problemModel);
-//     proxy->addRole(MetaTypeRoles::MetaObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ProblemModel"), m_problemModel);
+    probe->registerModel(QStringLiteral("com.kdab.GammaRay.AvailableProblemCheckersModel"), new AvailableCheckersModel(this));
 
     connect(ProblemCollector::instance(), SIGNAL(problemScansFinished()), this, SIGNAL(problemScansFinished()));
 }

--- a/core/tools/problemreporter/problemreporter.h
+++ b/core/tools/problemreporter/problemreporter.h
@@ -29,18 +29,22 @@
 #define GAMMARAY_PROBLEMREPORTER_PROBLEMREPORTER_H
 
 #include <core/toolfactory.h>
+#include <common/tools/problemreporter/problemreporterinterface.h>
 
 namespace GammaRay {
 
 class ProblemModel;
 
-class ProblemReporter : public QObject
+class ProblemReporter : public ProblemReporterInterface
 {
     Q_OBJECT
-//     Q_INTERFACES(GammaRay::ProblemReporterInterface)
+    Q_INTERFACES(GammaRay::ProblemReporterInterface)
 public:
     explicit ProblemReporter(Probe *probe, QObject *parent = nullptr);
     ~ProblemReporter();
+
+public slots:
+    void requestScan() override;
 
 private:
     ProblemModel *m_problemModel;

--- a/core/tools/problemreporter/problemreporter.h
+++ b/core/tools/problemreporter/problemreporter.h
@@ -1,0 +1,61 @@
+/*
+  problemreporter.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef GAMMARAY_PROBLEMREPORTER_PROBLEMREPORTER_H
+#define GAMMARAY_PROBLEMREPORTER_PROBLEMREPORTER_H
+
+#include <core/toolfactory.h>
+
+namespace GammaRay {
+
+class ProblemModel;
+
+class ProblemReporter : public QObject
+{
+    Q_OBJECT
+//     Q_INTERFACES(GammaRay::ProblemReporterInterface)
+public:
+    explicit ProblemReporter(Probe *probe, QObject *parent = nullptr);
+    ~ProblemReporter();
+
+private:
+    ProblemModel *m_problemModel;
+};
+
+class ProblemReporterFactory : public QObject, public StandardToolFactory<QObject, ProblemReporter>
+{
+    Q_OBJECT
+    Q_INTERFACES(GammaRay::ToolFactory)
+public:
+    explicit ProblemReporterFactory(QObject *parent)
+        : QObject(parent)
+    {
+    }
+};
+}
+
+#endif // PROBLEMREPORTER_H

--- a/plugins/actioninspector/actionmodel.cpp
+++ b/plugins/actioninspector/actionmodel.cpp
@@ -225,7 +225,7 @@ void ActionModel::scanForShortcutDuplicates() const
             p.description = QStringLiteral("Key sequence %1 is ambigous.").arg(sequence.toString(QKeySequence::NativeText));
             p.problemId = QStringLiteral("gammaray_actioninspector.ShortcutDuplicates:%1").arg(sequence.toString(QKeySequence::PortableText));
             p.object = ObjectId(action);
-            p.location = ObjectDataProvider::creationLocation(action);
+            p.locations.push_back(ObjectDataProvider::creationLocation(action));
             p.findingCategory = Problem::Scan;
             ProblemCollector::addProblem(p);
         }

--- a/plugins/actioninspector/actionmodel.h
+++ b/plugins/actioninspector/actionmodel.h
@@ -75,12 +75,13 @@ public:
 public slots:
     void objectAdded(QObject *object);
     void objectRemoved(QObject *object);
-    void scanForShortcutDuplicates() const;
 
 private slots:
     void actionChanged();
 
 private:
+    void scanForShortcutDuplicates() const;
+
     // sorted vector of QActions
     QVector<QAction *> m_actions;
 

--- a/plugins/actioninspector/actionmodel.h
+++ b/plugins/actioninspector/actionmodel.h
@@ -75,6 +75,7 @@ public:
 public slots:
     void objectAdded(QObject *object);
     void objectRemoved(QObject *object);
+    void scanForShortcutDuplicates() const;
 
 private slots:
     void actionChanged();

--- a/plugins/actioninspector/actionvalidator.cpp
+++ b/plugins/actioninspector/actionvalidator.cpp
@@ -124,7 +124,8 @@ void ActionValidator::handleActionDestroyed(QObject *object)
 
 bool ActionValidator::hasAmbiguousShortcut(const QAction *action) const
 {
-    return std::any_of(action->shortcuts().constBegin(), action->shortcuts().constEnd(),
+    QList<QKeySequence> shortcuts = action->shortcuts();
+    return std::any_of(shortcuts.constBegin(), shortcuts.constEnd(),
                        [action, this](const QKeySequence &seq) { return isAmbigous(action, seq); });
 }
 

--- a/plugins/actioninspector/actionvalidator.cpp
+++ b/plugins/actioninspector/actionvalidator.cpp
@@ -29,8 +29,10 @@
 #include "actionvalidator.h"
 
 #include <QAction>
+#include <QMutexLocker>
 
 #include <core/objectdataprovider.h>
+#include <core/probe.h>
 #include <core/problemcollector.h>
 #include <common/problem.h>
 
@@ -144,8 +146,14 @@ QVector<QKeySequence> GammaRay::ActionValidator::findAmbiguousShortcuts(const QA
 
 bool GammaRay::ActionValidator::isAmbigous(const QAction *action, const QKeySequence &sequence) const
 {
+    Q_ASSERT(action);
+    QMutexLocker lock(Probe::objectLock());
+    if (!Probe::instance()->isValidObject(action)) {
+        return false;
+    }
+
     Q_FOREACH(const QAction *other, m_shortcutActionMap.values(sequence)) {
-        if (other == action) {
+        if (!other || other == action || !Probe::instance()->isValidObject(other)) {
             continue;
         }
         if (action->shortcutContext() == Qt::ApplicationShortcut

--- a/plugins/actioninspector/actionvalidator.cpp
+++ b/plugins/actioninspector/actionvalidator.cpp
@@ -30,6 +30,7 @@
 
 #include <QAction>
 
+#include <core/objectdataprovider.h>
 #include <core/problemcollector.h>
 #include <common/problem.h>
 
@@ -86,6 +87,7 @@ void ActionValidator::insert(QAction *action)
             p.severity = Problem::Error;
             p.description = QStringLiteral("Key sequence %1 is ambigous.").arg(sequence.toString());
             p.object = ObjectId(action);
+            p.location = ObjectDataProvider::creationLocation(action);
             std::cout << "###################GammaRay synes" << qPrintable(p.description) << std::endl;
             ProblemCollector::addProblem(p);
         }

--- a/plugins/actioninspector/actionvalidator.cpp
+++ b/plugins/actioninspector/actionvalidator.cpp
@@ -122,7 +122,7 @@ void ActionValidator::handleActionDestroyed(QObject *object)
 
 bool ActionValidator::hasAmbiguousShortcut(const QAction *action) const
 {
-    return std::any_of(action->shortcuts().cbegin(), action->shortcuts().cend(),
+    return std::any_of(action->shortcuts().constBegin(), action->shortcuts().constEnd(),
                        [action, this](const QKeySequence &seq) { return isAmbigous(action, seq); });
 }
 

--- a/plugins/actioninspector/actionvalidator.cpp
+++ b/plugins/actioninspector/actionvalidator.cpp
@@ -30,6 +30,9 @@
 
 #include <QAction>
 
+#include <core/problemcollector.h>
+#include <common/problem.h>
+
 using namespace GammaRay;
 
 QT_BEGIN_NAMESPACE
@@ -69,7 +72,7 @@ void ActionValidator::clearActions()
 {
     m_shortcutActionMap.clear();
 }
-
+#include <iostream>
 void ActionValidator::insert(QAction *action)
 {
     Q_ASSERT(action);
@@ -77,6 +80,15 @@ void ActionValidator::insert(QAction *action)
     Q_FOREACH(const QKeySequence &sequence, action->shortcuts()) {
         if (m_shortcutActionMap.values(sequence).contains(action))
             continue;
+
+        if (m_shortcutActionMap.contains(sequence)) {
+            Problem p;
+            p.severity = Problem::Error;
+            p.description = QStringLiteral("Key sequence %1 is ambigous.").arg(sequence.toString());
+            p.object = ObjectId(action);
+            std::cout << "###################GammaRay synes" << qPrintable(p.description) << std::endl;
+            ProblemCollector::addProblem(p);
+        }
 
         m_shortcutActionMap.insertMulti(sequence, action);
     }

--- a/plugins/actioninspector/actionvalidator.h
+++ b/plugins/actioninspector/actionvalidator.h
@@ -57,6 +57,8 @@ public:
 
     /// helper method to find out if action has an ambiguous shortcut
     bool hasAmbiguousShortcut(const QAction *action) const;
+    bool isAmbigous(const QAction *action, const QKeySequence &sequence) const;
+    QVector<QKeySequence> findAmbiguousShortcuts(const QAction *action) const;
 
 private Q_SLOTS:
     void handleActionDestroyed(QObject *object);

--- a/plugins/qmlsupport/qmlbindingprovider.cpp
+++ b/plugins/qmlsupport/qmlbindingprovider.cpp
@@ -78,7 +78,7 @@ void QmlBindingProvider::fetchSourceLocationFor(BindingNode *node, QQmlBinding *
 std::vector<std::unique_ptr<BindingNode>> QmlBindingProvider::findDependenciesFor(BindingNode *node) const
 {
     std::vector<std::unique_ptr<BindingNode>> dependencies;
-    if (node->isBindingLoop()) // Don't look for further dependencies, if this is already known to be part of a loop.
+    if (node->hasFoundBindingLoop()) // Don't look for further dependencies, if this is already known to be part of a loop.
         return dependencies;
 
     QQmlAbstractBinding *abstractBinding = QQmlPropertyPrivate::binding(node->object(), QQmlPropertyIndex::fromEncoded(node->propertyIndex()));

--- a/plugins/qmlsupport/qmlsupport.cpp
+++ b/plugins/qmlsupport/qmlsupport.cpp
@@ -46,7 +46,7 @@
 #include <core/propertyadaptorfactory.h>
 #include <core/propertycontroller.h>
 #include <core/objectdataprovider.h>
-#include <core/tools/objectinspector/bindingmodel.h>
+#include <core/tools/objectinspector/bindingextension.h>
 
 #include <common/metatypedeclarations.h>
 #include <common/sourcelocation.h>
@@ -388,7 +388,7 @@ QmlSupport::QmlSupport(Probe *probe, QObject *parent)
     PropertyController::registerExtension<QmlTypeExtension>();
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-    BindingModel::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QmlBindingProvider));
+    BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QmlBindingProvider));
 #endif
 
     static auto dataProvider = new QmlObjectDataProvider;

--- a/plugins/qmlsupport/qmlsupport.cpp
+++ b/plugins/qmlsupport/qmlsupport.cpp
@@ -46,7 +46,7 @@
 #include <core/propertyadaptorfactory.h>
 #include <core/propertycontroller.h>
 #include <core/objectdataprovider.h>
-#include <core/tools/objectinspector/bindingextension.h>
+#include <core/bindingaggregator.h>
 
 #include <common/metatypedeclarations.h>
 #include <common/sourcelocation.h>
@@ -388,7 +388,7 @@ QmlSupport::QmlSupport(Probe *probe, QObject *parent)
     PropertyController::registerExtension<QmlTypeExtension>();
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-    BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QmlBindingProvider));
+    BindingAggregator::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QmlBindingProvider));
 #endif
 
     static auto dataProvider = new QmlObjectDataProvider;

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -60,7 +60,7 @@
 #include <core/varianthandler.h>
 #include <core/remoteviewserver.h>
 #include <core/paintanalyzer.h>
-#include <core/tools/objectinspector/bindingmodel.h>
+#include <core/tools/objectinspector/bindingextension.h>
 
 #include <3rdparty/kde/krecursivefilterproxymodel.h>
 
@@ -1160,6 +1160,6 @@ void QuickInspector::registerPCExtensions()
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    BindingModel::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));
+    BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));
 #endif
 }

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -60,7 +60,7 @@
 #include <core/varianthandler.h>
 #include <core/remoteviewserver.h>
 #include <core/paintanalyzer.h>
-#include <core/tools/objectinspector/bindingextension.h>
+#include <core/bindingaggregator.h>
 
 #include <3rdparty/kde/krecursivefilterproxymodel.h>
 
@@ -1160,6 +1160,6 @@ void QuickInspector::registerPCExtensions()
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    BindingExtension::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));
+    BindingAggregator::registerBindingProvider(std::unique_ptr<AbstractBindingProvider>(new QuickImplicitBindingDependencyProvider));
 #endif
 }

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -31,6 +31,8 @@
 
 #include <core/paintanalyzer.h>
 #include <core/probe.h>
+#include <core/problemcollector.h>
+#include <common/problem.h>
 
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -395,6 +397,13 @@ void QuickItemModel::updateItemFlags(QQuickItem *item)
             outOfView = partiallyOutOfView && !rect.intersects(ancestorRect);
 
             if (outOfView) {
+                Problem p;
+                p.severity = Problem::Info;
+                p.description = QStringLiteral("QtQuick Item %1 is visible, but out of view.").arg(ObjectDataProvider::typeName(item));
+                p.object = ObjectId(item);
+                p.location = ObjectDataProvider::creationLocation(item);
+                p.problemId = QString::number(reinterpret_cast<qintptr>(item)) + ".OutOfView";
+                ProblemCollector::addProblem(p);
                 break;
             }
         }

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -399,12 +399,19 @@ void QuickItemModel::updateItemFlags(QQuickItem *item)
             if (outOfView) {
                 Problem p;
                 p.severity = Problem::Info;
-                p.description = QStringLiteral("QtQuick Item %1 is visible, but out of view.").arg(ObjectDataProvider::typeName(item));
+                p.description = QStringLiteral("QtQuick: %1 %2 (0x%3) is visible, but out of view.").arg(
+                    ObjectDataProvider::typeName(item),
+                    ObjectDataProvider::name(item),
+                    QString::number(reinterpret_cast<quintptr>(item), 16)
+                );
                 p.object = ObjectId(item);
                 p.location = ObjectDataProvider::creationLocation(item);
-                p.problemId = QString::number(reinterpret_cast<quintptr>(item)) + ".OutOfView";
+                p.problemId = QStringLiteral("OutOfView:%1").arg(reinterpret_cast<quintptr>(item));
+                p.findingCategory = Problem::Live;
                 ProblemCollector::addProblem(p);
                 break;
+            } else {
+                ProblemCollector::removeProblem(QStringLiteral("OutOfView:%1").arg(reinterpret_cast<quintptr>(item)));
             }
         }
         ancestor = ancestor->parentItem();

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -402,7 +402,7 @@ void QuickItemModel::updateItemFlags(QQuickItem *item)
                 p.description = QStringLiteral("QtQuick Item %1 is visible, but out of view.").arg(ObjectDataProvider::typeName(item));
                 p.object = ObjectId(item);
                 p.location = ObjectDataProvider::creationLocation(item);
-                p.problemId = QString::number(reinterpret_cast<qintptr>(item)) + ".OutOfView";
+                p.problemId = QString::number(reinterpret_cast<quintptr>(item)) + ".OutOfView";
                 ProblemCollector::addProblem(p);
                 break;
             }

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -405,7 +405,7 @@ void QuickItemModel::updateItemFlags(QQuickItem *item)
                     QString::number(reinterpret_cast<quintptr>(item), 16)
                 );
                 p.object = ObjectId(item);
-                p.location = ObjectDataProvider::creationLocation(item);
+                p.locations.push_back(ObjectDataProvider::creationLocation(item));
                 p.problemId = QStringLiteral("OutOfView:%1").arg(reinterpret_cast<quintptr>(item));
                 p.findingCategory = Problem::Live;
                 ProblemCollector::addProblem(p);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,6 +207,15 @@ target_link_libraries(executiontest ${QT_QTGUI_LIBRARIES} gammaray_core)
 gammaray_add_test(metaobjecttest metaobjecttest.cpp)
 target_link_libraries(metaobjecttest gammaray_core)
 
+gammaray_add_probe_test(problemreportertest problemreportertest.cpp $<TARGET_OBJECTS:modeltestobj>)
+target_link_libraries(problemreportertest gammaray_core)
+if(Qt5Qml_FOUND)
+    target_link_libraries(problemreportertest Qt5::Qml)
+endif()
+if (Qt5Widgets_FOUND)
+    target_link_libraries(problemreportertest Qt5::Widgets)
+endif()
+
 gammaray_add_test(objectinstancetest objectinstancetest.cpp)
 target_link_libraries(objectinstancetest gammaray_core)
 

--- a/tests/actiontest.cpp
+++ b/tests/actiontest.cpp
@@ -79,8 +79,10 @@ private slots:
 
         QAction *a1 = new QAction(QStringLiteral("Action 1"), this);
         a1->setShortcut(QKeySequence(QStringLiteral("Ctrl+K")));
+        a1->setShortcutContext(Qt::ApplicationShortcut);
         QAction *a2 = new QAction(QStringLiteral("Action 2"), this);
         a2->setShortcut(QKeySequence(QStringLiteral("Ctrl+K")));
+        a2->setShortcutContext(Qt::WidgetShortcut);
         QTest::qWait(1); // event loop re-entry
 
         auto sourceModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ActionModel"));

--- a/tests/bindinginspectortest.cpp
+++ b/tests/bindinginspectortest.cpp
@@ -38,6 +38,7 @@
 #include <probe/probecreator.h>
 
 #include <core/abstractbindingprovider.h>
+#include <core/bindingaggregator.h>
 #include <core/bindingnode.h>
 #include <core/tools/objectinspector/bindingextension.h>
 #include <core/tools/objectinspector/bindingmodel.h>
@@ -258,7 +259,7 @@ void BindingInspectorTest::initTestCase()
 {
     QQmlEngine engine; // Needed to initialize the Qml support plugin
     provider = new MockBindingProvider;
-    BindingExtension::registerBindingProvider(std::unique_ptr<MockBindingProvider>(provider));
+    BindingAggregator::registerBindingProvider(std::unique_ptr<MockBindingProvider>(provider));
 
     QTest::qWait(1);
     bindingExtension = ObjectBroker::object<BindingExtension*>("com.kdab.GammaRay.ObjectInspector.bindingsExtension");

--- a/tests/bindinginspectortest.cpp
+++ b/tests/bindinginspectortest.cpp
@@ -286,7 +286,7 @@ void BindingInspectorTest::testMockProvider()
     QVERIFY(bindingNode1->parent() == nullptr);
     QCOMPARE(bindingNode1->object(), &obj1);
     QCOMPARE(bindingNode1->property().name(), "a");
-    QCOMPARE(bindingNode1->isBindingLoop(), false);
+    QCOMPARE(bindingNode1->isPartOfBindingLoop(), false);
     QCOMPARE(bindingNode1->cachedValue().toInt(), 53);
 
     auto dependencies1 = provider->findDependenciesFor(bindingNode1.get());
@@ -299,7 +299,7 @@ void BindingInspectorTest::testMockProvider()
     QVERIFY(bindingNode2->parent() == nullptr);
     QCOMPARE(bindingNode2->object(), &obj1);
     QCOMPARE(bindingNode2->property().name(), "c");
-    QCOMPARE(bindingNode2->isBindingLoop(), false);
+    QCOMPARE(bindingNode2->isPartOfBindingLoop(), false);
     QCOMPARE(bindingNode2->cachedValue().toChar(), QChar('x'));
 
     auto dependencies2 = provider->findDependenciesFor(bindingNode2.get());
@@ -308,13 +308,13 @@ void BindingInspectorTest::testMockProvider()
     QCOMPARE(dependency2->parent(), bindingNode2.get());
     QCOMPARE(dependency2->object(), &obj1);
     QCOMPARE(dependency2->property().name(), "b");
-    QCOMPARE(dependency2->isBindingLoop(), false);
+    QCOMPARE(dependency2->isPartOfBindingLoop(), false);
     QCOMPARE(dependency2->cachedValue().toBool(), true);
     auto &&dependency3 = dependencies2.back();
     QCOMPARE(dependency3->parent(), bindingNode2.get());
     QCOMPARE(dependency3->object(), &obj2);
     QCOMPARE(dependency3->property().name(), "b");
-    QCOMPARE(dependency3->isBindingLoop(), false);
+    QCOMPARE(dependency3->isPartOfBindingLoop(), false);
     QCOMPARE(dependency3->cachedValue().toBool(), false);
 }
 
@@ -412,7 +412,7 @@ void BindingInspectorTest::testQmlBindingProvider()
     QVERIFY(bindingNode);
     QCOMPARE(bindingNode->object(), text);
     QCOMPARE(bindingNode->property().name(), "text");
-    QCOMPARE(bindingNode->isBindingLoop(), false);
+    QCOMPARE(bindingNode->isPartOfBindingLoop(), false);
     QCOMPARE(bindingNode->cachedValue(), QStringLiteral("Hello world!"));
 
     auto dependencies = provider.findDependenciesFor(bindingNode.get());
@@ -420,7 +420,7 @@ void BindingInspectorTest::testQmlBindingProvider()
     const std::unique_ptr<BindingNode> &dependency = dependencies.front();
     QCOMPARE(dependency->object(), referencedObject);
     QCOMPARE(dependency->property().name(), "labelText");
-    QCOMPARE(dependency->isBindingLoop(), false);
+    QCOMPARE(dependency->isPartOfBindingLoop(), false);
     QCOMPARE(dependency->cachedValue(), QStringLiteral("Hello world!"));
     QCOMPARE(dependency->dependencies().size(), 0);
 

--- a/tests/bindinginspectortest.cpp
+++ b/tests/bindinginspectortest.cpp
@@ -252,7 +252,7 @@ private:
     MockBindingProvider *provider;
     BindingExtension *bindingExtension;
     std::unique_ptr<ModelTest> modelTest;
-    BindingModel *bindingModel;
+    QAbstractItemModel *bindingModel;
 };
 
 void BindingInspectorTest::initTestCase()

--- a/tests/problemreportertest.cpp
+++ b/tests/problemreportertest.cpp
@@ -1,0 +1,452 @@
+/*
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "baseprobetest.h"
+
+#include <core/problemcollector.h>
+#include <common/problem.h>
+#include <common/sourcelocation.h>
+#include <common/objectbroker.h>
+#include <3rdparty/qt/modeltest.h>
+
+#include <common/tools/problemreporter/problemmodelroles.h>
+
+#include <QDebug>
+#include <QTest>
+#include <QObject>
+#include <QThread>
+#include <QThreadPool>
+#include <QRunnable>
+#include <QUuid>
+
+#ifdef QT_QML_LIB
+#include <QQmlEngine>
+#include <QQmlComponent>
+#include <QQmlContext>
+#endif
+
+#ifdef HAVE_QT_WIDGETS
+#include <QAction>
+#include <QKeySequence>
+#endif
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+#include <qtest_global.h>
+#endif
+
+namespace GammaRay {
+
+class CrossThreadConnectionTask : public QRunnable
+{
+public:
+    void run() override
+    {
+        newThreadObj.reset(new QObject());
+        newThreadObj->setObjectName("newThreadObj");
+        QObject::connect(newThreadObj.get(), SIGNAL(destroyed(QObject*)), mainThreadObj.get(), SLOT(deleteLater()), Qt::DirectConnection);
+    }
+    std::unique_ptr<QObject> newThreadObj;
+    std::unique_ptr<QObject> mainThreadObj;
+};
+
+struct UnregisteredType {};
+
+class FaultyMetaObjectBaseClass : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(UnregisteredType someProp READ someProp CONSTANT)
+    UnregisteredType someProp() const { return UnregisteredType(); }
+};
+
+class FaultyMetaObjectClass : public FaultyMetaObjectBaseClass
+{
+    Q_OBJECT
+
+    Q_PROPERTY(UnregisteredType someProp READ someProp CONSTANT)
+
+public:
+    Q_INVOKABLE void noop(UnregisteredType param) { Q_UNUSED(param) }
+
+    UnregisteredType someProp() const { return UnregisteredType(); }
+};
+
+class ProblemReporterTest : public BaseProbeTest
+{
+    Q_OBJECT
+
+    static void dummyScan()
+    {
+        Problem p1;
+        p1.problemId = QUuid::createUuid().toString();
+        p1.findingCategory = Problem::Scan;
+        ProblemCollector::addProblem(p1);
+
+        Problem p2;
+        p2.problemId = QUuid::createUuid().toString();
+        p2.findingCategory = Problem::Scan;
+        ProblemCollector::addProblem(p2);
+    }
+
+    std::unique_ptr<ModelTest> problemModelTest;
+    std::unique_ptr<ModelTest> availableCheckersModelTest;
+
+private slots:
+    void initTestCase()
+    {
+        createProbe();
+        problemModelTest.reset(new ModelTest(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ProblemModel"))));
+        availableCheckersModelTest.reset(new ModelTest(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.AvailableProblemCheckersModel"))));
+    }
+
+    void cleanup()
+    {
+        ProblemCollector::instance()->clearScans();
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
+    }
+
+    void testDuplicates()
+    {
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
+
+        Problem p1;
+        p1.problemId = QStringLiteral("9skjlksdjb");
+        ProblemCollector::addProblem(p1);
+
+        Problem p2;
+        p2.problemId = QStringLiteral("9skjlksdjb");
+        ProblemCollector::addProblem(p2);
+
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 1);
+
+        ProblemCollector::removeProblem(QStringLiteral("9skjlksdjb"));
+    }
+
+    void testMultipleSourceLocations()
+    {
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
+
+        SourceLocation l1 = SourceLocation::fromOneBased(QUrl("../main.qml"), 101, 42);
+        SourceLocation l2 = SourceLocation::fromOneBased(QUrl("A.qml"), 43, 21);
+        SourceLocation l3 = SourceLocation::fromOneBased(QUrl("../../src/Singleton.cpp"), 555, 1);
+        SourceLocation l4 = SourceLocation::fromOneBased(QUrl("../main.qml"), 101, 42);
+        SourceLocation l5 = SourceLocation::fromOneBased(QUrl("A.qml"), 44, 21);
+
+        Problem p1;
+        p1.problemId = QStringLiteral("abcdefg");
+        ProblemCollector::addProblem(p1);
+
+        Problem p2;
+        p2.problemId = QStringLiteral("abcdefg");
+        p2.locations << l1;
+        ProblemCollector::addProblem(p2);
+
+        Problem p3;
+        p3.problemId = QStringLiteral("abcdefg");
+        p3.locations << l2 << l3 << l4;
+        ProblemCollector::addProblem(p3);
+
+        Problem p4;
+        p4.problemId = QStringLiteral("abcdefg");
+        p4.locations << l5;
+        ProblemCollector::addProblem(p4);
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 1);
+
+        QCOMPARE(ProblemCollector::instance()->problems().front().locations.size(), 4);
+        QCOMPARE(ProblemCollector::instance()->problems().front().locations.at(0), SourceLocation::fromOneBased(QUrl("../main.qml"), 101, 42));
+        QCOMPARE(ProblemCollector::instance()->problems().front().locations.at(1), SourceLocation::fromOneBased(QUrl("A.qml"), 43, 21));
+        QCOMPARE(ProblemCollector::instance()->problems().front().locations.at(2), SourceLocation::fromOneBased(QUrl("../../src/Singleton.cpp"), 555, 1));
+        QCOMPARE(ProblemCollector::instance()->problems().front().locations.at(3), SourceLocation::fromOneBased(QUrl("A.qml"), 44, 21));
+
+        ProblemCollector::removeProblem(QStringLiteral("abcdefg"));
+    }
+
+    void testScans()
+    {
+        auto standardCheckersCount = ProblemCollector::instance()->availableCheckers().size();
+        ProblemCollector::registerProblemChecker(QStringLiteral("Dummy"),
+                                                 QStringLiteral("Dummy"),
+                                                 QStringLiteral("Always reports two dummy problems"),
+                                                 &ProblemReporterTest::dummyScan);
+
+        QCOMPARE(ProblemCollector::instance()->availableCheckers().size(), standardCheckersCount + 1);
+
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
+        ProblemCollector::instance()->requestScan();
+        auto problemsFromScansCount = ProblemCollector::instance()->problems().size();
+        ProblemCollector::instance()->requestScan(); // scans should always be reproducable if the program didn't change.
+        QCOMPARE(ProblemCollector::instance()->problems().size(), problemsFromScansCount);
+
+        auto dummyChecker = std::find_if(ProblemCollector::instance()->availableCheckers().begin(),
+                                         ProblemCollector::instance()->availableCheckers().end(),
+                                         [](const ProblemCollector::Checker &c) { return c.id == QStringLiteral("Dummy"); }
+                                        );
+        dummyChecker->enabled = false;
+
+        ProblemCollector::instance()->requestScan(); // scans should always be reproducable if the program didn't change.
+        QCOMPARE(ProblemCollector::instance()->problems().size(), problemsFromScansCount - 2);
+        dummyChecker->enabled = true;
+
+        Problem p1;
+        p1.problemId = QStringLiteral("9skjlksdjb");
+        p1.findingCategory = Problem::Live;
+        ProblemCollector::addProblem(p1);
+        Problem p2;
+        p2.problemId = QStringLiteral("abcdefg");
+        p2.findingCategory = Problem::Permanent;
+        ProblemCollector::addProblem(p2);
+
+        // all problems originating from a scan should be deleted before doing a new scan, but not live- and permanent problems
+        ProblemCollector::instance()->requestScan();
+        QCOMPARE(ProblemCollector::instance()->problems().size(), problemsFromScansCount + 2);
+
+
+        ProblemCollector::instance()->clearScans();
+        QCOMPARE(ProblemCollector::instance()->problems().size(), 2);
+        ProblemCollector::removeProblem(QStringLiteral("9skjlksdjb"));
+        ProblemCollector::removeProblem(QStringLiteral("abcdefg"));
+
+        ProblemCollector::instance()->availableCheckers().erase(dummyChecker);
+    }
+
+    void testAvailableScansModel()
+    {
+        auto model = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.AvailableProblemCheckersModel"));
+        auto rowCount = model->rowCount();
+        ProblemCollector::registerProblemChecker(QStringLiteral("Dummy"),
+                                                 QStringLiteral("Dummy"),
+                                                 QStringLiteral("Always reports two dummy problems"),
+                                                 &ProblemReporterTest::dummyScan);
+        QCOMPARE(model->rowCount(), rowCount + 1);
+
+        auto &checkers = ProblemCollector::instance()->availableCheckers();
+        checkers.erase(std::remove_if(checkers.begin(),
+                                      checkers.end(),
+                                      [](ProblemCollector::Checker &c) { return c.id == "Dummy"; }
+                                     ));
+        QCOMPARE(model->rowCount(), rowCount);
+    }
+
+    void testProblemModel()
+    {
+        auto model = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ProblemModel"));
+        auto rowCount = model->rowCount();
+
+        Problem p1;
+        p1.problemId = QStringLiteral("9skjlksdjb");
+        p1.description = QStringLiteral("Lorem ipsum dolor sit amet.");
+        p1.severity = Problem::Warning;
+        SourceLocation l1 = SourceLocation::fromOneBased(QUrl("../main.qml"), 101, 42);
+        SourceLocation l2 = SourceLocation::fromOneBased(QUrl("A.qml"), 43, 21);
+        p1.object = ObjectId(this);
+        p1.locations << l1 << l2;
+        ProblemCollector::addProblem(p1);
+
+        Problem p2;
+        p2.problemId = QStringLiteral("asdf");
+        ProblemCollector::addProblem(p2);
+
+        QCOMPARE(model->rowCount(), rowCount + 2);
+
+        auto index = model->index(rowCount, 0, QModelIndex());
+        QCOMPARE(index.data(Qt::DisplayRole).toString(), QStringLiteral("Lorem ipsum dolor sit amet."));
+        QCOMPARE(index.sibling(rowCount, 1).data(Qt::DisplayRole).toString(), l1.displayString());
+        QCOMPARE(index.data(ObjectModel::ObjectIdRole).value<ObjectId>(), ObjectId(this));
+        QCOMPARE(index.data(ProblemModelRoles::SourceLocationRole).value<QVector<SourceLocation>>(), p1.locations);
+        QCOMPARE(index.data(ProblemModelRoles::SeverityRole).value<int>(), static_cast<int>(Problem::Warning));
+        QCOMPARE(index.data(ProblemModelRoles::ProblemIdRole).toString(), QStringLiteral("9skjlksdjb"));
+
+
+        ProblemCollector::removeProblem(QStringLiteral("9skjlksdjb"));
+        QCOMPARE(model->rowCount(), rowCount + 1);
+        ProblemCollector::removeProblem(QStringLiteral("asdf"));
+        QCOMPARE(model->rowCount(), rowCount);
+    }
+
+#ifdef QT_QML_LIB
+    void testBindingLoopChecker()
+    {
+        QQmlEngine engine;
+        QQmlComponent c(&engine);
+        c.setData("import QtQml 2.0\n"
+                  "QtObject{id: root\n"
+                  "  property list<QtObject> children: [\n"
+                  "  QtObject {id: a; objectName: b.objectName },\n"
+                  "  QtObject {id: b; objectName: a.objectName }\n"
+                  "  ]\n"
+                  "}",
+                  QUrl());
+
+        std::unique_ptr<QObject> obj(c.create());
+        QTest::qWait(1);
+        QVERIFY(static_cast<bool>(obj));
+
+        auto &checkers = ProblemCollector::instance()->availableCheckers();
+        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
+                    [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.ObjectInspector.BindingLoopScan"; }
+                   ));
+
+        ProblemCollector::instance()->requestScan();
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+        QEXPECT_FAIL("", "Can't find QML bindings with Qt < 5.10.", Abort);
+#endif
+        const auto &problems = ProblemCollector::instance()->problems();
+        QVERIFY(std::any_of(problems.begin(), problems.end(),
+            [](const Problem &p){ return p.problemId.startsWith("com.kdab.GammaRay.ObjectInspector.BindingLoopScan"); }
+        ));
+    }
+#endif
+
+    void testConnectionIssues()
+    {
+        auto &checkers = ProblemCollector::instance()->availableCheckers();
+        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
+                    [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.ObjectInspector.ConnectionsCheck"; }
+                   ));
+
+        auto task = std::unique_ptr<CrossThreadConnectionTask>(new CrossThreadConnectionTask());
+        task->mainThreadObj.reset(new QObject());
+        task->mainThreadObj->setObjectName("mainThreadObj");
+        task->setAutoDelete(false);
+        // QThreadPool takes ownership and deletes 'hello' automatically
+        QThreadPool::globalInstance()->start(task.get());
+
+        auto o1 = std::unique_ptr<QObject>(new QObject());
+        o1->setObjectName("o1");
+        auto o2 = std::unique_ptr<QObject>(new QObject());
+        o2->setObjectName("o2");
+        connect(o1.get(), SIGNAL(destroyed(QObject*)), o2.get(), SLOT(deleteLater()));
+        connect(o1.get(), SIGNAL(destroyed(QObject*)), o2.get(), SLOT(deleteLater()));
+
+        QTest::qWait(10);
+        ProblemCollector::instance()->requestScan();
+
+        o1->disconnect();
+        task->newThreadObj->disconnect();
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+        QEXPECT_FAIL("", "Can't access the connections of object in Qt4.", Abort);
+#endif
+
+        const auto &problems = ProblemCollector::instance()->problems();
+        auto crossThreadProblem = std::find_if(problems.begin(), problems.end(),
+            [](const Problem &p){ return p.problemId.startsWith("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck.CrossTread"); }
+        );
+
+        QVERIFY(crossThreadProblem != problems.end());
+        QCOMPARE(crossThreadProblem->object, ObjectId(task->mainThreadObj.get()));
+        QVERIFY(crossThreadProblem->description.contains("direct cross-thread connection"));
+        QVERIFY(crossThreadProblem->description.contains("signal newThreadObj"));
+        QVERIFY(crossThreadProblem->description.contains("slot mainThreadObj"));
+
+        auto duplicateProblem = std::find_if(problems.begin(), problems.end(),
+            [](const Problem &p){ return p.problemId.startsWith("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck.Duplicate"); }
+        );
+
+        QVERIFY(duplicateProblem != problems.end());
+        QCOMPARE(duplicateProblem->object, ObjectId(o2.get()));
+        QVERIFY(duplicateProblem->description.contains("multiple times"));
+        QVERIFY(duplicateProblem->description.contains("signal o1"));
+        QVERIFY(duplicateProblem->description.contains("slot o2"));
+    }
+
+    void testMetaTypeChecks()
+    {
+        std::unique_ptr<QObject> obj(new FaultyMetaObjectClass);
+        QTest::qWait(1);
+
+        auto &checkers = ProblemCollector::instance()->availableCheckers();
+        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
+                    [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator"; }
+                   ));
+
+        ProblemCollector::instance()->requestScan();
+
+        const auto &problems = ProblemCollector::instance()->problems();
+        QVERIFY(std::any_of(problems.begin(), problems.end(),
+            [&obj](const Problem &p){
+                return p.problemId.startsWith("com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator")
+                       && p.object == ObjectId(const_cast<QMetaObject*>(obj->metaObject()), "const QMetaObject*")
+                       && p.description.contains(QLatin1String("overrides base class property"));
+            }
+        ));
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+        QEXPECT_FAIL("", "Can't find unregistered types in Qt4.", Abort);
+#endif
+        QVERIFY(std::any_of(problems.begin(), problems.end(),
+            [&obj](const Problem &p){
+                return p.problemId.startsWith("com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator")
+                       && p.object == ObjectId(const_cast<QMetaObject*>(obj->metaObject()), "const QMetaObject*")
+                       && p.description.contains(QLatin1String("parameter type not registered"));
+            }
+        ));
+        QVERIFY(std::any_of(problems.begin(), problems.end(),
+            [&obj](const Problem &p){
+                return p.problemId.startsWith("com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator")
+                       && p.object == ObjectId(const_cast<QMetaObject*>(obj->metaObject()), "const QMetaObject*")
+                       && p.description.contains(QLatin1String("property with a type not registered"));
+            }
+        ));
+
+    }
+
+#ifdef HAVE_QT_WIDGETS
+    void testActionValidator()
+    {
+        QAction *a1 = new QAction(QStringLiteral("Action 1"), this);
+        a1->setShortcut(QKeySequence(QStringLiteral("Ctrl+K")));
+        a1->setShortcutContext(Qt::ApplicationShortcut);
+        QAction *a2 = new QAction(QStringLiteral("Action 2"), this);
+        a2->setShortcut(QKeySequence(QStringLiteral("Ctrl+K")));
+        a2->setShortcutContext(Qt::WidgetShortcut);
+        QTest::qWait(1); // event loop re-entry
+
+        auto &checkers = ProblemCollector::instance()->availableCheckers();
+        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
+                    [](ProblemCollector::Checker &c){ return c.id == "gammaray_actioninspector.ShortcutDuplicates"; }
+                   ));
+
+        ProblemCollector::instance()->requestScan();
+
+        const auto &problems = ProblemCollector::instance()->problems();
+        QVERIFY(std::any_of(problems.begin(), problems.end(),
+            [=](const Problem &p){
+                return p.problemId.startsWith("gammaray_actioninspector.ShortcutDuplicates")
+                       && (p.object == ObjectId(a1) || p.object == ObjectId(a2))
+                       && p.description.contains("ambigous")
+                       && p.description.contains(QKeySequence(QStringLiteral("Ctrl+K")).toString(QKeySequence::PortableText));
+            }
+        ));
+    }
+#endif
+};
+
+}
+
+QTEST_MAIN(ProblemReporterTest)
+
+#include "problemreportertest.moc"

--- a/tests/problemreportertest.cpp
+++ b/tests/problemreportertest.cpp
@@ -379,9 +379,11 @@ private slots:
         QTest::qWait(1);
 
         auto &checkers = ProblemCollector::instance()->availableCheckers();
-        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
+        auto checker = std::find_if(checkers.begin(), checkers.end(),
                     [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.MetaObjectBrowser.QMetaObjectValidator"; }
-                   ));
+                   );
+        QVERIFY(checker != checkers.end());
+        checker->enabled = true;
 
         ProblemCollector::instance()->requestScan();
 

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -79,6 +79,7 @@ set(gammaray_ui_srcs
   tools/objectinspector/bindingtab.cpp
   tools/objectinspector/stacktracetab.cpp
   tools/problemreporter/problemreporterwidget.cpp
+  tools/problemreporter/problemreporterclient.cpp
   tools/problemreporter/problemclientmodel.cpp
   tools/resourcebrowser/clientresourcemodel.cpp
   tools/resourcebrowser/resourcebrowserwidget.cpp

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -78,6 +78,8 @@ set(gammaray_ui_srcs
   tools/objectinspector/applicationattributetab.cpp
   tools/objectinspector/bindingtab.cpp
   tools/objectinspector/stacktracetab.cpp
+  tools/problemreporter/problemreporterwidget.cpp
+  tools/problemreporter/problemclientmodel.cpp
   tools/resourcebrowser/clientresourcemodel.cpp
   tools/resourcebrowser/resourcebrowserwidget.cpp
   tools/resourcebrowser/resourcebrowserclient.cpp

--- a/ui/clienttoolmanager.cpp
+++ b/ui/clienttoolmanager.cpp
@@ -62,7 +62,7 @@ using namespace GammaRay;
 MAKE_FACTORY(MessageHandler,    qApp->translate("GammaRay::MessageHandlerFactory", "Messages"));
 MAKE_FACTORY(MetaObjectBrowser, qApp->translate("GammaRay::MetaObjectBrowserFactory", "Meta Objects"));
 MAKE_FACTORY(MetaTypeBrowser,   qApp->translate("GammaRay::MetaTypeBrowserFactory", "Meta Types"));
-MAKE_FACTORY(ProblemReporter,   qApp->translate("GammaRay::ProblemReporterFactory", "Problem Reporter"));
+MAKE_FACTORY(ProblemReporter,   qApp->translate("GammaRay::ProblemReporterFactory", "Problems"));
 MAKE_FACTORY(ResourceBrowser,   qApp->translate("GammaRay::ResourceBrowserFactory", "Resources"));
 
 struct PluginRepository {

--- a/ui/clienttoolmanager.cpp
+++ b/ui/clienttoolmanager.cpp
@@ -34,6 +34,7 @@
 #include <ui/tools/metaobjectbrowser/metaobjectbrowserwidget.h>
 #include <ui/tools/metatypebrowser/metatypebrowserwidget.h>
 #include <ui/tools/objectinspector/objectinspectorwidget.h>
+#include <ui/tools/problemreporter/problemreporterwidget.h>
 #include <ui/tools/resourcebrowser/resourcebrowserwidget.h>
 
 #include <common/endpoint.h>
@@ -61,6 +62,7 @@ using namespace GammaRay;
 MAKE_FACTORY(MessageHandler,    qApp->translate("GammaRay::MessageHandlerFactory", "Messages"));
 MAKE_FACTORY(MetaObjectBrowser, qApp->translate("GammaRay::MetaObjectBrowserFactory", "Meta Objects"));
 MAKE_FACTORY(MetaTypeBrowser,   qApp->translate("GammaRay::MetaTypeBrowserFactory", "Meta Types"));
+MAKE_FACTORY(ProblemReporter,   qApp->translate("GammaRay::ProblemReporterFactory", "Problem Reporter"));
 MAKE_FACTORY(ResourceBrowser,   qApp->translate("GammaRay::ResourceBrowserFactory", "Resources"));
 
 struct PluginRepository {
@@ -94,6 +96,7 @@ static void initPluginRepository()
     insertFactory(new MetaObjectBrowserFactory);
     insertFactory(new MetaTypeBrowserFactory);
     insertFactory(new ObjectInspectorFactory);
+    insertFactory(new ProblemReporterFactory);
     insertFactory(new ResourceBrowserFactory);
 
     PluginManager<ToolUiFactory, ProxyToolUiFactory> pm;

--- a/ui/contextmenuextension.cpp
+++ b/ui/contextmenuextension.cpp
@@ -71,7 +71,7 @@ ContextMenuExtension::ContextMenuExtension(const ObjectId &id)
 void ContextMenuExtension::setLocation(ContextMenuExtension::Location location,
                                        const SourceLocation &sourceLocation)
 {
-    m_locations[location] = sourceLocation;
+    m_locations.push_back(QPair<Location, SourceLocation>(location, sourceLocation));
 }
 
 bool ContextMenuExtension::discoverSourceLocation(ContextMenuExtension::Location location,
@@ -111,11 +111,11 @@ void ContextMenuExtension::populateMenu(QMenu *menu)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     if (UiIntegration::instance()) {
         for (auto it = m_locations.constBegin(), end = m_locations.constEnd(); it != end; ++it) {
-            if (it.value().isValid()) {
-                auto action = menu->addAction(sourceLocationLabel(it.key(), it.value()));
+            if (it->second.isValid()) {
+                auto action = menu->addAction(sourceLocationLabel(it->first, it->second));
                 QObject::connect(action, &QAction::triggered, UiIntegration::instance(), [it]() {
-                    UiIntegration::requestNavigateToCode(it.value().url(), it.value().line(),
-                                                         it.value().column());
+                    UiIntegration::requestNavigateToCode(it->second.url(), it->second.line(),
+                                                         it->second.column());
                 });
             }
         }

--- a/ui/contextmenuextension.h
+++ b/ui/contextmenuextension.h
@@ -66,7 +66,7 @@ public:
 
 private:
     ObjectId m_id;
-    QMap<Location, SourceLocation> m_locations;
+    QVector<QPair<Location, SourceLocation>> m_locations;
 };
 }
 

--- a/ui/tools/problemreporter/problemclientmodel.cpp
+++ b/ui/tools/problemreporter/problemclientmodel.cpp
@@ -107,6 +107,6 @@ void ProblemClientModel::disableChecker(const QString& id)
 }
 void ProblemClientModel::enableChecker(const QString& id)
 {
-    m_disabledCheckers.removeAll(id);
+    m_disabledCheckers.erase(std::remove(m_disabledCheckers.begin(), m_disabledCheckers.end(), id), m_disabledCheckers.end());
     invalidateFilter();
 }

--- a/ui/tools/problemreporter/problemclientmodel.cpp
+++ b/ui/tools/problemreporter/problemclientmodel.cpp
@@ -1,0 +1,98 @@
+/*
+  problemclientmodel.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2016-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "problemclientmodel.h"
+
+#include <common/problem.h>
+#include <common/objectmodel.h>
+#include <common/tools/problemreporter/problemmodelroles.h>
+
+#include <uiresources.h>
+
+#include <QApplication>
+#include <QStyle>
+
+using namespace GammaRay;
+
+ProblemClientModel::ProblemClientModel(QObject* parent)
+    : QSortFilterProxyModel(parent)
+{
+}
+
+ProblemClientModel::~ProblemClientModel()
+{
+}
+
+QVariant ProblemClientModel::data(const QModelIndex& index, int role) const
+{
+    if (role == Qt::DecorationRole) {
+        auto severity = QSortFilterProxyModel::data(index, ProblemModelRoles::SeverityRole).value<int>();
+        switch (severity) {
+        case Problem::Info:
+            return QVariant::fromValue(QIcon::fromTheme(QStringLiteral("dialog-information")));
+        case Problem::Warning:
+            return QVariant::fromValue(UIResources::themedIcon(QStringLiteral("warning.png")).pixmap(16, 16));
+        case Problem::Error:
+            return QVariant::fromValue(QIcon::fromTheme(QStringLiteral("dialog-error")));
+        }
+    }
+    return QSortFilterProxyModel::data(index, role);
+}
+
+QVariant ProblemClientModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Horizontal) {
+        if (role == Qt::DisplayRole) {
+            switch (section) {
+                case 0:
+                    return tr("Problem Description");
+                case 1:
+                    return tr("Meta Type Id");
+                case 2:
+                    return tr("Size");
+                case 3:
+                    return tr("Meta Object");
+                case 4:
+                    return tr("Type Flags");
+                case 5:
+                    return tr("Compare");
+                case 6:
+                    return tr("Debug");
+            }
+        } else if (role == Qt::ToolTipRole) {
+            switch (section) {
+                case 5:
+                    return tr("Has equality comparison operators registered.");
+                case 6:
+                    return tr("Has debug stream operators registered.");
+            }
+        }
+        return QVariant();
+    }
+    return QSortFilterProxyModel::headerData(section, orientation, role);
+}

--- a/ui/tools/problemreporter/problemclientmodel.cpp
+++ b/ui/tools/problemreporter/problemclientmodel.cpp
@@ -51,6 +51,10 @@ ProblemClientModel::~ProblemClientModel()
 QVariant ProblemClientModel::data(const QModelIndex& index, int role) const
 {
     if (role == Qt::DecorationRole) {
+        if (index.column() != 0) {
+            return QVariant();
+        }
+
         auto severity = QSortFilterProxyModel::data(index, ProblemModelRoles::SeverityRole).value<int>();
         switch (severity) {
         case Problem::Info:
@@ -72,24 +76,7 @@ QVariant ProblemClientModel::headerData(int section, Qt::Orientation orientation
                 case 0:
                     return tr("Problem Description");
                 case 1:
-                    return tr("Meta Type Id");
-                case 2:
-                    return tr("Size");
-                case 3:
-                    return tr("Meta Object");
-                case 4:
-                    return tr("Type Flags");
-                case 5:
-                    return tr("Compare");
-                case 6:
-                    return tr("Debug");
-            }
-        } else if (role == Qt::ToolTipRole) {
-            switch (section) {
-                case 5:
-                    return tr("Has equality comparison operators registered.");
-                case 6:
-                    return tr("Has debug stream operators registered.");
+                    return tr("Source Location");
             }
         }
         return QVariant();

--- a/ui/tools/problemreporter/problemclientmodel.cpp
+++ b/ui/tools/problemreporter/problemclientmodel.cpp
@@ -83,3 +83,30 @@ QVariant ProblemClientModel::headerData(int section, Qt::Orientation orientation
     }
     return QSortFilterProxyModel::headerData(section, orientation, role);
 }
+
+bool ProblemClientModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const
+{
+    if (!QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent)) { // Implement the usual search-bar filtering
+        return false;
+    }
+
+    auto index = sourceModel()->index(source_row, 0, source_parent);
+    auto id = index.data(ProblemModelRoles::ProblemIdRole).toString();
+
+    return std::none_of(m_disabledCheckers.begin(), m_disabledCheckers.end(),
+        [id](const QString &checkerId) { return id.startsWith(checkerId); });
+}
+
+void ProblemClientModel::disableChecker(const QString& id)
+{
+    if (m_disabledCheckers.contains(id))
+        return;
+
+    m_disabledCheckers.push_back(id);
+    invalidateFilter();
+}
+void ProblemClientModel::enableChecker(const QString& id)
+{
+    m_disabledCheckers.removeAll(id);
+    invalidateFilter();
+}

--- a/ui/tools/problemreporter/problemclientmodel.h
+++ b/ui/tools/problemreporter/problemclientmodel.h
@@ -1,5 +1,5 @@
 /*
-  clienttoolmodel.h
+  problemclientmodel.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -26,53 +26,25 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_CLIENTTOOLMODEL_H
-#define GAMMARAY_CLIENTTOOLMODEL_H
+#ifndef GAMMARAY_PROBLEMCLIENTMODEL_H
+#define GAMMARAY_PROBLEMCLIENTMODEL_H
 
-#include <QAbstractListModel>
-#include <QItemSelectionModel>
+#include <QSortFilterProxyModel>
 
 namespace GammaRay {
 
-class ClientToolManager;
-
-/*! Model of all selectable client tools. */
-class ClientToolModel : public QAbstractListModel
+/*! Client-side part of the meta types model. */
+class ProblemClientModel : public QSortFilterProxyModel
 {
     Q_OBJECT
 public:
-    explicit ClientToolModel(ClientToolManager *manager);
-    virtual ~ClientToolModel();
+    explicit ProblemClientModel(QObject *parent = nullptr);
+    ~ProblemClientModel();
 
-    QVariant data(const QModelIndex &index, int role) const override;
-    Qt::ItemFlags flags(const QModelIndex &index) const override;
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-
-private slots:
-    void startReset();
-    void finishReset();
-    void toolEnabled(int toolIndex);
-
-private:
-    ClientToolManager *m_toolManager;
-};
-
-/*! Selection model that automatically syncs ClientToolModel with ClientToolManager. */
-class ClientToolSelectionModel : public QItemSelectionModel
-{
-    Q_OBJECT
-public:
-    explicit ClientToolSelectionModel(ClientToolManager *manager);
-    ~ClientToolSelectionModel();
-
-private slots:
-    void selectTool(int index);
-    void selectDefaultTool();
-
-private:
-    ClientToolManager *m_toolManager;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 };
 
 }
 
-#endif // GAMMARAY_CLIENTTOOLMODEL_H
+#endif // GAMMARAY_PROBLEMCLIENTMODEL_H

--- a/ui/tools/problemreporter/problemclientmodel.h
+++ b/ui/tools/problemreporter/problemclientmodel.h
@@ -29,6 +29,7 @@
 #ifndef GAMMARAY_PROBLEMCLIENTMODEL_H
 #define GAMMARAY_PROBLEMCLIENTMODEL_H
 
+#include <QVector>
 #include <QSortFilterProxyModel>
 
 namespace GammaRay {

--- a/ui/tools/problemreporter/problemreporterclient.cpp
+++ b/ui/tools/problemreporter/problemreporterclient.cpp
@@ -1,5 +1,5 @@
 /*
-  problemcollector.h
+  problemreporterclient.cpp
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -26,56 +26,22 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBLEMCOLLECTOR_H
-#define GAMMARAY_PROBLEMCOLLECTOR_H
+#include "problemreporterclient.h"
 
-// Own
-#include "gammaray_core_export.h"
+#include <common/endpoint.h>
 
-#include <common/problem.h>
-#include <common/objectid.h>
-#include <common/sourcelocation.h>
+using namespace GammaRay;
 
-// Qt
-#include <QAbstractItemModel>
-
-// Std
-#include <memory>
-#include <vector>
-
-namespace GammaRay {
-
-class ProblemModel;
-
-class GAMMARAY_CORE_EXPORT ProblemCollector : public QObject
+ProblemReporterClient::ProblemReporterClient(QObject* parent)
+    : ProblemReporterInterface(parent)
 {
-    Q_OBJECT
-
-public:
-    static void addProblem(const Problem &problem);
-    static void removeProblem(const QString &problemId);
-    static ProblemCollector *instance();
-
-    const QVector<Problem> &problems();
-
-signals:
-    void aboutToAddProblem(int row);
-    void problemAdded();
-    void aboutToRemoveProblems(int first, int count = 1);
-    void problemsRemoved();
-    void problemScanRequested();
-
-public slots:
-    void requestScan();
-
-private:
-    explicit ProblemCollector(QObject *parent);
-
-    QVector<Problem> m_problems;
-
-    friend class Probe;
-};
 }
 
-#endif // GAMMARAY_PROBLEMCOLLECTOR_H
+ProblemReporterClient::~ProblemReporterClient()
+{
+}
 
+void ProblemReporterClient::requestScan()
+{
+    Endpoint::instance()->invokeObject(objectName(), "requestScan");
+}

--- a/ui/tools/problemreporter/problemreporterclient.h
+++ b/ui/tools/problemreporter/problemreporterclient.h
@@ -1,5 +1,5 @@
 /*
-  problemcollector.h
+  problemreporterclient.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
@@ -26,56 +26,23 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_PROBLEMCOLLECTOR_H
-#define GAMMARAY_PROBLEMCOLLECTOR_H
+#ifndef GAMMARAY_PROBLEMREPORTERCLIENT_H
+#define GAMMARAY_PROBLEMREPORTERCLIENT_H
 
-// Own
-#include "gammaray_core_export.h"
-
-#include <common/problem.h>
-#include <common/objectid.h>
-#include <common/sourcelocation.h>
-
-// Qt
-#include <QAbstractItemModel>
-
-// Std
-#include <memory>
-#include <vector>
+#include <common/tools/problemreporter/problemreporterinterface.h>
 
 namespace GammaRay {
 
-class ProblemModel;
-
-class GAMMARAY_CORE_EXPORT ProblemCollector : public QObject
+class ProblemReporterClient : public ProblemReporterInterface
 {
     Q_OBJECT
-
+    Q_INTERFACES(GammaRay::ProblemReporterInterface)
 public:
-    static void addProblem(const Problem &problem);
-    static void removeProblem(const QString &problemId);
-    static ProblemCollector *instance();
+    explicit ProblemReporterClient(QObject *parent);
+    ~ProblemReporterClient();
 
-    const QVector<Problem> &problems();
-
-signals:
-    void aboutToAddProblem(int row);
-    void problemAdded();
-    void aboutToRemoveProblems(int first, int count = 1);
-    void problemsRemoved();
-    void problemScanRequested();
-
-public slots:
-    void requestScan();
-
-private:
-    explicit ProblemCollector(QObject *parent);
-
-    QVector<Problem> m_problems;
-
-    friend class Probe;
+    void requestScan() override;
 };
 }
 
-#endif // GAMMARAY_PROBLEMCOLLECTOR_H
-
+#endif // GAMMARAY_PROBLEMREPORTERCLIENT_H

--- a/ui/tools/problemreporter/problemreporterwidget.cpp
+++ b/ui/tools/problemreporter/problemreporterwidget.cpp
@@ -197,7 +197,10 @@ void ProblemReporterWidget::problemViewContextMenu(const QPoint &p)
 
     QMenu menu;
     ContextMenuExtension ext(objectId);
-    ext.setLocation(ContextMenuExtension::GoTo, index.data(ProblemModelRoles::SourceLocationRole).value<SourceLocation>());
+    auto sourceLocations = index.data(ProblemModelRoles::SourceLocationRole).value<QVector<SourceLocation>>();
+    foreach (const SourceLocation &sourceLocation, sourceLocations) {
+        ext.setLocation(ContextMenuExtension::GoTo, sourceLocation);
+    }
     ext.populateMenu(&menu);
 
     menu.exec(ui->problemView->viewport()->mapToGlobal(p));

--- a/ui/tools/problemreporter/problemreporterwidget.cpp
+++ b/ui/tools/problemreporter/problemreporterwidget.cpp
@@ -29,6 +29,7 @@
 #include "problemreporterwidget.h"
 #include "ui_problemreporterwidget.h"
 #include "problemclientmodel.h"
+#include "problemreporterclient.h"
 
 #include <ui/searchlinecontroller.h>
 #include <ui/contextmenuextension.h>
@@ -41,12 +42,23 @@
 
 using namespace GammaRay;
 
+static QObject *createProblemReporterClient(const QString & /*name*/, QObject *parent)
+{
+    return new ProblemReporterClient(parent);
+}
+
 ProblemReporterWidget::ProblemReporterWidget(QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::ProblemReporterWidget)
     , m_stateManager(this)
 {
     ui->setupUi(this);
+
+    ObjectBroker::registerClientObjectFactoryCallback<ProblemReporterInterface *>(
+        createProblemReporterClient);
+    ProblemReporterInterface *iface = ObjectBroker::object<ProblemReporterInterface *>();
+
+    connect(ui->scanButton, SIGNAL(clicked()), iface, SLOT(requestScan()));
 
     auto model = new ProblemClientModel(this);
     model->setSourceModel(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ProblemModel")));

--- a/ui/tools/problemreporter/problemreporterwidget.cpp
+++ b/ui/tools/problemreporter/problemreporterwidget.cpp
@@ -59,6 +59,9 @@ ProblemReporterWidget::ProblemReporterWidget(QWidget *parent)
     ProblemReporterInterface *iface = ObjectBroker::object<ProblemReporterInterface *>();
 
     connect(ui->scanButton, SIGNAL(clicked()), iface, SLOT(requestScan()));
+    connect(ui->scanButton, SIGNAL(clicked()), ui->progressBar, SLOT(show()));
+    connect(iface, SIGNAL(problemScansFinished()), ui->progressBar, SLOT(hide()));
+    ui->progressBar->setVisible(false);
 
     auto model = new ProblemClientModel(this);
     model->setSourceModel(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ProblemModel")));

--- a/ui/tools/problemreporter/problemreporterwidget.cpp
+++ b/ui/tools/problemreporter/problemreporterwidget.cpp
@@ -1,0 +1,79 @@
+/*
+  problemreporterwidget.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2012-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "problemreporterwidget.h"
+#include "ui_problemreporterwidget.h"
+#include "problemclientmodel.h"
+
+#include <ui/searchlinecontroller.h>
+#include <ui/contextmenuextension.h>
+
+#include <common/objectbroker.h>
+#include <common/objectmodel.h>
+#include <common/tools/problemreporter/problemmodelroles.h>
+
+#include <QMenu>
+
+using namespace GammaRay;
+
+ProblemReporterWidget::ProblemReporterWidget(QWidget *parent)
+    : QWidget(parent)
+    , ui(new Ui::ProblemReporterWidget)
+    , m_stateManager(this)
+{
+    ui->setupUi(this);
+
+    auto model = new ProblemClientModel(this);
+    model->setSourceModel(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.ProblemModel")));
+    ui->problemView->header()->setObjectName("problemViewHeader");
+    ui->problemView->setDeferredResizeMode(0, QHeaderView::ResizeToContents);
+    ui->problemView->setDeferredResizeMode(1, QHeaderView::ResizeToContents);
+    ui->problemView->setModel(model);
+    ui->problemView->sortByColumn(0, Qt::AscendingOrder);
+
+    connect(ui->problemView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(problemViewContextMenu(QPoint)));
+
+    new SearchLineController(ui->searchLine, model);
+}
+
+ProblemReporterWidget::~ProblemReporterWidget()
+{
+}
+
+void ProblemReporterWidget::problemViewContextMenu(const QPoint &p)
+{
+    QModelIndex index = ui->problemView->indexAt(p);
+    ObjectId objectId = index.data(ObjectModel::ObjectIdRole).value<ObjectId>();
+
+    QMenu menu;
+    ContextMenuExtension ext(objectId);
+    ext.setLocation(ContextMenuExtension::GoTo, index.data(ProblemModelRoles::SourceLocationRole).value<SourceLocation>());
+    ext.populateMenu(&menu);
+
+    menu.exec(ui->problemView->viewport()->mapToGlobal(p));
+}

--- a/ui/tools/problemreporter/problemreporterwidget.cpp
+++ b/ui/tools/problemreporter/problemreporterwidget.cpp
@@ -59,87 +59,39 @@ public:
      : QStyledItemDelegate(view)
     {}
 
+
 protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override
     {
-        const QStyleOptionViewItemV4 *viewItemOption =
-           qstyleoption_cast<const QStyleOptionViewItemV4 *>(&option); // This is for Qt4 compatibility. Should be a noop in Qt5
-        QStyle *style = viewItemOption->widget ? viewItemOption->widget->style() : QApplication::style();
-        QStyleOptionButton checkboxOption = copyStyleOptions(option, index);
-        painter->save();
+        QStyleOptionViewItemV4 opt = option; // we need V4 for Qt4, on Qt5 it's just a typedef for QStyleOptionViewItem
+        initStyleOption(&opt, index);
         QString title = index.data(Qt::DisplayRole).toString();
-        const QString description = index.data(Qt::ToolTipRole).toString();
-        const int vMargin = viewItemOption->widget->style()->pixelMetric(QStyle::PM_FocusFrameVMargin);
-        const int hMargin = viewItemOption->widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin)
-                          + viewItemOption->widget->style()->pixelMetric(QStyle::PM_CheckBoxLabelSpacing);
-        const QRect checkboxRect = style->subElementRect(QStyle::SE_CheckBoxIndicator, &checkboxOption, viewItemOption->widget);
-        const QRect textRect = option.rect.adjusted(checkboxRect.width() + hMargin, vMargin, -hMargin, -vMargin);
-        const QFontMetrics metrics(option.font);
-        const QRect titleRect(textRect.left(),
-                              textRect.top(),
-                              textRect.width(),
-                              metrics.height());
-        const QRect descriptionRect = metrics.boundingRect(textRect, Qt::TextWordWrap, description)
-                                             .translated(0, vMargin + titleRect.height());
+        QString description = index.data(Qt::ToolTipRole).toString();
+        QStyle *style = opt.widget ? opt.widget->style() : QApplication::style();
 
-        const QRect descriptionRect2 = metrics.boundingRect(viewItemOption->rect.adjusted(checkboxRect.width(),0,0,0), Qt::TextWordWrap, description);
+        opt.text = index.data(Qt::DisplayRole).toString() + QChar(QChar::LineSeparator) + index.data(Qt::ToolTipRole).toString();
+        auto textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &opt);
 
-        painter->save();
-        painter->drawText(titleRect, Qt::AlignLeft | Qt::AlignVCenter, title);
-        painter->restore();
+        // We first paint a normal ItemViewItem but with no text and then draw the title and description ourselves
+        opt.text.clear();
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+        style->drawItemText(painter, textRect, Qt::AlignLeft | Qt::AlignTop, opt.palette, opt.state & QStyle::State_Enabled, title, QPalette::Text);
+        auto oldOpacity = painter->opacity();
         painter->setOpacity(0.5);
-        painter->drawText(descriptionRect, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextWordWrap, description);
-        painter->restore();
-
-
-        style->drawControl(QStyle::CE_CheckBox, &checkboxOption, painter, viewItemOption->widget);
-    }
-
-    QStyleOptionButton copyStyleOptions(QStyleOptionViewItemV4 viewOption, const QModelIndex &index) const
-    {
-        initStyleOption(&viewOption, index);
-        QStyleOptionButton checkboxOption;
-        checkboxOption.direction = viewOption.direction;
-        checkboxOption.fontMetrics = viewOption.fontMetrics;
-        checkboxOption.palette = viewOption.palette;
-        checkboxOption.rect = viewOption.rect;
-        checkboxOption.state = viewOption.state;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-        checkboxOption.styleObject = viewOption.styleObject;
-#endif
-        if (viewOption.checkState == Qt::Checked) {
-            checkboxOption.state |= QStyle::State_On;
-        }
-        return checkboxOption;
+        style->drawItemText(painter, textRect, Qt::AlignLeft | Qt::AlignBottom | Qt::TextWordWrap, opt.palette,
+                            opt.state & QStyle::State_Enabled, description, QPalette::Text);
+        painter->setOpacity(oldOpacity);
     }
 
     QSize sizeHint(const QStyleOptionViewItem &option,
                    const QModelIndex &index) const override
     {
-        const QStyleOptionViewItemV4 *viewItemOption =
-           qstyleoption_cast<const QStyleOptionViewItemV4 *>(&option); // This is for Qt4 compatibility. Should be a noop in Qt5
-        Q_ASSERT(viewItemOption);
-
-        QStyleOptionButton checkboxOption = copyStyleOptions(*viewItemOption, index);
-
-        const QString title = index.data(Qt::DisplayRole).toString();
-        const QString description = index.data(Qt::ToolTipRole).toString();
-        const QFontMetrics metrics(option.font);
-        const int vMargin = viewItemOption->widget->style()->pixelMetric(QStyle::PM_FocusFrameVMargin);
-        const int hMargin = viewItemOption->widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin)
-                          + viewItemOption->widget->style()->pixelMetric(QStyle::PM_CheckBoxLabelSpacing);
-        const QRect checkboxRect = viewItemOption->widget->style()->subElementRect(QStyle::SE_CheckBoxIndicator, &checkboxOption, viewItemOption->widget);
-        const QRect titleRect = metrics.boundingRect(title);
-        const int textAvailableWidth = qobject_cast<const QListView*>(viewItemOption->widget)->width() // FIXME this is the wrong size if the view has a horizontal scrollbar...
-            - 2 * viewItemOption->widget->style()->pixelMetric(QStyle::PM_FocusFrameHMargin) - checkboxRect.width();
-        const QRect descriptionRect = metrics.boundingRect(QRect(0,0,textAvailableWidth, 0), Qt::TextWordWrap, description);
-        const int textWidth = qMax(titleRect.width(), descriptionRect.width());
-        const int textHeight = titleRect.height() + descriptionRect.height();
-        const int totalWidth = checkboxRect.width() + textWidth + hMargin * 2;
-        const int totalHeight = textHeight + vMargin * 3;
-
-        return QSize(totalWidth, totalHeight);
+        QStyleOptionViewItemV4 opt = option; // we need V4 for Qt4, on Qt5 it's just a typedef for QStyleOptionViewItem
+        initStyleOption(&opt, index);
+        opt.text = index.data(Qt::DisplayRole).toString() + QChar(QChar::LineSeparator) + index.data(Qt::ToolTipRole).toString();
+        QStyle *style = opt.widget ? opt.widget->style() : QApplication::style();
+        return style->sizeFromContents(QStyle::CT_ItemViewItem, &opt, QSize(), opt.widget);
     }
 };
 

--- a/ui/tools/problemreporter/problemreporterwidget.h
+++ b/ui/tools/problemreporter/problemreporterwidget.h
@@ -4,8 +4,8 @@
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2012-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Anton Kreuzkamp <anton.kreuzkamp@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -34,10 +34,13 @@
 
 #include <QWidget>
 
+class QAbstractItemModel;
+
 namespace GammaRay {
 namespace Ui {
 class ProblemReporterWidget;
 }
+class ProblemClientModel;
 
 class ProblemReporterWidget : public QWidget
 {
@@ -48,10 +51,13 @@ public:
 
 private slots:
     void problemViewContextMenu(const QPoint &p);
+    void updateFilter(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
 
 private:
     QScopedPointer<Ui::ProblemReporterWidget> ui;
     UIStateManager m_stateManager;
+    QAbstractItemModel *m_availableCheckersModel;
+    ProblemClientModel *m_problemsModel;
 };
 
 }

--- a/ui/tools/problemreporter/problemreporterwidget.h
+++ b/ui/tools/problemreporter/problemreporterwidget.h
@@ -1,0 +1,59 @@
+/*
+  problemreporterwidget.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2012-2018 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Volker Krause <volker.krause@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_PROBLEMREPORTERWIDGET_H
+#define GAMMARAY_PROBLEMREPORTERWIDGET_H
+
+#include <ui/uistatemanager.h>
+#include <ui/tooluifactory.h>
+
+#include <QWidget>
+
+namespace GammaRay {
+namespace Ui {
+class ProblemReporterWidget;
+}
+
+class ProblemReporterWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ProblemReporterWidget(QWidget *parent = nullptr);
+    ~ProblemReporterWidget();
+
+private slots:
+    void problemViewContextMenu(const QPoint &p);
+
+private:
+    QScopedPointer<Ui::ProblemReporterWidget> ui;
+    UIStateManager m_stateManager;
+};
+
+}
+
+#endif // GAMMARAY_PROBLEMREPORTERWIDGET_H

--- a/ui/tools/problemreporter/problemreporterwidget.h
+++ b/ui/tools/problemreporter/problemreporterwidget.h
@@ -32,9 +32,13 @@
 #include <ui/uistatemanager.h>
 #include <ui/tooluifactory.h>
 
+#include <QVector>
 #include <QWidget>
 
+QT_BEGIN_NAMESPACE
 class QAbstractItemModel;
+class QModelIndex;
+QT_END_NAMESPACE
 
 namespace GammaRay {
 namespace Ui {

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GammaRay::ProblemReporterWidget</class>
+ <widget class="QWidget" name="GammaRay::ProblemReporterWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLineEdit" name="searchLine"/>
+   </item>
+   <item>
+    <widget class="GammaRay::DeferredTreeView" name="problemView">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>GammaRay::DeferredTreeView</class>
+   <extends>QTreeView</extends>
+   <header location="global">ui/deferredtreeview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -10,35 +10,76 @@
     <height>300</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="toplevelLayout">
    <item>
-    <widget class="QLineEdit" name="searchLine"/>
-   </item>
-   <item>
-    <widget class="GammaRay::DeferredTreeView" name="problemView">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar">
-     <property name="maximum">
-      <number>0</number>
-     </property>
-     <property name="value">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QPushButton" name="scanButton">
-     <property name="text">
-      <string>Scan for Problems</string>
-     </property>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Available Problem Checkers</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListView" name="problemfilterwidget">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::NoSelection</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="scanButton">
+         <property name="text">
+          <string>Start Scan for Problems</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="searchLine"/>
+       </item>
+       <item>
+        <widget class="GammaRay::DeferredTreeView" name="problemView">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QProgressBar" name="progressBar">
+         <property name="maximum">
+          <number>0</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -66,6 +66,9 @@
          <property name="contextMenuPolicy">
           <enum>Qt::CustomContextMenu</enum>
          </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
         </widget>
        </item>
        <item>

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -25,6 +25,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="maximum">
+      <number>0</number>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="scanButton">
      <property name="text">
       <string>Scan for Problems</string>

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -42,6 +42,12 @@
          <property name="selectionMode">
           <enum>QAbstractItemView::NoSelection</enum>
          </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>

--- a/ui/tools/problemreporter/problemreporterwidget.ui
+++ b/ui/tools/problemreporter/problemreporterwidget.ui
@@ -24,6 +24,13 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QPushButton" name="scanButton">
+     <property name="text">
+      <string>Scan for Problems</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
This PR adds a global focal point for tools to report issues that they (already) find during their analysis, with the possibility for the user to actively trigger scans through all objects for certain kinds of issues.

It contains a tool with a UI for listing the issues, filtering the checkers and triggering the scans and includes scans for
* Property Bindings (implemented in the Object Inspector and fed by data from the qmlsupport and quickinspector plugins)
* Shortcut duplicates (provided by the Action Inspector)
* common issues in QMetaType treatment (provided by the MetaObjectBrowser)

Still to do is Direct-Crossthread-Connections, but that is pretty independent of the work already done.