### PR TITLE
Fix some GCC 9 warnings

### DIFF
--- a/common/sharedpool.h
+++ b/common/sharedpool.h
@@ -81,7 +81,7 @@ public:
             m_pool.push(std::unique_ptr<T>(ptr));
         });
         m_pool.pop();
-        return std::move(tmp);
+        return tmp;
     }
 
     bool empty() const

--- a/plugins/widgetinspector/widget3dmodel.h
+++ b/plugins/widgetinspector/widget3dmodel.h
@@ -65,7 +65,8 @@ public:
     inline QString id() const {
         QString str(8, QLatin1Char('0'));
         const quint64 ptr = reinterpret_cast<quint64>(mQWidget.data());
-        std::memcpy(str.data(), &ptr, 8);
+        // this is almost certainly wrong, but keep it for backwards compat:
+        std::memcpy(static_cast<void*>(str.data()), &ptr, 8);
         return str;
     };
 

--- a/plugins/widgetinspector/widget3dmodel.h
+++ b/plugins/widgetinspector/widget3dmodel.h
@@ -63,11 +63,7 @@ public:
     // QML does not handle 64bit integers, so use string instead, we only need
     // the value for comparison, we can convert back to quintptr in C++
     inline QString id() const {
-        QString str(8, QLatin1Char('0'));
-        const quint64 ptr = reinterpret_cast<quint64>(mQWidget.data());
-        // this is almost certainly wrong, but keep it for backwards compat:
-        std::memcpy(static_cast<void*>(str.data()), &ptr, 8);
-        return str;
+        return QString::asprintf("%p", static_cast<const void*>(mQWidget.data()));
     };
 
 protected:


### PR DESCRIPTION
- pessimizing std::move
- memcpy to object of non-trivial type

The code in widget3dmodel.h is almost certainly wrong, since it memcpy's
8 bytes into a buffer of 16 bytes, but I left it as-is, because I don't
know if and where it's converted back.