### PR TITLE
Fix build against Qt 5.14

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -654,7 +654,7 @@ void QuickInspector::checkOverlaySettings()
 class SGSoftwareRendererPrivacyViolater : public QSGAbstractSoftwareRenderer
 {
 public:
-#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0) || QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     using QSGAbstractSoftwareRenderer::renderableNodes;
 #endif
     using QSGAbstractSoftwareRenderer::renderNodes;
@@ -684,7 +684,7 @@ void QuickInspector::analyzePainting()
         renderer->markDirty();
         renderer->buildRenderList();
         renderer->optimizeRenderList();
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0) || QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         renderer->renderNodes(&painter);
 #else
         auto iterator = renderer->renderableNodes().begin();


### PR DESCRIPTION
renderableNodes() doesn't seem to be available in current Qt master. Use the old renderNodes() as a quick fix to enable building Gammaray.

It would be preferrable though to find a solution that keeps the functionality