### PR TITLE
Add event type list and propagation inspection to event monitor

### DIFF
--- a/plugins/eventmonitor/CMakeLists.txt
+++ b/plugins/eventmonitor/CMakeLists.txt
@@ -28,6 +28,7 @@ if(GAMMARAY_BUILD_UI)
     eventmonitorwidget.cpp
     eventmonitorinterface.cpp
     eventmonitorclient.cpp
+    eventtypeclientproxymodel.cpp
   )
 
   gammaray_add_plugin(gammaray_eventmonitor_ui_plugin

--- a/plugins/eventmonitor/CMakeLists.txt
+++ b/plugins/eventmonitor/CMakeLists.txt
@@ -7,6 +7,7 @@ set(gammaray_eventmonitor_plugin_srcs
   eventmonitor.cpp
   eventmodel.cpp
   eventmonitorinterface.cpp
+  eventtypemodel.cpp
 )
 
 gammaray_add_plugin(gammaray_eventmonitor_plugin

--- a/plugins/eventmonitor/CMakeLists.txt
+++ b/plugins/eventmonitor/CMakeLists.txt
@@ -8,6 +8,7 @@ set(gammaray_eventmonitor_plugin_srcs
   eventmodel.cpp
   eventmonitorinterface.cpp
   eventtypemodel.cpp
+  eventtypefilter.cpp
 )
 
 gammaray_add_plugin(gammaray_eventmonitor_plugin

--- a/plugins/eventmonitor/eventmodel.h
+++ b/plugins/eventmonitor/eventmodel.h
@@ -41,6 +41,8 @@ struct EventData {
     QEvent::Type type;
     QObject* receiver;
     QVector<QPair<const char *, QVariant>> attributes;
+    QEvent* eventPtr;
+    QVector<EventData> propagatedEvents;
 };
 }
 
@@ -73,6 +75,7 @@ public slots:
     void clear();
 
 private:
+    friend class EventPropagationListener;
     QVector<EventData> m_events;
 };
 }

--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -29,6 +29,7 @@
 #include "eventmonitor.h"
 
 #include "eventmodelroles.h"
+#include "eventtypefilter.h"
 
 #include <core/aggregatedpropertymodel.h>
 #include <core/metaobjectrepository.h>
@@ -266,8 +267,11 @@ EventMonitor::EventMonitor(Probe *probe, QObject *parent)
 
     QInternal::registerCallback(QInternal::EventNotifyCallback, eventCallback);
 
+    auto filterProxy = new EventTypeFilter(this, m_eventTypeModel);
+    filterProxy->setSourceModel(m_eventModel);
+    connect(m_eventTypeModel, &EventTypeModel::typeVisibilityChanged, filterProxy, &QSortFilterProxyModel::invalidate);
     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
-    proxy->setSourceModel(m_eventModel);
+    proxy->setSourceModel(filterProxy);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.EventModel"), proxy);
 
     auto evenTypeProxy = new ServerProxyModel<QSortFilterProxyModel>(this);

--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -51,6 +51,7 @@ using namespace GammaRay;
 
 
 static EventModel *s_model = nullptr;
+static EventTypeModel *s_eventTypeModel = nullptr;
 static EventMonitor *s_eventMonitor = nullptr;
 
 
@@ -155,7 +156,7 @@ QString eventTypeToClassName(QEvent::Type type) {
 
 static bool eventCallback(void **data)
 {
-    if (!s_model || !s_eventMonitor || !Probe::instance()) {
+    if (!s_model || !s_eventTypeModel || !s_eventMonitor || !Probe::instance()) {
         return false;
     }
 
@@ -237,11 +238,11 @@ static bool eventCallback(void **data)
         }
     }
 
-    if (s_model) {
-        // add directly from foreground thread, delay from background thread
-        QMetaObject::invokeMethod(s_model, "addEvent", Qt::AutoConnection,
-                                  Q_ARG(GammaRay::EventData, eventData));
-    }
+    // add directly from foreground thread, delay from background thread
+    QMetaObject::invokeMethod(s_model, "addEvent", Qt::AutoConnection,
+                              Q_ARG(GammaRay::EventData, eventData));
+    QMetaObject::invokeMethod(s_eventTypeModel, "increaseCount", Qt::AutoConnection,
+                              Q_ARG(QEvent::Type, event->type()));
     return false;
 }
 
@@ -249,10 +250,14 @@ static bool eventCallback(void **data)
 EventMonitor::EventMonitor(Probe *probe, QObject *parent)
     : EventMonitorInterface(parent)
     , m_eventModel(new EventModel(this))
