### PR TITLE
Allow capturing response for network operations

### DIFF
--- a/plugins/network/CMakeLists.txt
+++ b/plugins/network/CMakeLists.txt
@@ -2,6 +2,7 @@
 if (NOT GAMMARAY_CLIENT_ONLY_BUILD)
 set(gammaray_network_srcs
     networksupport.cpp
+    networksupportinterface.cpp
     networkinterfacemodel.cpp
     networkreplymodel.cpp
 
@@ -24,6 +25,8 @@ if(GAMMARAY_BUILD_UI)
     clientnetworkconfigurationmodel.cpp
     networkreplywidget.cpp
     clientnetworkreplymodel.cpp
+    networksupportinterface.cpp
+    networksupportclient.cpp
 
     cookies/cookietab.cpp
   )

--- a/plugins/network/CMakeLists.txt
+++ b/plugins/network/CMakeLists.txt
@@ -13,7 +13,7 @@ if (TARGET Qt5::Network)
     list(APPEND gammaray_network_srcs networkconfigurationmodel.cpp)
 endif()
 gammaray_add_plugin(gammaray_network JSON gammaray_network.json SOURCES ${gammaray_network_srcs})
-target_link_libraries(gammaray_network gammaray_core Qt::Network)
+target_link_libraries(gammaray_network gammaray_core Qt::Network Qt::CorePrivate)
 endif()
 
 # ui plugin

--- a/plugins/network/networkreplymodel.h
+++ b/plugins/network/networkreplymodel.h
@@ -90,12 +90,14 @@ private:
 
     void replyFinished(QNetworkReply *reply, QNetworkAccessManager *nam);
     void replyProgress(QNetworkReply *reply, qint64 progress, qint64 total, QNetworkAccessManager *nam);
+    void replyProgressSync(QNetworkReply *reply, qint64 progress, qint64 total, QNetworkAccessManager *nam);
 #ifndef QT_NO_SSL
     void replyEncrypted(QNetworkReply *reply, QNetworkAccessManager *nam);
     void replySslErrors(QNetworkReply *reply, const QList<QSslError> &errors, QNetworkAccessManager *nam);
 #endif
     void replyDeleted(QNetworkReply *reply, QNetworkAccessManager *nam);
 
+    void maybePeekResponse(ReplyNode &node, QNetworkReply *reply);
     Q_INVOKABLE void updateReplyNode(QNetworkAccessManager *nam, const GammaRay::NetworkReplyModel::ReplyNode &newNode);
 
     std::vector<NAMNode> m_nodes;

--- a/plugins/network/networkreplymodel.h
+++ b/plugins/network/networkreplymodel.h
@@ -49,6 +49,7 @@ namespace GammaRay
 class NetworkReplyModel : public QAbstractItemModel
 {
     Q_OBJECT
+    Q_PROPERTY(bool captureResponse READ captureResponse WRITE setCaptureResponse NOTIFY captureResponseChanged)
 public:
     explicit NetworkReplyModel(QObject *parent = nullptr);
     ~NetworkReplyModel();
@@ -69,9 +70,16 @@ public:
         QStringList errorMsgs;
         qint64 size = 0;
         quint64 duration = 0;
+        QByteArray response;
         QNetworkAccessManager::Operation op;
         int state = NetworkReply::Running;
     };
+
+    bool captureResponse() const { return m_captureResponse; }
+    void setCaptureResponse(bool newCaptureResponse);
+
+signals:
+    void captureResponseChanged();
 
 private:
     struct NAMNode {
@@ -92,8 +100,8 @@ private:
 
     std::vector<NAMNode> m_nodes;
     QElapsedTimer m_time;
+    bool m_captureResponse = false;
 };
-
 }
 
 #endif // GAMMARAY_NETWORKREPLYMODEL_H

--- a/plugins/network/networkreplymodeldefs.h
+++ b/plugins/network/networkreplymodeldefs.h
@@ -49,7 +49,8 @@ namespace NetworkReplyModelRole {
 enum Role {
     ReplyStateRole = GammaRay::UserRole,
     ReplyErrorRole,
-    ObjectIdRole
+    ObjectIdRole,
+    ReplyResponseRole
 };
 }
 

