### PR TITLE
Allow to build GammaRay when Qt5OpenGL is not present

### DIFF
--- a/3rdparty/kuserfeedback/core/openglinfosource.cpp
+++ b/3rdparty/kuserfeedback/core/openglinfosource.cpp
@@ -19,7 +19,7 @@
 #include "openglinfosource_p.h"
 
 #include <QVariant>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && !defined(QT_NO_OPENGL)
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
 #include <QSurfaceFormat>
@@ -42,7 +42,7 @@ QVariant OpenGLInfoSource::data()
 {
     QVariantMap m;
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && !defined(QT_NO_OPENGL)
     QOpenGLContext context;
     if (context.create()) {
         QWindow window;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ find_package(Qt5 NO_MODULE QUIET OPTIONAL_COMPONENTS
   WebEngineWidgets
   Widgets
   WaylandCompositor
+  OpenGL
 )
 # Find these 'exotic' Qt modules without using find_package(... COMPONENTS)
 # so we can retrieve those packages even when installed into a different prefix

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -22,14 +22,19 @@ if(Qt5Quick_FOUND)
     quickscenegraphmodel.cpp
     quickpaintanalyzerextension.cpp
     quickscreengrabber.cpp
-    materialextension/materialextension.cpp
-    materialextension/materialshadermodel.cpp
-    materialextension/qquickopenglshadereffectmaterialadaptor.cpp
-    geometryextension/sggeometryextension.cpp
-    geometryextension/sggeometrymodel.cpp
-    textureextension/textureextension.cpp
-    textureextension/qsgtexturegrabber.cpp
   )
+
+  if(Qt5OpenGL_FOUND)
+    list(APPEND gammaray_quickinspector_srcs
+      materialextension/materialextension.cpp
+      materialextension/materialshadermodel.cpp
+      materialextension/qquickopenglshadereffectmaterialadaptor.cpp
+      geometryextension/sggeometryextension.cpp
+      geometryextension/sggeometrymodel.cpp
+      textureextension/textureextension.cpp
+      textureextension/qsgtexturegrabber.cpp
+    )
+  endif()
 
   gammaray_add_plugin(gammaray_quickinspector
     JSON gammaray_quickinspector.json
@@ -70,15 +75,19 @@ if(Qt5Quick_FOUND)
       quickscenecontrolwidget.cpp
       quickoverlaylegend.cpp
       gridsettingswidget.cpp
+    )
 
-      materialextension/materialextensionclient.cpp
-      materialextension/materialtab.cpp
-      geometryextension/sggeometrytab.cpp
-      geometryextension/sgwireframewidget.cpp
-      textureextension/texturetab.cpp
-      textureextension/textureviewwidget.cpp
-      textureextension/resources.qrc
+    if(Qt5OpenGL_FOUND)
+      list(APPEND gammaray_quickinspector_ui_srcs
+        geometryextension/sggeometrytab.cpp
+        geometryextension/sgwireframewidget.cpp
+        materialextension/materialextensionclient.cpp
+        materialextension/materialtab.cpp
+        textureextension/texturetab.cpp
+        textureextension/textureviewwidget.cpp
+        textureextension/resources.qrc
       )
+    endif()
 
     gammaray_add_plugin(gammaray_quickinspector_ui
       JSON gammaray_quickinspector.json

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -80,7 +80,9 @@
 #include <QItemSelection>
 #include <QItemSelectionModel>
 #include <QMouseEvent>
+#ifndef QT_NO_OPENGL
 #include <QOpenGLContext>
+#endif
 #include <QSGNode>
 #include <QSGGeometry>
 #include <QSGMaterial>
@@ -95,7 +97,9 @@
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
 #include <QSGRenderNode>
 #include <QSGRendererInterface>
+#ifndef QT_NO_OPENGL
 #include <private/qquickopenglshadereffectnode_p.h>
+#endif
 #include <private/qsgsoftwarecontext_p.h>
 #include <private/qsgsoftwarerenderer_p.h>
 #include <private/qsgsoftwarerenderablenode_p.h>
@@ -103,7 +107,9 @@
 
 #include <private/qquickanchors_p.h>
 #include <private/qquickitem_p.h>
+#ifndef QT_NO_OPENGL
 #include <private/qsgbatchrenderer_p.h>
+#endif
 #include <private/qsgdistancefieldglyphnode_p_p.h>
 #include <private/qabstractanimation_p.h>
 
@@ -398,8 +404,10 @@ QuickInspector::QuickInspector(Probe *probe, QObject *parent)
     connect(m_pendingRenderMode, &RenderModeRequest::aboutToCleanSceneGraph, this, &QuickInspector::aboutToCleanSceneGraph);
     connect(m_pendingRenderMode, &RenderModeRequest::sceneGraphCleanedUp, this, &QuickInspector::sceneGraphCleanedUp);
 
+#ifndef QT_NO_OPENGL
     auto texGrab = new QSGTextureGrabber(this);
     connect(probe, &Probe::objectCreated, texGrab, &QSGTextureGrabber::objectCreated);
+#endif
 
     connect(Endpoint::instance(), &Endpoint::disconnected, this, [this]() {
         if (m_overlay)
@@ -923,10 +931,14 @@ void QuickInspector::registerMetaTypes()
     MO_ADD_METAOBJECT1(QQuickWindow, QWindow);
     MO_ADD_PROPERTY(QQuickWindow, clearBeforeRendering, setClearBeforeRendering);
     MO_ADD_PROPERTY_RO(QQuickWindow, effectiveDevicePixelRatio);
+#ifndef QT_NO_OPENGL
     MO_ADD_PROPERTY(QQuickWindow, isPersistentOpenGLContext, setPersistentOpenGLContext);
+#endif
     MO_ADD_PROPERTY(QQuickWindow, isPersistentSceneGraph, setPersistentSceneGraph);
     MO_ADD_PROPERTY_RO(QQuickWindow, mouseGrabberItem);
+#ifndef QT_NO_OPENGL
     MO_ADD_PROPERTY_RO(QQuickWindow, openglContext);
+#endif
     MO_ADD_PROPERTY_RO(QQuickWindow, renderTargetId);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
     MO_ADD_PROPERTY_RO(QQuickWindow, rendererInterface);
@@ -1041,6 +1053,7 @@ void QuickInspector::registerMetaTypes()
 
     MO_ADD_METAOBJECT1(QSGVertexColorMaterial, QSGMaterial);
 
+#ifndef QT_NO_OPENGL
     MO_ADD_METAOBJECT1(QSGDistanceFieldTextMaterial, QSGMaterial);
     MO_ADD_PROPERTY_RO(QSGDistanceFieldTextMaterial, color);
     MO_ADD_PROPERTY_RO(QSGDistanceFieldTextMaterial, fontScale);
@@ -1058,6 +1071,7 @@ void QuickInspector::registerMetaTypes()
     MO_ADD_PROPERTY_MEM(QQuickOpenGLShaderEffectMaterial, cullMode);
     MO_ADD_PROPERTY_MEM(QQuickOpenGLShaderEffectMaterial, geometryUsesTextureSubRect);
     MO_ADD_PROPERTY_MEM(QQuickOpenGLShaderEffectMaterial, textureProviders);
+#endif
 #endif
 }
 
@@ -1180,12 +1194,14 @@ void QuickInspector::registerVariantHandlers()
 
 void QuickInspector::registerPCExtensions()
 {
+#ifndef QT_NO_OPENGL
     PropertyController::registerExtension<MaterialExtension>();
     PropertyController::registerExtension<SGGeometryExtension>();
     PropertyController::registerExtension<QuickPaintAnalyzerExtension>();
     PropertyController::registerExtension<TextureExtension>();
 
     PropertyAdaptorFactory::registerFactory(QQuickOpenGLShaderEffectMaterialAdaptorFactory::instance());
+#endif
     PropertyAdaptorFactory::registerFactory(QuickAnchorsPropertyAdaptorFactory::instance());
     PropertyFilters::registerFilter(PropertyFilter("QQuickItem", "anchors"));
 

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -32,10 +32,12 @@
 #include "quickitemtreewatcher.h"
 #include "quickitemmodelroles.h"
 #include "quickscenepreviewwidget.h"
+#ifndef QT_NO_OPENGL
 #include "geometryextension/sggeometrytab.h"
 #include "materialextension/materialextensionclient.h"
 #include "materialextension/materialtab.h"
 #include "textureextension/texturetab.h"
+#endif
 #include "quickitemdelegate.h"
 #include "ui_quickinspectorwidget.h"
 
@@ -68,10 +70,12 @@ static QObject *createQuickInspectorClient(const QString & /*name*/, QObject *pa
     return new QuickInspectorClient(parent);
 }
 
+#ifndef QT_NO_OPENGL
 static QObject *createMaterialExtension(const QString &name, QObject *parent)
 {
     return new MaterialExtensionClient(name, parent);
 }
+#endif
 
 static QAction *createSeparator(QObject *parent)
 {
@@ -269,6 +273,7 @@ void QuickInspectorWidget::itemModelDataChanged(const QModelIndex &topLeft,
 
 void QuickInspectorUiFactory::initUi()
 {
+#ifndef QT_NO_OPENGL
     ObjectBroker::registerClientObjectFactoryCallback<MaterialExtensionInterface *>(
         createMaterialExtension);
 
@@ -276,6 +281,7 @@ void QuickInspectorUiFactory::initUi()
 
     PropertyWidget::registerTab<SGGeometryTab>(QStringLiteral("sgGeometry"), tr("Geometry"));
     PropertyWidget::registerTab<TextureTab>(QStringLiteral("texture"), tr("Texture"));
+#endif
 }
 
 void GammaRay::QuickInspectorWidget::itemContextMenu(const QPoint &pos)

--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -34,9 +34,12 @@
 #include <QEvent>
 #include <QPainter>
 #include <QQuickWindow>
+
+#ifndef QT_NO_OPENGL
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
 #include <QOpenGLPaintDevice>
+#endif
 
 #include <private/qquickanchors_p.h>
 #include <private/qquickitem_p.h>
@@ -231,8 +234,10 @@ bool ItemOrLayoutFacade::isLayout() const
 std::unique_ptr<AbstractScreenGrabber> AbstractScreenGrabber::get(QQuickWindow* window)
 {
     switch (graphicsApiFor(window)) {
+#ifndef QT_NO_OPENGL
         case RenderInfo::OpenGL:
             return std::unique_ptr<AbstractScreenGrabber>(new OpenGLScreenGrabber(window));
+#endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
         case RenderInfo::Software:
             return std::unique_ptr<AbstractScreenGrabber>(new SoftwareScreenGrabber(window));
@@ -574,6 +579,7 @@ void AbstractScreenGrabber::disconnectTopItemChanges(QQuickItem *item)
     disconnect(item, &QQuickItem::heightChanged, this, &AbstractScreenGrabber::updateOverlay);
 }
 
+#ifndef QT_NO_OPENGL
 OpenGLScreenGrabber::OpenGLScreenGrabber(QQuickWindow *window)
     : AbstractScreenGrabber(window)
     , m_isGrabbing(false)
@@ -684,6 +690,7 @@ void OpenGLScreenGrabber::drawDecorations()
     QPainter p(&device);
     doDrawDecorations(p);
 }
+#endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
 SoftwareScreenGrabber::SoftwareScreenGrabber(QQuickWindow* window)

--- a/plugins/quickinspector/quickscreengrabber.h
+++ b/plugins/quickinspector/quickscreengrabber.h
@@ -40,7 +40,9 @@
 
 QT_BEGIN_NAMESPACE
 class QQuickWindow;
+#ifndef QT_NO_OPENGL
 class QOpenGLPaintDevice;
+#endif
 class QSGSoftwareRenderer;
 QT_END_NAMESPACE
 
@@ -188,6 +190,7 @@ protected:
     RenderInfo m_renderInfo;
 };
 
+#ifndef QT_NO_OPENGL
 class OpenGLScreenGrabber : public AbstractScreenGrabber
 {
     Q_OBJECT
@@ -206,6 +209,7 @@ private:
     bool m_isGrabbing;
     QMutex m_mutex;
 };
+#endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
 class SoftwareScreenGrabber : public AbstractScreenGrabber


### PR DESCRIPTION
The changes in this PR allow to build GammaRay when Qt5 is built without OpenGL support.

Fixes #546 

NOTE: Due to my little knowledge about the GammaRay codebase, some components may have been unnecessarily removed from the non-OpenGL build.