+    , m_eventTypeModel(new EventTypeModel(this))
     , m_eventPropertyModel(new AggregatedPropertyModel(this))
 {
     Q_ASSERT(s_model == nullptr);
     s_model = m_eventModel;
+
+    Q_ASSERT(s_eventTypeModel == nullptr);
+    s_eventTypeModel = m_eventTypeModel;
 
     Q_ASSERT(s_eventMonitor == nullptr);
     s_eventMonitor = this;
@@ -262,6 +267,10 @@ EventMonitor::EventMonitor(Probe *probe, QObject *parent)
     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
     proxy->setSourceModel(m_eventModel);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.EventModel"), proxy);
+
+    auto evenTypeProxy = new ServerProxyModel<QSortFilterProxyModel>(this);
+    evenTypeProxy->setSourceModel(m_eventTypeModel);
+    probe->registerModel(QStringLiteral("com.kdab.GammaRay.EventTypeModel"), evenTypeProxy);
 
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.EventPropertyModel"), m_eventPropertyModel);
 
@@ -282,6 +291,7 @@ void EventMonitor::eventSelected(const QItemSelection &selection)
 
 EventMonitor::~EventMonitor() {
     s_model = nullptr;
+    s_eventTypeModel = nullptr;
     s_eventMonitor = nullptr;
     QInternal::unregisterCallback(QInternal::EventNotifyCallback, eventCallback);
 }

--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -359,6 +359,14 @@ bool EventPropagationListener::eventFilter(QObject *receiver, QEvent *event)
     if (!shouldBeRecorded(receiver, event))
         return false;
 
+    if (event->type() != lastEvent.type) {
+        // a new event was created during the propagation
+        EventData newEvent = createEventData(receiver, event);
+        s_model->addEvent(newEvent);
+        s_eventTypeModel->increaseCount(event->type());
+        return false;
+    }
+
     EventData propagatedEvent = createEventData(receiver, event);
     lastEvent.propagatedEvents.append(propagatedEvent);
 

--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -170,7 +170,9 @@ static bool eventCallback(void **data)
         qWarning() << "Event or receiver is invalid";
         return false;
     }
-
+    if (!s_eventTypeModel->isRecording(event->type())) {
+        return false;
+    }
     if (Probe::instance()->filterObject(receiver)) {
         return false;
     }
@@ -298,5 +300,26 @@ EventMonitor::~EventMonitor() {
 
 void EventMonitor::clearHistory()
 {
-    s_model->clear();
+    m_eventModel->clear();
+    m_eventTypeModel->resetCounts();
+}
+
+void EventMonitor::recordAll()
+{
+    m_eventTypeModel->recordAll();
+}
+
+void EventMonitor::recordNone()
+{
+    m_eventTypeModel->recordNone();
+}
+
+void EventMonitor::showAll()
+{
+    m_eventTypeModel->showAll();
+}
+
+void EventMonitor::showNone()
+{
+    m_eventTypeModel->showNone();
 }

--- a/plugins/eventmonitor/eventmonitor.h
+++ b/plugins/eventmonitor/eventmonitor.h
@@ -44,6 +44,20 @@ QT_END_NAMESPACE
 namespace GammaRay {
 class AggregatedPropertyModel;
 
+
+class EventPropagationListener : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit EventPropagationListener(QObject *parent)
+        : QObject(parent)
+    {}
+
+    virtual bool eventFilter(QObject *receiver, QEvent *event) override;
+};
+
+
 class EventMonitor : public EventMonitorInterface
 {
     Q_OBJECT

--- a/plugins/eventmonitor/eventmonitor.h
+++ b/plugins/eventmonitor/eventmonitor.h
@@ -32,6 +32,7 @@
 #include <core/toolfactory.h>
 #include "eventmodel.h"
 #include "eventmonitorinterface.h"
+#include "eventtypemodel.h"
 
 #include <QObject>
 
@@ -60,6 +61,7 @@ private slots:
 
 private:
     EventModel *m_eventModel;
+    EventTypeModel *m_eventTypeModel;
     AggregatedPropertyModel *m_eventPropertyModel;
 };
 

--- a/plugins/eventmonitor/eventmonitor.h
+++ b/plugins/eventmonitor/eventmonitor.h
@@ -55,6 +55,10 @@ public:
 
 public slots:
     virtual void clearHistory() override;
+    virtual void recordAll() override;
+    virtual void recordNone() override;
+    virtual void showAll() override;
+    virtual void showNone() override;
 
 private slots:
     void eventSelected(const QItemSelection &selection);

--- a/plugins/eventmonitor/eventmonitor.h
+++ b/plugins/eventmonitor/eventmonitor.h
@@ -30,9 +30,7 @@
 #define GAMMARAY_EVENTMONITOR_EVENTMONITOR_H
 
 #include <core/toolfactory.h>
-#include "eventmodel.h"
 #include "eventmonitorinterface.h"
-#include "eventtypemodel.h"
 
 #include <QObject>
 
@@ -43,6 +41,8 @@ QT_END_NAMESPACE
 
 namespace GammaRay {
 class AggregatedPropertyModel;
+class EventModel;
+class EventTypeModel;
 
 
 class EventPropagationListener : public QObject
@@ -50,9 +50,7 @@ class EventPropagationListener : public QObject
     Q_OBJECT
 
 public:
-    explicit EventPropagationListener(QObject *parent)
-        : QObject(parent)
-    {}
+    explicit EventPropagationListener(QObject *parent);
 
     virtual bool eventFilter(QObject *receiver, QEvent *event) override;
 };

--- a/plugins/eventmonitor/eventmonitorclient.cpp
+++ b/plugins/eventmonitor/eventmonitorclient.cpp
@@ -45,3 +45,23 @@ void GammaRay::EventMonitorClient::clearHistory()
 {
     Endpoint::instance()->invokeObject(objectName(), "clearHistory");
 }
+
+void EventMonitorClient::recordAll()
+{
+    Endpoint::instance()->invokeObject(objectName(), "recordAll");
+}
+
+void EventMonitorClient::recordNone()
+{
+    Endpoint::instance()->invokeObject(objectName(), "recordNone");
+}
+
+void EventMonitorClient::showAll()
+{
+    Endpoint::instance()->invokeObject(objectName(), "showAll");
+}
+
+void EventMonitorClient::showNone()
+{
+    Endpoint::instance()->invokeObject(objectName(), "showNone");
+}

--- a/plugins/eventmonitor/eventmonitorclient.h
+++ b/plugins/eventmonitor/eventmonitorclient.h
@@ -41,7 +41,11 @@ public:
     ~EventMonitorClient() override;
 
 public slots:
-    void clearHistory() override;
+    virtual void clearHistory() override;
+    virtual void recordAll() override;
+    virtual void recordNone() override;
+    virtual void showAll() override;
+    virtual void showNone() override;
 };
 }
 

