### PR TITLE
Guard current texture with smart QPointer

### DIFF
--- a/plugins/quickinspector/textureextension/textureextension.h
+++ b/plugins/quickinspector/textureextension/textureextension.h
@@ -32,6 +32,7 @@
 #include <core/propertycontrollerextension.h>
 
 #include <QObject>
+#include <QPointer>
 
 QT_BEGIN_NAMESPACE
 class QImage;
@@ -61,7 +62,7 @@ private:
     bool ensureSetup();
     void triggerGrab();
 
-    QSGTexture *m_currentTexture;
+    QPointer<QSGTexture> m_currentTexture;
     QSGDistanceFieldTextMaterial *m_currentMaterial;
     RemoteViewServer *m_remoteView;
     bool m_connected;


### PR DESCRIPTION
Hotfixes a scenario where a change of texture objects in a Texture view
could crash the GammaRay injector.

Smart QPointer to a QSGTexture is what a QSGTextureGrabber already uses,
which seems to work fine for it.

I noticed that it does not update textures in real-time as an inspected
button itself changes on a screen; but at least we don't segfault on it
anymore either.

Closes: #678