--- a/plugins/network/networkreplywidget.cpp
+++ b/plugins/network/networkreplywidget.cpp
@@ -89,6 +89,7 @@ NetworkReplyWidget::NetworkReplyWidget(QWidget* parent)
             ui->responseTextEdit->setPlainText(text);
         }
     });
+    ui->responseTextEdit->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     connect(ui->responseTextEdit, &QPlainTextEdit::textChanged, this, [this]() {
         ui->responseTextEdit->setVisible(!ui->responseTextEdit->toPlainText().isEmpty());
     });

--- a/plugins/network/networkreplywidget.ui
+++ b/plugins/network/networkreplywidget.ui
@@ -10,16 +10,43 @@
     <height>300</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QTreeView" name="replyView">
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="uniformRowHeights">
-      <bool>true</bool>
-     </property>
-    </widget>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QCheckBox" name="captureResponse">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Capture response body</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSplitter" name="splitter">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <widget class="QTreeView" name="replyView">
+        <property name="contextMenuPolicy">
+         <enum>Qt::CustomContextMenu</enum>
+        </property>
+        <property name="uniformRowHeights">
+         <bool>true</bool>
+        </property>
+       </widget>
+       <widget class="QPlainTextEdit" name="responseTextEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/plugins/network/networksupport.cpp
+++ b/plugins/network/networksupport.cpp
@@ -115,7 +115,7 @@ Q_DECLARE_METATYPE(QSslSocket::SslMode)
 #endif // QT_NO_SSL
 
 NetworkSupport::NetworkSupport(Probe *probe, QObject *parent)
