### PR TITLE
Don't update window icon while holding the probe lock

### DIFF
--- a/plugins/guisupport/guisupport.cpp
+++ b/plugins/guisupport/guisupport.cpp
@@ -138,7 +138,9 @@ GuiSupport::GuiSupport(Probe *probe, QObject *parent)
     connect(m_probe, &Probe::objectCreated, this, &GuiSupport::objectCreated);
 
     if (auto guiApp = qobject_cast<QGuiApplication*>(QCoreApplication::instance())) {
-        updateWindowIcon();
+        QMetaObject::invokeMethod(this, [this]() {
+            updateWindowIcon();
+        }, Qt::QueuedConnection);
 
         m_probe->installGlobalEventFilter(this);
         foreach (auto w, guiApp->topLevelWindows()) {


### PR DESCRIPTION
Fixes potential deadlock when the icon requires a multi-threaded
image conversion, which can happen on hidpi screens with Qt 5.15+.

Fixes: https://github.com/KDAB/GammaRay/issues/607