### PR TITLE
Create QPainter on stack rather than with new.

### DIFF
--- a/ui/trailingcolorlabel.cpp
+++ b/ui/trailingcolorlabel.cpp
@@ -47,10 +47,9 @@ TrailingColorLabel::TrailingColorLabel(QWidget *parent) : QLabel(parent)
 void TrailingColorLabel::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
-    QPainter *p = new QPainter(this);
+    QPainter p(this);
 
-
-    QFontMetrics metrics(p->font());
+    QFontMetrics metrics(p.font());
 
     const int margin = 5;
     const int squaresize = 20;
@@ -64,26 +63,26 @@ void TrailingColorLabel::paintEvent(QPaintEvent *event)
     setMinimumSize(QSize(width + 1, height + 1));
 
 
-    p->setPen(QPen(Qt::lightGray));
-    p->setBrush(palette().base());
-    p->drawRect(0, 0, width, height);
-    p->setPen(QPen(palette().color(QPalette::Normal, QPalette::Text)));
+    p.setPen(QPen(Qt::lightGray));
+    p.setBrush(palette().base());
+    p.drawRect(0, 0, width, height);
+    p.setPen(QPen(palette().color(QPalette::Normal, QPalette::Text)));
 
-    p->drawText(QRect(margin + squaresize + margin + 0 * numberGroupWidth, 0, numberGroupWidth, height),
+    p.drawText(QRect(margin + squaresize + margin + 0 * numberGroupWidth, 0, numberGroupWidth, height),
                 Qt::AlignVCenter | Qt::AlignRight,
                 QString::number(qRed(m_pickedColor)));
-    p->drawText(QRect(margin + squaresize + margin + 1 * numberGroupWidth, 0, numberGroupWidth, height),
+    p.drawText(QRect(margin + squaresize + margin + 1 * numberGroupWidth, 0, numberGroupWidth, height),
                 Qt::AlignVCenter | Qt::AlignRight,
                 QString::number(qGreen(m_pickedColor)));
-    p->drawText(QRect(margin + squaresize + margin + 2 * numberGroupWidth, 0, numberGroupWidth, height),
+    p.drawText(QRect(margin + squaresize + margin + 2 * numberGroupWidth, 0, numberGroupWidth, height),
                 Qt::AlignVCenter | Qt::AlignRight,
                 QString::number(qBlue(m_pickedColor)));
     //alpha
-    p->setPen(QPen(palette().color(QPalette::Disabled, QPalette::Text)));
-    p->drawText(QRect(margin + squaresize + margin + 3 * numberGroupWidth + 2, 0, numberGroupWidth, height),
+    p.setPen(QPen(palette().color(QPalette::Disabled, QPalette::Text)));
+    p.drawText(QRect(margin + squaresize + margin + 3 * numberGroupWidth + 2, 0, numberGroupWidth, height),
                 Qt::AlignVCenter | Qt::AlignLeft,
                 "|");
-    p->drawText(QRect(margin + squaresize + margin + 3 * numberGroupWidth, 0, numberGroupWidth, height),
+    p.drawText(QRect(margin + squaresize + margin + 3 * numberGroupWidth, 0, numberGroupWidth, height),
                 Qt::AlignVCenter | Qt::AlignRight,
                 QString::number(qAlpha(m_pickedColor)));
     { // Color bg-pattern
@@ -94,14 +93,14 @@ void TrailingColorLabel::paintEvent(QPaintEvent *event)
     bgPainter.fillRect(10, 0, 10, 10, Qt::gray);
     bgPainter.fillRect(0, 10, 10, 10, Qt::gray);
     brush.setTexture(bgPattern);
-    p->setBrush(brush);
-    p->drawRect(margin, margin, squaresize, squaresize);
+    p.setBrush(brush);
+    p.drawRect(margin, margin, squaresize, squaresize);
     }
 
     QColor color = QColor::fromRgba(m_pickedColor);
-    p->setBrush(QBrush(color));
-    p->setPen(QPen(Qt::black));
-    p->drawRect(margin, margin, squaresize, squaresize);
+    p.setBrush(QBrush(color));
+    p.setPen(QPen(Qt::black));
+    p.drawRect(margin, margin, squaresize, squaresize);
 }
 
 QColor TrailingColorLabel::pickedColor() const


### PR DESCRIPTION
This fixes the runtime warning
QBackingStore::endPaint() called with active painter; did you forget to destroy it or call QPainter::end() on it?

@chsterz 