--- a/plugins/eventmonitor/eventmonitorinterface.h
+++ b/plugins/eventmonitor/eventmonitorinterface.h
@@ -47,6 +47,11 @@ public:
 
 public slots:
     virtual void clearHistory() = 0;
+    virtual void recordAll() = 0;
+    virtual void recordNone() = 0;
+    virtual void showAll() = 0;
+    virtual void showNone() = 0;
+
     bool isPaused() const { return m_isPaused; }
     void setIsPaused(bool value);
 

--- a/plugins/eventmonitor/eventmonitorwidget.cpp
+++ b/plugins/eventmonitor/eventmonitorwidget.cpp
@@ -83,6 +83,7 @@ EventMonitorWidget::EventMonitorWidget(QWidget *parent)
     EventTypeClientProxyModel * const eventTypeProxyModel = new EventTypeClientProxyModel(this);
     eventTypeProxyModel->setSourceModel(eventTypeModel);
     ui->eventTypeTree->sortByColumn(EventTypeModel::Columns::Type, Qt::AscendingOrder);
+    ui->eventTypeTree->setDeferredResizeMode(EventTypeModel::Columns::Value, QHeaderView::ResizeToContents);
     ui->eventTypeTree->setDeferredResizeMode(EventTypeModel::Columns::Type, QHeaderView::Stretch);
     ui->eventTypeTree->setModel(eventTypeProxyModel);
 

--- a/plugins/eventmonitor/eventmonitorwidget.cpp
+++ b/plugins/eventmonitor/eventmonitorwidget.cpp
@@ -32,6 +32,7 @@
 #include "eventmodelroles.h"
 #include "eventmonitorclient.h"
 #include "eventtypemodel.h"
+#include "eventtypeclientproxymodel.h"
 
 #include <ui/clientpropertymodel.h>
 #include <ui/contextmenuextension.h>
@@ -78,9 +79,11 @@ EventMonitorWidget::EventMonitorWidget(QWidget *parent)
     connect(ui->eventInspector, &QTreeView::customContextMenuRequested, this, &EventMonitorWidget::eventInspectorContextMenu);
 
     QAbstractItemModel * const eventTypeModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.EventTypeModel"));
+    EventTypeClientProxyModel * const eventTypeProxyModel = new EventTypeClientProxyModel(this);
+    eventTypeProxyModel->setSourceModel(eventTypeModel);
     ui->eventTypeTree->sortByColumn(EventTypeModel::Columns::Type, Qt::AscendingOrder);
     ui->eventTypeTree->setDeferredResizeMode(EventTypeModel::Columns::Type, QHeaderView::Stretch);
-    ui->eventTypeTree->setModel(eventTypeModel);
+    ui->eventTypeTree->setModel(eventTypeProxyModel);
 
     connect(ui->recordAllButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::recordAll);
     connect(ui->recordNoneButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::recordNone);

--- a/plugins/eventmonitor/eventmonitorwidget.cpp
+++ b/plugins/eventmonitor/eventmonitorwidget.cpp
@@ -79,6 +79,7 @@ EventMonitorWidget::EventMonitorWidget(QWidget *parent)
     connect(ui->eventInspector, &QTreeView::customContextMenuRequested, this, &EventMonitorWidget::eventInspectorContextMenu);
 
     QAbstractItemModel * const eventTypeModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.EventTypeModel"));