-    : QObject(parent)
+    : NetworkSupportInterface(parent)
 {
     registerMetaTypes();
     registerVariantHandler();
@@ -130,6 +130,7 @@ NetworkSupport::NetworkSupport(Probe *probe, QObject *parent)
 #endif
 
     auto replyModel = new NetworkReplyModel(this);
+    connect(this, &NetworkSupportInterface::captureResponseChanged, replyModel, &NetworkReplyModel::setCaptureResponse);
     connect(probe, &Probe::objectCreated, replyModel, &NetworkReplyModel::objectCreated);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.NetworkReplyModel"), replyModel);
 

--- a/plugins/network/networksupportclient.cpp
+++ b/plugins/network/networksupportclient.cpp
@@ -1,0 +1,9 @@
+#include "networksupportclient.h"
+
+namespace GammaRay {
+NetworkSupportClient::NetworkSupportClient(QObject *parent) : NetworkSupportInterface(parent)
+{
+}
+
+NetworkSupportClient::~NetworkSupportClient() = default;
+}

--- a/plugins/network/networksupportclient.h
+++ b/plugins/network/networksupportclient.h
@@ -1,0 +1,45 @@
+/*
+ networksupportclient.h
+
+ This file is part of GammaRay, the Qt application inspection and
+ manipulation tool.
+
+ Copyright (C) 2019-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+ Author: Shantanu Tushar <shantanu.tushar@kdab.com>
+
+ Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+ accordance with GammaRay Commercial License Agreement provided with the Software.
+
+ Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GAMMARAY_NETWORKSUPPORTCLIENT_H
+#define GAMMARAY_NETWORKSUPPORTCLIENT_H
+
+#include "networksupportinterface.h"
+
+namespace GammaRay {
+class NetworkSupportClient : public NetworkSupportInterface
+{
+    Q_OBJECT
+    Q_INTERFACES(GammaRay::NetworkSupportInterface)
+public:
+    explicit NetworkSupportClient(QObject *parent = nullptr);
+    ~NetworkSupportClient() override;
+};
+}
+
+#endif // GAMMARAY_NETWORKSUPPORTCLIENT_H

--- a/plugins/network/networksupportinterface.cpp
+++ b/plugins/network/networksupportinterface.cpp
@@ -1,11 +1,11 @@
 /*
-  networksupport.h
+  networksupportinterface.cpp
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2016-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2019-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Shantanu Tushar <shantanu.tushar@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,35 +26,16 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_NETWORKSUPPORT_H
-#define GAMMARAY_NETWORKSUPPORT_H
-
 #include "networksupportinterface.h"
 
-#include <core/toolfactory.h>
+#include <common/objectbroker.h>
 
-namespace GammaRay {
-class NetworkSupport : public NetworkSupportInterface
+using namespace GammaRay;
+
+NetworkSupportInterface::NetworkSupportInterface(QObject *parent)
+    : QObject(parent)
 {
-    Q_OBJECT
-public:
-    explicit NetworkSupport(Probe *probe, QObject *parent = nullptr);
-    ~NetworkSupport() override;
-
-private:
-    void registerMetaTypes();
-    void registerVariantHandler();
-};
-
-class NetworkSupportFactory : public QObject, public StandardToolFactory<QObject, NetworkSupport>
-{
-    Q_OBJECT
-    Q_INTERFACES(GammaRay::ToolFactory)
-    Q_PLUGIN_METADATA(IID "com.kdab.GammaRay.ToolFactory" FILE "gammaray_network.json")
-
-public:
-    explicit NetworkSupportFactory(QObject *parent = nullptr);
-};
+    ObjectBroker::registerObject<NetworkSupportInterface *>(this);
 }
 
-#endif // GAMMARAY_NETWORKSUPPORT_H
+NetworkSupportInterface::~NetworkSupportInterface() = default;

--- a/plugins/network/networksupportinterface.h
+++ b/plugins/network/networksupportinterface.h
@@ -1,11 +1,11 @@
 /*
-  networksupport.h
+  networksupportinterface.h
 
   This file is part of GammaRay, the Qt application inspection and
   manipulation tool.
 
-  Copyright (C) 2016-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
-  Author: Volker Krause <volker.krause@kdab.com>
+  Copyright (C) 2019-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+  Author: Shantanu Tushar <shantanu.tushar@kdab.com>
 
   Licensees holding valid commercial KDAB GammaRay licenses may use this file in
   accordance with GammaRay Commercial License Agreement provided with the Software.
@@ -26,35 +26,30 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GAMMARAY_NETWORKSUPPORT_H
-#define GAMMARAY_NETWORKSUPPORT_H
+#ifndef GAMMARAY_NETWORKSUPPORTINTERFACE_H
+#define GAMMARAY_NETWORKSUPPORTINTERFACE_H
 
-#include "networksupportinterface.h"
-
-#include <core/toolfactory.h>
+#include <QObject>
 
 namespace GammaRay {
-class NetworkSupport : public NetworkSupportInterface
+class NetworkSupportInterface : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool captureResponse MEMBER m_captureResponse NOTIFY captureResponseChanged)
 public:
-    explicit NetworkSupport(Probe *probe, QObject *parent = nullptr);
-    ~NetworkSupport() override;
+    explicit NetworkSupportInterface(QObject *parent = nullptr);
+    ~NetworkSupportInterface() override;
+
+signals:
+    void captureResponseChanged(bool captureResponse);
 
 private:
-    void registerMetaTypes();
-    void registerVariantHandler();
-};
-
-class NetworkSupportFactory : public QObject, public StandardToolFactory<QObject, NetworkSupport>
-{
-    Q_OBJECT
-    Q_INTERFACES(GammaRay::ToolFactory)
-    Q_PLUGIN_METADATA(IID "com.kdab.GammaRay.ToolFactory" FILE "gammaray_network.json")
-
-public:
-    explicit NetworkSupportFactory(QObject *parent = nullptr);
+    bool m_captureResponse = false;
 };
 }
 
-#endif // GAMMARAY_NETWORKSUPPORT_H
+QT_BEGIN_NAMESPACE
+Q_DECLARE_INTERFACE(GammaRay::NetworkSupportInterface, "com.kdab.GammaRay.NetworkSupportInterface")
+QT_END_NAMESPACE
+
+#endif // GAMMARAY_NETWORKSUPPORTINTERFACE_H

--- a/plugins/network/networkwidget.ui
+++ b/plugins/network/networkwidget.ui
@@ -14,7 +14,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="interfaceTab">
       <attribute name="title">
@@ -42,7 +42,12 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="GammaRay::NetworkReplyWidget" name="widget_2" native="true"/>
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <widget class="GammaRay::NetworkReplyWidget" name="widget_2" native="true"/>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
The Network Operations tab now contains a checkbox that allows the user
to enable collection of the response body for network replies.

To begin with, we only only collect up to 5MiB of data. In the future we
might make this configurable, and maybe even allow the user to whitelist
to specific Content-Type values.