### PR TITLE
Fixing problem with backtrace and uclibc

### DIFF
--- a/core/execution.cpp
+++ b/core/execution.cpp
@@ -31,7 +31,7 @@
 
 #include <QtGlobal>
 
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID) && defined(HAVE_BACKTRACE)
 #include <backward.hpp>
 #define USE_BACKWARD_CPP
 #else


### PR DESCRIPTION
When compiling on uclibc, backtrace is not always available, so gammaray doesn't compile.

This series trying to fixing it.