### PR TITLE
Fix propagation detection of QtQuick pointer events

### DIFF
--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -270,7 +270,6 @@ static bool eventCallback(void **data)
 
     // add directly from foreground thread, delay from background thread
     QMetaObject::invokeMethod(s_eventMonitor, "addEvent", Qt::AutoConnection, Q_ARG(GammaRay::EventData, eventData));
-
     return false;
 }
 


### PR DESCRIPTION
QtQuick pointer events are propagated different than Qt Widgets. The same event is modified and sent again using `QCoreApplication::sendEvent()` to a different receiver.