### PR TITLE
WidgetInspector: Auto expand the tree on filtering

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,6 @@
 Diagnostics:
   ClangTidy:
-    Remove: [modernize*, readability-function-*, readability-magic-numbers, readability-qualified-auto, llvm-qualified-auto, misc-non-private-member-variables-in-classes, cppcoreguidelines-pro-type-reinterpret-cast, llvmlibc-*, altera-*, readability-redundant-access-specifiers, readability-redundant-member-init, performance-no-int-to-ptr]
+    Remove: [modernize*, readability-function-*, readability-magic-numbers, readability-qualified-auto, llvm-qualified-auto, misc-non-private-member-variables-in-classes, cppcoreguidelines-pro-type-reinterpret-cast, llvmlibc-*, altera-*, readability-redundant-access-specifiers, readability-redundant-member-init, performance-no-int-to-ptr, misc-no-recursion]
 CompileFlags:
   Add: -Wno-gnu-zero-variadic-macro-arguments
   Remove: -Wgnu-zero-variadic-macro-arguments

--- a/plugins/quickinspector/quickinspectorwidget.cpp
+++ b/plugins/quickinspector/quickinspectorwidget.cpp
@@ -113,7 +113,7 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
     ui->itemTreeView->setDeferredResizeMode(0, QHeaderView::ResizeToContents);
     ui->itemTreeView->setModel(proxy);
     ui->itemTreeView->setItemDelegate(new QuickItemDelegate(ui->itemTreeView));
-    new SearchLineController(ui->itemTreeSearchLine, proxy);
+    new SearchLineController(ui->itemTreeSearchLine, proxy, ui->itemTreeView);
     QItemSelectionModel *selectionModel = ObjectBroker::selectionModel(proxy);
     ui->itemTreeView->setSelectionModel(selectionModel);
     connect(selectionModel, &QItemSelectionModel::selectionChanged,
@@ -127,7 +127,7 @@ QuickInspectorWidget::QuickInspectorWidget(QWidget *parent)
     ui->sgTreeView->header()->setObjectName("sceneGraphTreeViewHeader");
     ui->sgTreeView->setDeferredResizeMode(0, QHeaderView::ResizeToContents);
     ui->sgTreeView->setModel(clientSceneGraphModel);
-    new SearchLineController(ui->sgTreeSearchLine, clientSceneGraphModel);
+    new SearchLineController(ui->sgTreeSearchLine, clientSceneGraphModel, ui->sgTreeView);
     QItemSelectionModel *sgSelectionModel = ObjectBroker::selectionModel(clientSceneGraphModel);
     ui->sgTreeView->setSelectionModel(sgSelectionModel);
     connect(sgSelectionModel, &QItemSelectionModel::selectionChanged,

--- a/plugins/widgetinspector/widgetinspectorwidget.cpp
+++ b/plugins/widgetinspector/widgetinspectorwidget.cpp
@@ -44,6 +44,7 @@
 
 #include "common/objectbroker.h"
 #include "common/objectmodel.h"
+#include "common/remotemodelroles.h"
 
 #include <ui/contextmenuextension.h>
 #include <ui/paintbufferviewer.h>
@@ -61,6 +62,7 @@
 #include <QSettings>
 #include <QLayout>
 #include <QTabBar>
+#include <QTimer>
 
 using namespace GammaRay;
 
@@ -92,7 +94,7 @@ WidgetInspectorWidget::WidgetInspectorWidget(QWidget *parent)
     ui->widgetTreeView->setDeferredResizeMode(1, QHeaderView::Interactive);
     ui->widgetTreeView->setModel(widgetModel);
     ui->widgetTreeView->setSelectionModel(ObjectBroker::selectionModel(widgetModel));
-    new SearchLineController(ui->widgetSearchLine, widgetModel);
+    new SearchLineController(ui->widgetSearchLine, widgetModel, ui->widgetTreeView);
     connect(ui->widgetTreeView->selectionModel(),
             &QItemSelectionModel::selectionChanged,
             this, &WidgetInspectorWidget::widgetSelected);
@@ -186,6 +188,7 @@ void WidgetInspectorWidget::restoreTargetState(QSettings *settings)
     m_remoteView->restoreState(settings->value("remoteViewState").toByteArray());
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void WidgetInspectorWidget::onTabChanged(int index)
 {
 #ifdef GAMMARAY_WITH_WIDGET3D

--- a/ui/searchlinecontroller.h
+++ b/ui/searchlinecontroller.h
@@ -37,6 +37,8 @@
 
 QT_BEGIN_NAMESPACE
 class QLineEdit;
+class QTimer;
+class QTreeView;
 QT_END_NAMESPACE
 
 namespace GammaRay {
@@ -45,21 +47,30 @@ namespace GammaRay {
  * implementing QSFPM like properties (ie, filterKeyColumn, filterCaseSensitivity etc...).
  * If the given proxy is not a QSFPM api-like model, a check is performed recursively in all
  * sourceModel until a compatible QSFPM api-like one is found.
+ *
+ * If a treeView is provided, then the controller tries to auto expand the tree to reveal
+ * matching indexes
 */
 class GAMMARAY_UI_EXPORT SearchLineController : public QObject
 {
     Q_OBJECT
 public:
     /** Establish a connection between @p lineEdit and @p proxyModel. */
-    explicit SearchLineController(QLineEdit *lineEdit, QAbstractItemModel *proxyModel);
+    explicit SearchLineController(QLineEdit *lineEdit, QAbstractItemModel *proxyModel, QTreeView *treeView = nullptr);
     ~SearchLineController() override;
 
 private slots:
     void activateSearch();
+    void onSearchFinished(const QString &searchTerm);
 
 private:
+    void expandRecursively(const QModelIndex &);
+
     QLineEdit *m_lineEdit;
     QPointer<QAbstractItemModel> m_filterModel;
+    QPointer<QTreeView> m_targetTreeView;
+    QTimer *m_delayedExpandTimer = nullptr;
+    QVector<QPersistentModelIndex> m_delayedIdxesToExpand;
 };
 }
 

--- a/ui/tools/objectinspector/objectinspectorwidget.cpp
+++ b/ui/tools/objectinspector/objectinspectorwidget.cpp
@@ -60,7 +60,7 @@ ObjectInspectorWidget::ObjectInspectorWidget(QWidget *parent)
     ui->objectTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->objectTreeView->setDeferredResizeMode(0, QHeaderView::Stretch);
     ui->objectTreeView->setDeferredResizeMode(1, QHeaderView::Interactive);
-    new SearchLineController(ui->objectSearchLine, clientModel);
+    new SearchLineController(ui->objectSearchLine, clientModel, ui->objectTreeView);
 
     QItemSelectionModel *selectionModel = ObjectBroker::selectionModel(ui->objectTreeView->model());
     ui->objectTreeView->setSelectionModel(selectionModel);


### PR DESCRIPTION
When you are filtering for a particular widget, Gammaray doesn't expand
the tree for you. This can be really annoying when you have long object
hierarchies as you need to manually expand each node to get to the item
you want. To fix this, auto expand the tree after filtering.