### PR TITLE
Context menu option to copy message stack trace

### DIFF
--- a/common/tools/messagehandler/messagehandlerinterface.cpp
+++ b/common/tools/messagehandler/messagehandlerinterface.cpp
@@ -52,3 +52,16 @@ void MessageHandlerInterface::setStackTraceAvailable(bool available)
     m_stackTraceAvailable = available;
     emit stackTraceAvailableChanged(available);
 }
+
+QStringList MessageHandlerInterface::fullTrace() const
+{
+    return m_fullTrace;
+}
+
+void MessageHandlerInterface::setFullTrace(const QStringList &newFullTrace)
+{
+    if (m_fullTrace == newFullTrace)
+        return;
+    m_fullTrace = newFullTrace;
+    emit fullTraceChanged();
+}

--- a/common/tools/messagehandler/messagehandlerinterface.h
+++ b/common/tools/messagehandler/messagehandlerinterface.h
@@ -40,6 +40,7 @@ class MessageHandlerInterface : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool stackTraceAvailable READ stackTraceAvailable WRITE setStackTraceAvailable NOTIFY stackTraceAvailableChanged)
+    Q_PROPERTY(QStringList fullTrace READ fullTrace WRITE setFullTrace NOTIFY fullTraceChanged)
 public:
     explicit MessageHandlerInterface(QObject *parent = nullptr);
     ~MessageHandlerInterface() override;
@@ -47,13 +48,21 @@ public:
     bool stackTraceAvailable() const;
     void setStackTraceAvailable(bool available);
 
+    QStringList fullTrace() const;
+    void setFullTrace(const QStringList &newFullTrace);
+
+public slots:
+    virtual void generateFullTrace() = 0;
+
 signals:
     void fatalMessageReceived(const QString &app, const QString &message, const QTime &time,
                               const QStringList &backtrace);
     void stackTraceAvailableChanged(bool available);
+    void fullTraceChanged();
 
 private:
     bool m_stackTraceAvailable;
+    QStringList m_fullTrace;
 };
 }
 

--- a/core/stacktracemodel.cpp
+++ b/core/stacktracemodel.cpp
@@ -98,3 +98,17 @@ QVariant StackTraceModel::headerData(int section, Qt::Orientation orientation, i
     }
     return QAbstractTableModel::headerData(section, orientation, role);
 }
+
+QStringList StackTraceModel::fullTrace() const
+{
+    QStringList bt;
+    bt.reserve(m_frames.size());
+    for (const auto &frame : qAsConst(m_frames)) {
+        if (frame.location.isValid())
+            bt.push_back(frame.name + QLatin1String(" (") + frame.location.displayString() + QLatin1Char(')'));
+        else
+            bt.push_back(frame.name);
+    }
+
+    return bt;
+}

--- a/core/stacktracemodel.h
+++ b/core/stacktracemodel.h
@@ -54,6 +54,8 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
+    QStringList fullTrace() const;
+
 private:
     mutable QVector<Execution::ResolvedFrame> m_frames;
     Execution::Trace m_trace;

--- a/core/tools/messagehandler/messagehandler.cpp
+++ b/core/tools/messagehandler/messagehandler.cpp
@@ -171,6 +171,11 @@ MessageHandler::~MessageHandler()
     s_handler = nullptr;
 }
 
+void MessageHandler::generateFullTrace()
+{
+    setFullTrace(m_stackTraceModel->fullTrace());
+}
+
 void MessageHandler::ensureHandlerInstalled()
 {
     QMutexLocker lock(&s_mutex);

--- a/core/tools/messagehandler/messagehandler.h
+++ b/core/tools/messagehandler/messagehandler.h
@@ -53,6 +53,9 @@ public:
     explicit MessageHandler(Probe *probe, QObject *parent = nullptr);
     ~MessageHandler() override;
 
+public slots:
+    void generateFullTrace() override;
+
 private slots:
     void ensureHandlerInstalled();
     void handleFatalMessage(const GammaRay::DebugMessage &message);

--- a/ui/tools/messagehandler/messagehandlerclient.cpp
+++ b/ui/tools/messagehandler/messagehandlerclient.cpp
@@ -28,9 +28,16 @@
 
 #include "messagehandlerclient.h"
 
+#include <common/endpoint.h>
+
 using namespace GammaRay;
 
 MessageHandlerClient::MessageHandlerClient(QObject *parent)
     : MessageHandlerInterface(parent)
 {
+}
+
+void MessageHandlerClient::generateFullTrace()
+{
+    Endpoint::instance()->invokeObject(objectName(), "generateFullTrace");
 }

--- a/ui/tools/messagehandler/messagehandlerclient.h
+++ b/ui/tools/messagehandler/messagehandlerclient.h
@@ -38,6 +38,9 @@ class MessageHandlerClient : public MessageHandlerInterface
     Q_INTERFACES(GammaRay::MessageHandlerInterface)
 public:
     explicit MessageHandlerClient(QObject *parent = nullptr);
+
+public slots:
+    void generateFullTrace() override;
 };
 }
 

--- a/ui/tools/messagehandler/messagehandlerwidget.h
+++ b/ui/tools/messagehandler/messagehandlerwidget.h
@@ -59,6 +59,7 @@ private slots:
 private:
     QScopedPointer<Ui::MessageHandlerWidget> ui;
     UIStateManager m_stateManager;
+    QObject *m_backtraceFetchContext = nullptr;
 };
 }
 


### PR DESCRIPTION
Useful when you want to share the stack trace for the current message with someone.