### PR TITLE
Prefer picking items in fully visible parent-child chains

### DIFF
--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -152,7 +152,8 @@ private:
     static void scanForProblems();
 
     GammaRay::ObjectIds recursiveItemsAt(QQuickItem *parent, const QPointF &pos,
-                                         GammaRay::RemoteViewInterface::RequestMode mode, int& bestCandidate) const;
+                                         GammaRay::RemoteViewInterface::RequestMode mode,
+                                         int& bestCandidate, bool parentIsGoodCandidate = true) const;
 
     Probe *m_probe;
     std::unique_ptr<AbstractScreenGrabber> m_overlay;

--- a/tests/manual/picking/opacityzerooverlay.qml
+++ b/tests/manual/picking/opacityzerooverlay.qml
@@ -39,6 +39,14 @@ Item {
       color:"#ffffffff"
       anchors.fill: parent
       opacity: 0
+
+      Rectangle {
+        id: visibleChildOfInvisibleParent
+
+        color: "#ffff0000"
+        anchors.fill: parent
+        opacity: 1
+      }
   }
 
   Rectangle {


### PR DESCRIPTION
Most notably, don't pick the first item that's visible and has
a non-zero opacity: While the visibility property takes the parent's
visibility into account, that is not the case for the opacity
property. Thus, we need to track that manually, otherwise we
would easily end up picking unrelated items. In the samegame example
e.g. one could easily end up picking an invisible highscore item
in the center of the game canvas - the parent for that item is
visible but has opacity 0. With this patch, we instead pick the game
blocks instead, which is closer to what I'd expect.