+    new SearchLineController(ui->typeSearchLine, eventTypeModel);
     EventTypeClientProxyModel * const eventTypeProxyModel = new EventTypeClientProxyModel(this);
     eventTypeProxyModel->setSourceModel(eventTypeModel);
     ui->eventTypeTree->sortByColumn(EventTypeModel::Columns::Type, Qt::AscendingOrder);

--- a/plugins/eventmonitor/eventmonitorwidget.cpp
+++ b/plugins/eventmonitor/eventmonitorwidget.cpp
@@ -75,6 +75,9 @@ EventMonitorWidget::EventMonitorWidget(QWidget *parent)
     ui->eventInspector->setModel(clientPropModel);
     ui->eventInspector->setItemDelegate(new PropertyEditorDelegate(this));
     connect(ui->eventInspector, &QTreeView::customContextMenuRequested, this, &EventMonitorWidget::eventInspectorContextMenu);
+
+    QAbstractItemModel * const eventTypeModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.EventTypeModel"));
+    ui->eventTypeTree->setModel(eventTypeModel);
 }
 
 EventMonitorWidget::~EventMonitorWidget()

--- a/plugins/eventmonitor/eventmonitorwidget.cpp
+++ b/plugins/eventmonitor/eventmonitorwidget.cpp
@@ -31,6 +31,7 @@
 
 #include "eventmodelroles.h"
 #include "eventmonitorclient.h"
+#include "eventtypemodel.h"
 
 #include <ui/clientpropertymodel.h>
 #include <ui/contextmenuextension.h>
@@ -77,7 +78,14 @@ EventMonitorWidget::EventMonitorWidget(QWidget *parent)
     connect(ui->eventInspector, &QTreeView::customContextMenuRequested, this, &EventMonitorWidget::eventInspectorContextMenu);
 
     QAbstractItemModel * const eventTypeModel = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.EventTypeModel"));
+    ui->eventTypeTree->sortByColumn(EventTypeModel::Columns::Type, Qt::AscendingOrder);
+    ui->eventTypeTree->setDeferredResizeMode(EventTypeModel::Columns::Type, QHeaderView::Stretch);
     ui->eventTypeTree->setModel(eventTypeModel);
+
+    connect(ui->recordAllButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::recordAll);
+    connect(ui->recordNoneButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::recordNone);
+    connect(ui->showAllButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::showAll);
+    connect(ui->showNoneButton, &QAbstractButton::pressed, m_interface, &EventMonitorInterface::showNone);
 }
 
 EventMonitorWidget::~EventMonitorWidget()

--- a/plugins/eventmonitor/eventmonitorwidget.ui
+++ b/plugins/eventmonitor/eventmonitorwidget.ui
@@ -18,62 +18,128 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QSplitter" name="mainSplitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <widget class="QWidget" name="layoutWidget_2">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Log</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <layout class="QHBoxLayout" name="toolbarLayout">
-         <property name="bottomMargin">
-          <number>6</number>
+        <widget class="QSplitter" name="mainSplitter">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
-         <item>
-          <widget class="QLineEdit" name="eventSearchLine"/>
-         </item>
-         <item>
-          <widget class="QToolButton" name="pauseButton">
-           <property name="text">
-            <string>Pause</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="clearButton">
-           <property name="text">
-            <string>Clear History</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="GammaRay::DeferredTreeView" name="eventTree">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
+         <widget class="QWidget" name="layoutWidget">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <layout class="QHBoxLayout" name="toolbarLayout">
+             <property name="bottomMargin">
+              <number>6</number>
+             </property>
+             <item>
+              <widget class="QLineEdit" name="eventSearchLine"/>
+             </item>
+             <item>
+              <widget class="QToolButton" name="pauseButton">
+               <property name="text">
+                <string>Pause</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="clearButton">
+               <property name="text">
+                <string>Clear History</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="GammaRay::DeferredTreeView" name="eventTree">
+             <property name="contextMenuPolicy">
+              <enum>Qt::CustomContextMenu</enum>
+             </property>
+             <property name="uniformRowHeights">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="layoutWidget_2">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="GammaRay::DeferredTreeView" name="eventInspector">
+             <property name="contextMenuPolicy">
+              <enum>Qt::CustomContextMenu</enum>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::ContiguousSelection</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="layoutWidget_2">
-      <layout class="QVBoxLayout" name="verticalLayout">
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Types</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="GammaRay::DeferredTreeView" name="eventInspector">
-         <property name="contextMenuPolicy">
-          <enum>Qt::CustomContextMenu</enum>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ContiguousSelection</enum>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QHBoxLayout" name="toolbarLayout">
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QToolButton" name="selectAllButton">
+             <property name="text">
+              <string>Enable All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="deselectAllButton">
+             <property name="text">
+              <string>Disable All</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="GammaRay::DeferredTreeView" name="eventTypeTree">
+           <property name="uniformRowHeights">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/plugins/eventmonitor/eventmonitorwidget.ui
+++ b/plugins/eventmonitor/eventmonitorwidget.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/plugins/eventmonitor/eventmonitorwidget.ui
+++ b/plugins/eventmonitor/eventmonitorwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>689</width>
     <height>300</height>
    </rect>
   </property>
