### PR TITLE
Don't clean up scenegraph in RenderModeRequest::apply()

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -325,7 +325,6 @@ void RenderModeRequest::apply()
         emit aboutToCleanSceneGraph();
         const QByteArray mode = renderModeToString(RenderModeRequest::mode);
         QQuickWindowPrivate *winPriv = QQuickWindowPrivate::get(window);
-        QMetaObject::invokeMethod(window, "cleanupSceneGraph", Qt::DirectConnection);
         winPriv->customRenderMode = mode;
         emit sceneGraphCleanedUp();
     }


### PR DESCRIPTION
cleanupSceneGraph deletes the renderer object in QQuickWindow (qquickwindow.cpp:3729) which leads to a crash in renderSceneGraph() (see #586 )

Removing the cleanup fixes the crash for me, but I don't know about the possible side effects of doing this. At first glance the Quick Inspector seems to work normally