### PR TITLE
Make QuickInspector's out of view check a scan

### DIFF
--- a/core/problemcollector.cpp
+++ b/core/problemcollector.cpp
@@ -126,4 +126,11 @@ QVector<ProblemCollector::Checker> &ProblemCollector::availableCheckers()
     return m_availableCheckers;
 }
 
+bool ProblemCollector::isCheckerRegistered(const QString& id) const
+{
+    return std::any_of(m_availableCheckers.begin(), m_availableCheckers.end(),
+                        [&id](const Checker &c){ return c.id == id; }
+                      );
+}
+
 

--- a/core/problemcollector.h
+++ b/core/problemcollector.h
@@ -81,6 +81,9 @@ public:
                                     const std::function<void()> &callback,
                                     bool enabled = true);
 
+    /// Meant to be used in unit tests
+    bool isCheckerRegistered(const QString &id) const;
+
 private:
     struct Checker {
         QString id;

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -149,6 +149,7 @@ private:
     void registerVariantHandlers();
     void registerPCExtensions();
     QString findSGNodeType(QSGNode *node) const;
+    static void scanForProblems();
 
     GammaRay::ObjectIds recursiveItemsAt(QQuickItem *parent, const QPointF &pos,
                                          GammaRay::RemoteViewInterface::RequestMode mode, int& bestCandidate) const;

--- a/plugins/quickinspector/quickitemmodel.cpp
+++ b/plugins/quickinspector/quickitemmodel.cpp
@@ -31,8 +31,6 @@
 
 #include <core/paintanalyzer.h>
 #include <core/probe.h>
-#include <core/problemcollector.h>
-#include <common/problem.h>
 
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -397,21 +395,7 @@ void QuickItemModel::updateItemFlags(QQuickItem *item)
             outOfView = partiallyOutOfView && !rect.intersects(ancestorRect);
 
             if (outOfView) {
-                Problem p;
-                p.severity = Problem::Info;
-                p.description = QStringLiteral("QtQuick: %1 %2 (0x%3) is visible, but out of view.").arg(
-                    ObjectDataProvider::typeName(item),
-                    ObjectDataProvider::name(item),
-                    QString::number(reinterpret_cast<quintptr>(item), 16)
-                );
-                p.object = ObjectId(item);
-                p.locations.push_back(ObjectDataProvider::creationLocation(item));
-                p.problemId = QStringLiteral("OutOfView:%1").arg(reinterpret_cast<quintptr>(item));
-                p.findingCategory = Problem::Live;
-                ProblemCollector::addProblem(p);
                 break;
-            } else {
-                ProblemCollector::removeProblem(QStringLiteral("OutOfView:%1").arg(reinterpret_cast<quintptr>(item)));
             }
         }
         ancestor = ancestor->parentItem();

--- a/plugins/quickinspector/quickitemmodel.h
+++ b/plugins/quickinspector/quickitemmodel.h
@@ -83,6 +83,12 @@ private:
     void clear();
     void populateFromItem(QQuickItem *item);
 
+    /**
+     * Reports problems (e.g. visible but out of view) about all items of this
+     * model. Uses the item flags from the model.
+     */
+    void reportProblems();
+
     /// Track all changes to item @p item in this model (parentChanged, windowChanged, ...)
     void connectItem(QQuickItem *item);
 

--- a/tests/problemreportertest.cpp
+++ b/tests/problemreportertest.cpp
@@ -303,10 +303,7 @@ private slots:
         QTest::qWait(1);
         QVERIFY(static_cast<bool>(obj));
 
-        auto &checkers = ProblemCollector::instance()->availableCheckers();
-        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
-                    [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.ObjectInspector.BindingLoopScan"; }
-                   ));
+        QVERIFY(ProblemCollector::instance()->isCheckerRegistered("com.kdab.GammaRay.ObjectInspector.BindingLoopScan"));
 
         ProblemCollector::instance()->requestScan();
 
@@ -322,10 +319,7 @@ private slots:
 
     void testConnectionIssues()
     {
-        auto &checkers = ProblemCollector::instance()->availableCheckers();
-        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
-                    [](ProblemCollector::Checker &c){ return c.id == "com.kdab.GammaRay.ObjectInspector.ConnectionsCheck"; }
-                   ));
+        QVERIFY(ProblemCollector::instance()->isCheckerRegistered("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck"));
 
         auto task = std::unique_ptr<CrossThreadConnectionTask>(new CrossThreadConnectionTask());
         task->mainThreadObj.reset(new QObject());
@@ -427,10 +421,7 @@ private slots:
         a2->setShortcutContext(Qt::WidgetShortcut);
         QTest::qWait(1); // event loop re-entry
 
-        auto &checkers = ProblemCollector::instance()->availableCheckers();
-        QVERIFY(std::any_of(checkers.begin(), checkers.end(),
-                    [](ProblemCollector::Checker &c){ return c.id == "gammaray_actioninspector.ShortcutDuplicates"; }
-                   ));
+        QVERIFY(ProblemCollector::instance()->isCheckerRegistered("gammaray_actioninspector.ShortcutDuplicates"));
 
         ProblemCollector::instance()->requestScan();
 


### PR DESCRIPTION
So far the QuickInspector would report a warning about visible but out
of view Items to the problem reporter tool live. That caused a lot of
stack traces to be resolved, which is pretty expensive. Thus, now the
problem reporting is only done on demand.