### PR TITLE
Install doc: A couple of updates and a deletion

### DIFF
--- a/Install.txt
+++ b/Install.txt
@@ -19,9 +19,9 @@ installation:
 To build a debug version pass -DCMAKE_BUILD_TYPE=Debug to cmake.
 
 To build GammaRay you will need *at least*:
- - CMake 3.11.0
+ - CMake 3.16.0
  - a C++ compiler with C++11 support
- - Qt 5.5 or higher
+ - Qt 5.5 or higher, or Qt 6
 
 Optional FOSS packages (eg. KDSME, etc) provide extra functionality.
 See the "Optional Dependencies" section below for more details.

--- a/Install.txt
+++ b/Install.txt
@@ -130,19 +130,3 @@ You can therefore change this via the following CMake options:
 - CMAKE_INSTALL_RPATH=<path(s)> will add the specified absolute paths to RPATH,
   additionally to the relative RPATHs between GammaRay's components.
 
-== Warning! (Qt <= 5.4 only) ==
-If your Qt is linked with the "-Bsymbolic-function" option preloading will be
-broken.  When this is enabled, references to global functions will be bound to
-the shared object internally; therefore, the definition of the function will be
-fixed and cannot be overwritten by preloading.
-
-So, be sure that your distro-provided packages or your self-compiled packages
-are not linked with this flag (check with `echo $LDFLAGS` before compiling).
-For more info see: "man ld; search for "-Bsymbolic-function".
-
-Known affected distros:
-
-    Ubuntu 10.10, 11.04
-
-If you are affected by this, try the gdb injector instead by using the "-i gdb"
-command line argument.


### PR DESCRIPTION
This PR changes the `Install.txt` file (in separate commits) by:

1. Updating two dependencies:
        * The minimum required CMake version is explicitly listed as 3.16.0, to match the `cmake_minimum_version()` call at the top of the `CMakeLists.txt`.
        * Qt 6 support (while arguably implicit in "Qt 5.5 or higher") is made explicit
1. Removing the section at the end of the file that applied to "Qt <= 5.4 only", because 5.5 is the minimum version.