### PR TITLE
Fix probe destruction

### DIFF
--- a/core/probe.h
+++ b/core/probe.h
@@ -49,6 +49,7 @@ class QModelIndex;
 class QThread;
 class QTimer;
 class QMutex;
+class QSignalSpyCallbackSet;
 QT_END_NAMESPACE
 
 namespace GammaRay {
@@ -329,7 +330,12 @@ private:
     QTimer *m_queueTimer;
     QVector<QObject *> m_globalEventFilters;
     QVector<SignalSpyCallbackSet> m_signalSpyCallbacks;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QSignalSpyCallbackSet *m_previousSignalSpyCallbackSet;
+#else
     SignalSpyCallbackSet m_previousSignalSpyCallbackSet;
+#endif
     Server *m_server;
 };
 }


### PR DESCRIPTION
For Qt 5.14 qt_register_signal_spy_callbacks takes a pointer, not a value anymore. Still, the probe copied the callback struct and on destruction would call qt_register_signal_spy_callbacks with a pointer to the function-local object, leading to a crash. Now, for Qt 5.14, we don't copy the callback struct, but instead just store a copy of the pointer and on Probe-destruction reset the qt_signal_spy_callback_set with the old pointer value.