@@ -33,7 +33,7 @@
           <enum>Qt::Horizontal</enum>
          </property>
          <widget class="QWidget" name="layoutWidget">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
             <layout class="QHBoxLayout" name="toolbarLayout">
              <property name="bottomMargin">
@@ -99,7 +99,7 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <layout class="QHBoxLayout" name="toolbarLayout">
+          <layout class="QHBoxLayout" name="toolbarLayout_2">
            <property name="bottomMargin">
             <number>6</number>
            </property>
@@ -117,16 +117,46 @@
             </spacer>
            </item>
            <item>
-            <widget class="QToolButton" name="selectAllButton">
+            <widget class="QToolButton" name="recordAllButton">
              <property name="text">
-              <string>Enable All</string>
+              <string>Record All</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QToolButton" name="deselectAllButton">
+            <widget class="QToolButton" name="recordNoneButton">
              <property name="text">
-              <string>Disable All</string>
+              <string>Record None</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Maximum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>50</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QToolButton" name="showAllButton">
+             <property name="text">
+              <string>Show All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="showNoneButton">
+             <property name="text">
+              <string>Show None</string>
              </property>
             </widget>
            </item>

--- a/plugins/eventmonitor/eventmonitorwidget.ui
+++ b/plugins/eventmonitor/eventmonitorwidget.ui
@@ -104,17 +104,7 @@
             <number>6</number>
            </property>
            <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
+            <widget class="QLineEdit" name="typeSearchLine"/>
            </item>
            <item>
             <widget class="QToolButton" name="recordAllButton">
@@ -131,7 +121,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer">
+            <spacer name="horizontalSpacer2">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>

--- a/plugins/eventmonitor/eventtypeclientproxymodel.cpp
+++ b/plugins/eventmonitor/eventtypeclientproxymodel.cpp
@@ -1,0 +1,75 @@
+/*
+  eventtypeclientproxymodel.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Tim Henning <tim.henning@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "eventtypeclientproxymodel.h"
+
+#include "eventtypemodel.h"
+
+#include <ui/uiintegration.h>
+
+#include <QColor>
+
+using namespace GammaRay;
+
+EventTypeClientProxyModel::EventTypeClientProxyModel(QObject *parent)
+    : QIdentityProxyModel(parent)
+{
+}
+
+EventTypeClientProxyModel::~EventTypeClientProxyModel() = default;
+
+// 1 / GRADIENT_SCALE_FACTOR is yellow, 2 / GRADIENT_SCALE_FACTOR and beyond is red
+static const int GRADIENT_SCALE_FACTOR = 4;
+
+static QColor colorForRatio(double ratio)
+{
+    const auto red = qBound<qreal>(0.0, ratio * GRADIENT_SCALE_FACTOR, 0.5);
+    const auto green = qBound<qreal>(0.0, 1 - ratio * GRADIENT_SCALE_FACTOR, 0.5);
+    auto color = QColor(int(255 * red), int(255 * green), 0);
+    if (!UiIntegration::hasDarkUI())
+        return color.lighter(300);
+    return color;
+}
+
+QVariant EventTypeClientProxyModel::data(const QModelIndex &index, int role) const
+{
+    if (!sourceModel() || !index.isValid())
+        return QVariant();
+
+    if (role != Qt::BackgroundRole || index.column() != EventTypeModel::Count)
+        return QIdentityProxyModel::data(index, role);
+
+    const int maxCount = QIdentityProxyModel::data(index, EventTypeModel::MaxEventCount).toInt();
+    const int count = QIdentityProxyModel::data(index, Qt::DisplayRole).toInt();
+    if (maxCount <= 0 || count <= 0) {
+        return QVariant();
+    }
+    const double ratio = double(count) / double(maxCount);
+
+    return colorForRatio(ratio);
+}

--- a/plugins/eventmonitor/eventtypeclientproxymodel.h
+++ b/plugins/eventmonitor/eventtypeclientproxymodel.h
@@ -1,0 +1,47 @@
+/*
+  eventtypeclientproxymodel.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Tim Henning <tim.henning@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef GAMMARAY_EVENTMONITOR_EVENTTYPECLIENTPROXYMODEL_H
+#define GAMMARAY_EVENTMONITOR_EVENTTYPECLIENTPROXYMODEL_H
+
+#include <QIdentityProxyModel>
+
+namespace GammaRay {
+/** Colors the event counts based on the max events of a single type. */
+class EventTypeClientProxyModel : public QIdentityProxyModel
+{
+    Q_OBJECT
+public:
+    explicit EventTypeClientProxyModel(QObject *parent = nullptr);
+    ~EventTypeClientProxyModel() override;
+
+    QVariant data(const QModelIndex &index, int role) const override;
+
+};
+}
+
+#endif // GAMMARAY_EVENTMONITOR_EVENTTYPECLIENTPROXYMODEL_H

