### PR TITLE
BaseQuickTest::showSource: increase wait period to make the tests less flaky

### DIFF
--- a/tests/basequicktest.h
+++ b/tests/basequicktest.h
@@ -95,7 +95,7 @@ protected:
         }
 
         // wait at least two frames so we have the final window size with all render loop/driver combinations...
-        QTest::qWait(20);
+        QTest::qWait(100);
         renderSpy.wait();
         renderSpy.clear();
         m_view->update();


### PR DESCRIPTION
In Debian, when Qt was updated from 5.14 to 5.15, QuickInspectorTest started failing (retrying the build 6 times did not help):
https://buildd.debian.org/status/logs.php?pkg=gammaray&ver=2.11.2-1%2Bb1&arch=amd64

(click on "Maybe-Failed" to see the full build logs, search for `FAIL!`)

With this change, it passed from the first try:
https://buildd.debian.org/status/logs.php?pkg=gammaray&ver=2.11.2-2&arch=amd64