### PR TITLE
ObjectInspector: Add thread affinity checker

### DIFF
--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -223,7 +223,6 @@ void ObjectInspector::scanForThreadAffinityIssues()
 
         const auto objectName = Util::displayString(object);
         if (object == object->thread()) {
-            const auto objectName = Util::displayString(object);
             Problem problem;
             problem.severity = Problem::Warning;
             problem.description = QStringLiteral("The thread %1 has affinity with itself.").arg(objectName);

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -254,7 +254,7 @@ void ObjectInspector::scanForThreadAffinityIssues()
             ProblemCollector::addProblem(problem);
         }
 
-        if (parent->inherits("QThread") && object->thread() != object->parent()) {
+        if (qobject_cast<QThread*>(parent) && object->thread() != object->parent()) {
             Problem problem;
             problem.severity = Problem::Warning;
             problem.description = QStringLiteral("The object %1 has thread %2 as parent, but doesn't have affinity with it.").arg(objectName, parentName);

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -57,6 +57,7 @@ private:
     void registerPCExtensions();
 
     static void scanForConnectionIssues();
+    static void scanForThreadAffinityIssues();
 
     PropertyController *m_propertyController;
     QItemSelectionModel *m_selectionModel;


### PR DESCRIPTION
Some new checks i've been thinking about, i think they are sound, but i'm open to ideas on how to improve this.
When run on a empty Qt project (eg, w/ just an app and a window), this gives two warnings:
`The thread QDBusConnectionManager[this=0x7f1a5516ad80] has affinity with itself.`
`The thread QThread[this=0x5560ce4e0680] has affinity with itself.`
So maybe this new check should not be enabled by default. I haven't looked yet where to disable it.
