### PR TITLE
Add support to export logging rules actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,6 @@
 
 cmake_minimum_required(VERSION 3.16.0)
 
-if(POLICY CMP0076)
-  cmake_policy(SET CMP0076 NEW)
-endif()
-
 project(GammaRay
   VERSION 2.99.50
   LANGUAGES CXX C

--- a/core/tools/messagehandler/loggingcategorymodel.h
+++ b/core/tools/messagehandler/loggingcategorymodel.h
@@ -43,6 +43,8 @@ public:
     explicit LoggingCategoryModel(QObject *parent = nullptr);
     ~LoggingCategoryModel() override;
 
+    Q_INVOKABLE QByteArray exportLoggingConfig(bool all, bool forFile);
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
@@ -51,9 +53,21 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
 
+Q_SIGNALS:
+    void addCategorySignal(QLoggingCategory *category);
+
 private:
+    void addCategorySlot(QLoggingCategory *category);
     void addCategory(QLoggingCategory *category);
-    QVector<QLoggingCategory *> m_categories;
+
+    struct CategoryWithDefaultValues {
+        QLoggingCategory *category;
+        bool wasDebugEnabled;
+        bool wasInfoEnabled;
+        bool wasWarningEnabled;
+        bool wasCriticalEnabled;
+    };
+    QVector<CategoryWithDefaultValues> m_categories;
     QLoggingCategory::CategoryFilter m_previousFilter;
 
     friend void categoryFilter(QLoggingCategory *);

--- a/ui/tools/messagehandler/messagehandlerwidget.h
+++ b/ui/tools/messagehandler/messagehandlerwidget.h
@@ -55,6 +55,10 @@ private slots:
     void copyToClipboard(const QString &message);
     void messageContextMenu(const QPoint &pos);
     void stackTraceContextMenu(QPoint pos);
+    void saveFileAllLogConfig();
+    void saveFileModLogConfig();
+    void saveFileLogConfig(bool all);
+    void exportModLogConfig();
 
 private:
     QScopedPointer<Ui::MessageHandlerWidget> ui;

--- a/ui/tools/messagehandler/messagehandlerwidget.ui
+++ b/ui/tools/messagehandler/messagehandlerwidget.ui
@@ -62,14 +62,48 @@
       <attribute name="title">
        <string>Categories</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="2" column="0" colspan="4">
         <widget class="GammaRay::DeferredTreeView" name="categoriesView">
          <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
          <property name="uniformRowHeights">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="saveAllConf">
+         <property name="text">
+          <string>Save All Logging Config</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QPushButton" name="saveModConf">
+         <property name="text">
+          <string>Save Modified Logging Config</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QPushButton" name="copyModConf">
+         <property name="text">
+          <string>Copy Modified Config for Env Var</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
 * Saves all registered categories to a file
 * Saves modified categories (best effort) to a file
 * File is in the QT_LOGGING_CONF/qtlogging.ini format
 * Copy to clipboard the modified categories as an env
   QT_LOGGING_RULES='rules..' variable

ISSUE: #651