### PR TITLE
Fix qFuzzyCompare build error when Qt is configured with qreal=float

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -236,7 +236,7 @@ static const MetaEnum::Value<QSGTexture::WrapMode> qsg_texture_wrapmode_table[] 
 static bool isGoodCandidateItem(QQuickItem *item)
 {
 
-    if (!item->isVisible() || qFuzzyCompare(item->opacity() + 1.0, qreal(1.0)) ||
+    if (!item->isVisible() || qFuzzyCompare(item->opacity() + qreal(1.0), qreal(1.0)) ||
             !item->flags().testFlag(QQuickItem::ItemHasContents)) {
         return false;
     }


### PR DESCRIPTION
The first parameter was implicitely converted to double, making gcc complain
about not finding the right overload when Qt is configured with qreal=float.