### PR TITLE
Fix build when using Qt < 5.15.0

### DIFF
--- a/plugins/network/networkreplywidget.cpp
+++ b/plugins/network/networkreplywidget.cpp
@@ -96,6 +96,9 @@ NetworkReplyWidget::NetworkReplyWidget(QWidget* parent)
     connect(ui->captureResponse, &QCheckBox::toggled, interface, [interface](bool checked) {
         interface->setProperty("captureResponse", checked);
     });
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    ui->captureResponse->setVisible(false);
+#endif
 }
 
 NetworkReplyWidget::~NetworkReplyWidget() = default;


### PR DESCRIPTION
The support for capturing network response fiddles with the signal-slot
connections in QNetworkReply. The private API for this is different in
older Qt versions and hence the prioritizeLatestConnection function will
need to be adapted for those.
For now, disable the feature on older versions so that GammaRay can
still build. The function will then be a no-op which is fine because we
also hide the feature in such versions.