### PR TITLE
Launch QtCreator with the -client argument, to reuse the same instance

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -109,7 +109,7 @@ static const IdeSettings ideSettings[] = {
       nullptr     },
     { "gvim", "%f +%l", QT_TRANSLATE_NOOP("GammaRay::MainWindow", "gvim"),
       nullptr     },
-    { "qtcreator", "%f:%l:%c", QT_TRANSLATE_NOOP("GammaRay::MainWindow", "Qt Creator"), nullptr     }
+    { "qtcreator", "-client %f:%l:%c", QT_TRANSLATE_NOOP("GammaRay::MainWindow", "Qt Creator"), nullptr     }
 #endif
 };
 #if defined(Q_OS_WIN) || defined(Q_OS_OSX) // Remove this #if branch when adding real data to ideSettings for Windows/OSX.


### PR DESCRIPTION
Launching a brand new QtCreator each time the user does "Show Source"
is really not convenient. Reusing the same QtCreator even allows to load
the project once and navigate in a proper project after that.