--- a/plugins/eventmonitor/eventtypefilter.cpp
+++ b/plugins/eventmonitor/eventtypefilter.cpp
@@ -1,0 +1,45 @@
+/*
+  eventtypefilter.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Tim Henning <tim.henning@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "eventtypefilter.h"
+
+#include "eventtypemodel.h"
+
+GammaRay::EventTypeFilter::EventTypeFilter(QObject *parent, const EventTypeModel *model)
+    : QSortFilterProxyModel(parent)
+    , m_eventTypeModel(model)
+{
+
+}
+
+bool GammaRay::EventTypeFilter::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    QModelIndex typeIndex = sourceModel()->index(sourceRow, EventTypeModel::Columns::Value, sourceParent);
+    QEvent::Type type = sourceModel()->data(typeIndex).value<QEvent::Type>();
+    return m_eventTypeModel->isVisible(type);
+}

--- a/plugins/eventmonitor/eventtypefilter.h
+++ b/plugins/eventmonitor/eventtypefilter.h
@@ -1,0 +1,56 @@
+/*
+  eventtypefilter.h
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Tim Henning <tim.henning@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_EVENTMONITOR_EVENTTYPEFILTER_H
+#define GAMMARAY_EVENTMONITOR_EVENTTYPEFILTER_H
+
+#include <QSortFilterProxyModel>
+
+
+namespace GammaRay {
+
+class EventTypeModel;
+
+class EventTypeFilter : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit EventTypeFilter(QObject *parent, const EventTypeModel *model);
+    ~EventTypeFilter() override = default;
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    const EventTypeModel*  m_eventTypeModel;
+};
+}
+
+
+#endif // GAMMARAY_EVENTMONITOR_EVENTTYPEFILTER_H

--- a/plugins/eventmonitor/eventtypemodel.cpp
+++ b/plugins/eventmonitor/eventtypemodel.cpp
@@ -1,0 +1,175 @@
+/*
+  eventtypemodel.cpp
+
+  This file is part of GammaRay, the Qt application inspection and
+  manipulation tool.
+
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Tim Henning <tim.henning@kdab.com>
+
+  Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+  accordance with GammaRay Commercial License Agreement provided with the Software.
+
+  Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "eventtypemodel.h"
+
+#include <core/probe.h>
+#include <core/util.h>
+#include <core/varianthandler.h>
+
+#include <QMetaEnum>
+#include <QMutexLocker>
+
+using namespace GammaRay;
+
+EventTypeModel::EventTypeModel(QObject *parent)
+    : QAbstractTableModel(parent)
+{
+    qRegisterMetaType<EventTypeData>();
+    initEventTypes();
+}
+
+EventTypeModel::~EventTypeModel() = default;
+
+int EventTypeModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return EventTypeModel::Columns::COUNT;
+}
+
+int EventTypeModel::rowCount(const QModelIndex &parent) const
+{
+    if (!parent.isValid())
+        return m_data.size();
+
+    return 0;
+}
+
+QVariant EventTypeModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= rowCount() || index.column() >= columnCount())
+        return QVariant();
+
+    EventTypeData* eventTypeData = static_cast<EventTypeData*>(index.internalPointer());
+
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case Columns::Type:
+            return VariantHandler::displayString(m_data.keys().at(index.row()));
+        case Columns::Count:
+            return eventTypeData->count;
+        case Columns::LoggingStatus:
+            return ""; //eventTypeData->loggingEnabled;
+        }
+    } else if (role == Qt::CheckStateRole) {
+        switch (index.column()) {
+        case Columns::LoggingStatus:
+            return eventTypeData->loggingEnabled ? Qt::Checked : Qt::Unchecked;
+        }
+    }
+
+    return QVariant();
+}
+
+Qt::ItemFlags EventTypeModel::flags(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return Qt::ItemFlag::NoItemFlags;
+
+    Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+
+    if (index.column() == Columns::LoggingStatus)
+        flags |= Qt::ItemIsUserCheckable;
+
+    return flags;
+}
+
+bool EventTypeModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (!index.isValid() || index.column() != Columns::LoggingStatus || role != Qt::CheckStateRole)
+        return false;
+
+    const auto enabled = value.toInt() == Qt::Checked;
+    EventTypeData* eventTypeData = static_cast<EventTypeData*>(index.internalPointer());
+    eventTypeData->loggingEnabled = enabled;
+    emit dataChanged(index, index);
+    return true;
+}
+
+QVariant EventTypeModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
+        switch (section) {
+        case Columns::Type:
+            return tr("Type");
+        case Columns::Count:
+            return tr("Count");
+        case Columns::LoggingStatus:
+            return tr("Logging");
+        }
+    }
+
+    return QVariant();
+}
+
+QModelIndex EventTypeModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (row < 0 || column < 0 || column >= columnCount() || parent.isValid())
+        return {};
+
+    EventTypeData* item = m_data.value(m_data.keys().at(row));
+
+    return createIndex(row, column, item);
+}
+
+void EventTypeModel::increaseCount(QEvent::Type type)
+{
+    if (m_data.contains(type)) {
+        EventTypeData* item = m_data.value(type);
+        item->count++;
+        QModelIndex index = createIndex(m_data.keys().indexOf(type), Columns::Count, item);
+        emit dataChanged(index, index);
+    }
+}
+
+void EventTypeModel::enableAll()
+{
+    for (EventTypeData* eventTypeData: m_data) {
+        eventTypeData->loggingEnabled = true;
+    }
+}
+
+void EventTypeModel::disableAll()
+{
+    for (EventTypeData* eventTypeData: m_data) {
+        eventTypeData->loggingEnabled = false;
+    }
+}
+
+void EventTypeModel::resetCount()
+{
+    for (EventTypeData* eventTypeData: m_data) {
+        eventTypeData->count = 0;
+    }
+}
+
+void EventTypeModel::initEventTypes()
+{
+    m_data[QEvent::Type::MouseMove] = new EventTypeData();
+    m_data[QEvent::Type::Timer] = new EventTypeData();
+}

--- a/plugins/eventmonitor/eventtypemodel.cpp
+++ b/plugins/eventmonitor/eventtypemodel.cpp
@@ -107,10 +107,12 @@ bool EventTypeModel::setData(const QModelIndex &index, const QVariant &value, in
 
     const auto enabled = value.toInt() == Qt::Checked;
     EventTypeData* eventTypeData = static_cast<EventTypeData*>(index.internalPointer());
-    if (index.column() == Columns::RecordingStatus)
+    if (index.column() == Columns::RecordingStatus) {
         eventTypeData->recordingEnabled = enabled;
-    else if (index.column() == Columns::Visibility)
+    } else if (index.column() == Columns::Visibility) {
         eventTypeData->isVisibleInLog = enabled;
+        emit typeVisibilityChanged();
+    }
     emit dataChanged(index, index, { Qt::CheckStateRole });
     return true;
 }
@@ -196,6 +198,14 @@ void EventTypeModel::recordNone()
     endResetModel();
 }
 
+bool EventTypeModel::isVisible(QEvent::Type type) const
+{
+    if (m_data.contains(type)) {
+        return m_data.value(type)->isVisibleInLog;
+    }
+    return true;
+}
+
 void EventTypeModel::showAll()
 {
     beginResetModel();
@@ -203,6 +213,7 @@ void EventTypeModel::showAll()
         eventTypeData->isVisibleInLog = true;
     }
     endResetModel();
+    emit typeVisibilityChanged();
 }
 
 void EventTypeModel::showNone()
@@ -212,6 +223,7 @@ void EventTypeModel::showNone()
         eventTypeData->isVisibleInLog = false;
     }
     endResetModel();
+    emit typeVisibilityChanged();
 }
 
 void EventTypeModel::initEventTypes()

--- a/plugins/eventmonitor/eventtypemodel.h
+++ b/plugins/eventmonitor/eventtypemodel.h
@@ -28,8 +28,6 @@
 #ifndef GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 #define GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 
-#include <core/execution.h>
-
 #include <QAbstractTableModel>
 #include <QMap>
 #include <QEvent>
@@ -37,7 +35,8 @@
 namespace GammaRay {
 struct EventTypeData {
     int count = 0;
-    bool loggingEnabled = true;
+    bool recordingEnabled = true;
+    bool isVisibleInLog = true;
 };
 }
 
@@ -51,10 +50,13 @@ class EventTypeModel : public QAbstractTableModel
 {
     Q_OBJECT
 
+public:
     enum Columns {
         Type = 0,
+        Value,
         Count,
-        LoggingStatus,
+        RecordingStatus,
+        Visibility,
         COUNT
     };
 
@@ -74,11 +76,14 @@ public:
 
 public slots:
     void increaseCount(QEvent::Type type);
+    void resetCounts();
 
-    void enableAll();
-    void disableAll();
+    bool isRecording(QEvent::Type type) const;
+    void recordAll();
+    void recordNone();
 
-    void resetCount();
+    void showAll();
+    void showNone();
 
 private:
     void initEventTypes();

--- a/plugins/eventmonitor/eventtypemodel.h
+++ b/plugins/eventmonitor/eventtypemodel.h
@@ -54,8 +54,8 @@ class EventTypeModel : public QAbstractTableModel
 
 public:
     enum Columns {
-        Type = 0,
-        Value,
+        Value = 0,
+        Type,
         Count,
         RecordingStatus,
         Visibility,

--- a/plugins/eventmonitor/eventtypemodel.h
+++ b/plugins/eventmonitor/eventtypemodel.h
@@ -28,6 +28,8 @@
 #ifndef GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 #define GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 
+#include <common/modelroles.h>
+
 #include <QAbstractTableModel>
 #include <QMap>
 #include <QEvent>
@@ -60,6 +62,10 @@ public:
         COUNT
     };
 
+    enum Role {
+        MaxEventCount = GammaRay::UserRole + 1,
+    };
+
 public:
     explicit EventTypeModel(QObject *parent = nullptr);
     ~EventTypeModel() override;
@@ -73,6 +79,7 @@ public:
                         int role = Qt::DisplayRole) const override;
     QModelIndex index(int row, int column,
                       const QModelIndex &parent = QModelIndex()) const override;
+    QMap<int, QVariant> itemData(const QModelIndex& index) const override;
 
 public slots:
     void increaseCount(QEvent::Type type);
@@ -94,6 +101,7 @@ private:
 
 private:
     QMap<QEvent::Type, EventTypeData*> m_data;
+    int m_maxEventCount;
 };
 }
 

--- a/plugins/eventmonitor/eventtypemodel.h
+++ b/plugins/eventmonitor/eventtypemodel.h
@@ -1,10 +1,10 @@
 /*
-  eventmodel.h
+  eventtypemodel.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2010-2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Copyright (C) 2019 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
   Author: Tim Henning <tim.henning@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
@@ -25,57 +25,68 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef GAMMARAY_EVENTMONITOR_EVENTMODEL_H
-#define GAMMARAY_EVENTMONITOR_EVENTMODEL_H
+#ifndef GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
+#define GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 
-#include <QAbstractItemModel>
-#include <QTime>
-#include <QVector>
+#include <core/execution.h>
+
+#include <QAbstractTableModel>
+#include <QMap>
 #include <QEvent>
-#include <QVariant>
-#include <QPair>
 
 namespace GammaRay {
-struct EventData {
-    QTime time;
-    QEvent::Type type;
-    QObject* receiver;
-    QVector<QPair<const char *, QVariant>> attributes;
+struct EventTypeData {
+    int count = 0;
+    bool loggingEnabled = true;
 };
 }
 
-Q_DECLARE_METATYPE(GammaRay::EventData)
+Q_DECLARE_METATYPE(GammaRay::EventTypeData)
 QT_BEGIN_NAMESPACE
-    Q_DECLARE_TYPEINFO(GammaRay::EventData, Q_MOVABLE_TYPE);
+    Q_DECLARE_TYPEINFO(GammaRay::EventTypeData, Q_MOVABLE_TYPE);
 QT_END_NAMESPACE
 
 namespace GammaRay {
-class EventModel : public QAbstractItemModel
+class EventTypeModel : public QAbstractTableModel
 {
     Q_OBJECT
+
+    enum Columns {
+        Type = 0,
+        Count,
+        LoggingStatus,
+        COUNT
+    };
+
 public:
-    explicit EventModel(QObject *parent = nullptr);
-    ~EventModel() override;
+    explicit EventTypeModel(QObject *parent = nullptr);
+    ~EventTypeModel() override;
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
     QModelIndex index(int row, int column,
                       const QModelIndex &parent = QModelIndex()) const override;
-    QModelIndex parent(const QModelIndex &child) const override;
-    QMap<int, QVariant> itemData(const QModelIndex & index) const override;
 
 public slots:
-    void addEvent(const GammaRay::EventData &event);
+    void increaseCount(QEvent::Type type);
 
-    void clear();
+    void enableAll();
+    void disableAll();
+
+    void resetCount();
 
 private:
-    QVector<EventData> m_events;
+    void initEventTypes();
+
+private:
+    QMap<QEvent::Type, EventTypeData*> m_data;
 };
 }
 
-#endif // GAMMARAY_EVENTMONITOR_EVENTMODEL_H
+#endif // GAMMARAY_EVENTMONITOR_EVENTTYPEMODEL_H
 

--- a/plugins/eventmonitor/eventtypemodel.h
+++ b/plugins/eventmonitor/eventtypemodel.h
@@ -82,8 +82,12 @@ public slots:
     void recordAll();
     void recordNone();
 
+    bool isVisible(QEvent::Type type) const;
     void showAll();
     void showNone();
+
+signals:
+    void typeVisibilityChanged();
 
 private:
     void initEventTypes();


### PR DESCRIPTION
- add a list of all events types
- can be used to configure what events should be recorded and / or shown in the UI
- propagated events are shown in the event log as children of the original event