### PR TITLE
MyStrCpy: fixed to work with long typenames

### DIFF
--- a/3rdparty/StackWalker/StackWalker.cpp
+++ b/3rdparty/StackWalker/StackWalker.cpp
@@ -243,7 +243,7 @@ static void MyStrCpy(char* szDest, size_t nMaxDestSize, const char* szSrc)
   }
   else
   {
-    strncpy_s(szDest, nMaxDestSize, szSrc, nMaxDestSize);
+    strncpy_s(szDest, nMaxDestSize, szSrc, nMaxDestSize-1);
     szDest[nMaxDestSize-1] = 0;
   }
 }  // MyStrCpy
@@ -655,7 +655,7 @@ private:
     pGMI = (tGMI) GetProcAddress( hPsapi, "GetModuleInformation" );
     if ( (pEPM == NULL) || (pGMFNE == NULL) || (pGMBN == NULL) || (pGMI == NULL) )
     {
-      // we couldn´t find all functions
+      // we couldnÂ´t find all functions
       FreeLibrary(hPsapi);
       return FALSE;
     }


### PR DESCRIPTION
I have encountered the crash when inspecting objects with long typenames.
This PR fixes it — `strncpy_s`'s last argument cannot be equal to size, as there would be no space remaining for null character.
(we cannot just copy N characters into N-sized buffer)

Also I see the another line touched, as the file was converted to UTF-8. If you don't want this change, please let me know (or just manually apply the relevant part).