### PR TITLE
Fix a lot of clang-tidy readibility warnings

### DIFF
--- a/client/clientconnectionmanager.h
+++ b/client/clientconnectionmanager.h
@@ -69,7 +69,7 @@ public:
     void connectToHost(const QUrl &url, int tryAgain = 0);
 
     /*! Manually show the splash screen. */
-    void showSplashScreen();
+    static void showSplashScreen();
 
     GammaRay::ProcessTrackerBackend *processTrackerBackend() const;
     void setProcessTrackerBackend(GammaRay::ProcessTrackerBackend *backend);
@@ -124,7 +124,7 @@ private slots:
     void transientConnectionError();
 
     void delayedHideSplashScreen();
-    void hideSplashScreen();
+    static void hideSplashScreen();
     void targetQuitRequested();
 
     void updateProcessTrackerState();

--- a/client/processtracker.cpp
+++ b/client/processtracker.cpp
@@ -57,7 +57,7 @@ public:
     }
 
 public slots:
-    void requestUpdate()
+    void requestUpdate() const
     {
         if (!backend) {
             qWarning("%s: Backend not set", Q_FUNC_INFO);

--- a/client/remotemodel.cpp
+++ b/client/remotemodel.cpp
@@ -637,7 +637,8 @@ void RemoteModel::newMessage(const GammaRay::Message &msg)
                     // parent already there, no need to add
                     skip = true;
                     break;
-                } else if (isAncestor(node, n)) {
+                }
+                if (isAncestor(node, n)) {
                     // Remove childs
                     childsOfNode.push_back(n);
                 }

--- a/client/remotemodel.cpp
+++ b/client/remotemodel.cpp
@@ -738,7 +738,7 @@ bool RemoteModel::isAncestor(RemoteModel::Node *ancestor, RemoteModel::Node *chi
     return isAncestor(ancestor, child->parent);
 }
 
-RemoteModelNodeState::NodeStates RemoteModel::stateForColumn(RemoteModel::Node *node, int columnIndex) const
+RemoteModelNodeState::NodeStates RemoteModel::stateForColumn(RemoteModel::Node *node, int columnIndex) 
 {
     Q_ASSERT(node);
     if (!node->hasColumnData())

--- a/client/remotemodel.h
+++ b/client/remotemodel.h
@@ -135,7 +135,7 @@ private:
     /** Checks if @p ancestor is a (grand)parent of @p child. */
     bool isAncestor(Node *ancestor, Node *child) const;
 
-    RemoteModelNodeState::NodeStates stateForColumn(Node *node, int columnIndex) const;
+    static RemoteModelNodeState::NodeStates stateForColumn(Node *node, int columnIndex) ;
 
     void requestRowColumnCount(const QModelIndex &index) const;
     void requestDataAndFlags(const QModelIndex &index) const;

--- a/common/endpoint.cpp
+++ b/common/endpoint.cpp
@@ -233,7 +233,7 @@ void Endpoint::invokeObject(const QString &objectName, const char *method,
 }
 
 void Endpoint::invokeObjectLocal(QObject *object, const char *method,
-                                 const QVariantList &args) const
+                                 const QVariantList &args) 
 {
     Q_ASSERT(args.size() <= 10);
     QVector<MethodArgument> a(10);

--- a/common/endpoint.h
+++ b/common/endpoint.h
@@ -211,7 +211,7 @@ protected:
      *
      * This is invokes the method directly on the local object.
      */
-    void invokeObjectLocal(QObject *object, const char *method, const QVariantList &args) const;
+    static void invokeObjectLocal(QObject *object, const char *method, const QVariantList &args) ;
 
     PropertySyncer *m_propertySyncer;
     ///@endcond

--- a/common/networkselectionmodel.cpp
+++ b/common/networkselectionmodel.cpp
@@ -66,7 +66,7 @@ static QAbstractItemModel *findSourceModel(QAbstractItemModel *model)
         if (model->metaObject()->indexOfMethod(QMetaObject::normalizedSignature(
                                                    "defaultSelectedItem()")) != -1)
             return model;
-        else if (auto proxy = qobject_cast<QAbstractProxyModel *>(model))
+        if (auto proxy = qobject_cast<QAbstractProxyModel *>(model))
             return findSourceModel(proxy->sourceModel());
     }
 

--- a/common/pluginmanager.cpp
+++ b/common/pluginmanager.cpp
@@ -50,7 +50,7 @@ PluginManagerBase::PluginManagerBase(QObject *parent)
 
 PluginManagerBase::~PluginManagerBase() = default;
 
-QStringList PluginManagerBase::pluginPaths() const
+QStringList PluginManagerBase::pluginPaths() 
 {
 #ifndef GAMMARAY_STATIC_PROBE
     return Paths::pluginPaths(GAMMARAY_PROBE_ABI);
@@ -59,7 +59,7 @@ QStringList PluginManagerBase::pluginPaths() const
 #endif
 }
 
-QStringList PluginManagerBase::pluginFilter() const
+QStringList PluginManagerBase::pluginFilter() 
 {
     QStringList filter;
 #if defined(GAMMARAY_INSTALL_QT_LAYOUT)

--- a/common/pluginmanager.h
+++ b/common/pluginmanager.h
@@ -81,8 +81,8 @@ protected:
     virtual bool createProxyFactory(const PluginInfo &pluginInfo, QObject *parent) = 0;
 
     void scan(const QString &serviceType);
-    QStringList pluginPaths() const;
-    QStringList pluginFilter() const;
+    static QStringList pluginPaths() ;
+    static QStringList pluginFilter() ;
 
     QList<PluginLoadError> m_errors;
     QObject *m_parent;

--- a/common/translator.cpp
+++ b/common/translator.cpp
@@ -64,15 +64,15 @@ void Translator::loadTranslations(const QString &catalog, const QString &path, c
         if (translator->load(uiLocale, catalog, QStringLiteral("_"), path)) {
             QCoreApplication::instance()->installTranslator(translator);
             return;
-        } else {
-            delete translator;
+        }
 
-            foreach (const QString &name, uiLocale.uiLanguages()) {
-                const QString fileName = QString("%1_%2.qm").arg(catalog, name);
-                const QString filePath = dir.filePath(fileName);
-                if (QFile::exists(filePath)) {
-                    return;
-                }
+        delete translator;
+
+        foreach (const QString &name, uiLocale.uiLanguages()) {
+            const QString fileName = QString("%1_%2.qm").arg(catalog, name);
+            const QString filePath = dir.filePath(fileName);
+            if (QFile::exists(filePath)) {
+                return;
             }
         }
     }

--- a/core/aggregatedpropertymodel.cpp
+++ b/core/aggregatedpropertymodel.cpp
@@ -170,7 +170,7 @@ QMap<int, QVariant> AggregatedPropertyModel::itemData(const QModelIndex &index) 
 }
 
 QVariant AggregatedPropertyModel::data(PropertyAdaptor *adaptor, const PropertyData &d, int column,
-                                       int role) const
+                                       int role) 
 {
     switch (role) {
     case Qt::DisplayRole:
@@ -451,7 +451,7 @@ void AggregatedPropertyModel::objectInvalidated(PropertyAdaptor *adaptor)
     reloadSubTree(parentAdaptor, m_parentChildrenMap.value(parentAdaptor).indexOf(adaptor));
 }
 
-bool AggregatedPropertyModel::hasLoop(PropertyAdaptor *adaptor, const QVariant &v) const
+bool AggregatedPropertyModel::hasLoop(PropertyAdaptor *adaptor, const QVariant &v) 
 {
     const ObjectInstance newOi(v);
     if (newOi.type() != ObjectInstance::QtObject && newOi.type() != ObjectInstance::Object)

--- a/core/aggregatedpropertymodel.h
+++ b/core/aggregatedpropertymodel.h
@@ -66,8 +66,8 @@ private:
     void clear();
     PropertyAdaptor *adaptorForIndex(const QModelIndex &index) const;
     void addPropertyAdaptor(PropertyAdaptor *adaptor) const;
-    QVariant data(PropertyAdaptor *adaptor, const PropertyData &d, int column, int role) const;
-    bool hasLoop(PropertyAdaptor *adaptor, const QVariant &v) const;
+    static QVariant data(PropertyAdaptor *adaptor, const PropertyData &d, int column, int role) ;
+    static bool hasLoop(PropertyAdaptor *adaptor, const QVariant &v) ;
     void reloadSubTree(PropertyAdaptor *parentAdaptor, int index);
     bool isParentEditable(PropertyAdaptor *adaptor) const;
     void propagateWrite(PropertyAdaptor *adaptor);

--- a/core/jsonpropertyadaptor.cpp
+++ b/core/jsonpropertyadaptor.cpp
@@ -60,9 +60,8 @@ int JsonPropertyAdaptor::count() const
 {
     if (m_isObject) {
         return m_object.size();
-    } else {
-        return m_array.size();
     }
+    return m_array.size();
 }
 
 PropertyData JsonPropertyAdaptor::propertyData(int index) const

--- a/core/metaobjectrepository.h
+++ b/core/metaobjectrepository.h
@@ -100,9 +100,9 @@ protected:
 private:
     Q_DISABLE_COPY(MetaObjectRepository)
     void initBuiltInTypes();
-    void initQObjectTypes();
-    void initIOTypes();
-    void initQEventTypes();
+    static void initQObjectTypes();
+    static void initIOTypes();
+    static void initQEventTypes();
 
 private:
     QHash<QString, MetaObject*> m_metaObjects;

--- a/core/multisignalmapper.cpp
+++ b/core/multisignalmapper.cpp
@@ -57,7 +57,7 @@ public:
         return methodId;
     }
 
-    QVector<QVariant> convertArguments(QObject *sender, int signalIndex, void **args)
+    static QVector<QVariant> convertArguments(QObject *sender, int signalIndex, void **args)
     {
         Q_ASSERT(sender);
         Q_ASSERT(signalIndex >= 0);

--- a/core/objectlistmodel.cpp
+++ b/core/objectlistmodel.cpp
@@ -48,7 +48,7 @@ ObjectListModel::ObjectListModel(Probe *probe)
             this, &ObjectListModel::objectRemoved);
 }
 
-QPair<int, QVariant> ObjectListModel::defaultSelectedItem() const
+QPair<int, QVariant> ObjectListModel::defaultSelectedItem() 
 {
     // select the qApp object (if any) in the object model
     return QPair<int, QVariant>(ObjectModel::ObjectRole, QVariant::fromValue<QObject *>(qApp));

--- a/core/objectlistmodel.h
+++ b/core/objectlistmodel.h
@@ -58,7 +58,7 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
-    Q_INVOKABLE QPair<int, QVariant> defaultSelectedItem() const;
+    Q_INVOKABLE static QPair<int, QVariant> defaultSelectedItem() ;
 
     /*!
      * Returns a list of all objects.

--- a/core/objecttreemodel.cpp
+++ b/core/objecttreemodel.cpp
@@ -213,11 +213,11 @@ QVariant ObjectTreeModel::data(const QModelIndex &index, int role) const
     QMutexLocker lock(Probe::objectLock());
     if (Probe::instance()->isValidObject(obj)) {
         return dataForObject(obj, index, role);
-    } else if (role == Qt::DisplayRole) {
+    }
+    if (role == Qt::DisplayRole) {
         if (index.column() == 0)
             return Util::addressToString(obj);
-        else
-            return tr("<deleted>");
+        return tr("<deleted>");
     }
 
     return QVariant();

--- a/core/objecttreemodel.cpp
+++ b/core/objecttreemodel.cpp
@@ -56,7 +56,7 @@ ObjectTreeModel::ObjectTreeModel(Probe *probe)
             this, &ObjectTreeModel::objectReparented);
 }
 
-QPair<int, QVariant> ObjectTreeModel::defaultSelectedItem() const
+QPair<int, QVariant> ObjectTreeModel::defaultSelectedItem() 
 {
     // select the qApp object (if any) in the object model
     return QPair<int, QVariant>(ObjectModel::ObjectRole, QVariant::fromValue<QObject *>(qApp));

--- a/core/objecttreemodel.h
+++ b/core/objecttreemodel.h
@@ -48,7 +48,7 @@ public:
     QModelIndex index(int row, int column,
                       const QModelIndex &parent = QModelIndex()) const override;
 
-    Q_INVOKABLE QPair<int, QVariant> defaultSelectedItem() const;
+    Q_INVOKABLE static QPair<int, QVariant> defaultSelectedItem() ;
 
 private slots:
     void objectAdded(QObject *obj);

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -928,12 +928,12 @@ void Probe::installGlobalEventFilter(QObject *filter)
     m_globalEventFilters.push_back(filter);
 }
 
-bool Probe::needsObjectDiscovery() const
+bool Probe::needsObjectDiscovery() 
 {
     return s_listener()->trackDestroyed;
 }
 
-bool Probe::hasReliableObjectTracking() const
+bool Probe::hasReliableObjectTracking() 
 {
     return true; // qHooks available, which works independent of the injector used
 }
@@ -1003,7 +1003,7 @@ void Probe::executeSignalCallback(const Func &func)
                   func);
 }
 
-SourceLocation Probe::objectCreationSourceLocation(QObject *object) const
+SourceLocation Probe::objectCreationSourceLocation(QObject *object) 
 {
   if (!s_listener()->constructionBacktracesForObjects.contains(object)) {
     IF_DEBUG(std::cout << "No backtrace for object available" << object << "." << std::endl;)
@@ -1023,7 +1023,7 @@ SourceLocation Probe::objectCreationSourceLocation(QObject *object) const
   return frame.location;
 }
 
-Execution::Trace Probe::objectCreationStackTrace(QObject *object) const
+Execution::Trace Probe::objectCreationStackTrace(QObject *object) 
 {
     return s_listener()->constructionBacktracesForObjects.value(object);
 }

--- a/core/probe.h
+++ b/core/probe.h
@@ -123,7 +123,7 @@ public:
      * @param objectName Unique identifier for the model, typically in reverse domain notation.
      * @param model The model to register.
      */
-    void registerModel(const QString &objectName, QAbstractItemModel *model);
+    static void registerModel(const QString &objectName, QAbstractItemModel *model);
     /*!
      * Install a global event filter.
      * Use this rather than installing the filter manually on QCoreApplication,
@@ -143,7 +143,7 @@ public:
      *
      * @since 2.5
      */
-    bool needsObjectDiscovery() const;
+    static bool needsObjectDiscovery() ;
     /*!
      * Notify the probe about QObjects your plug-in can discover by using information about
      * the types it can handle.
@@ -178,9 +178,9 @@ public:
     void registerSignalSpyCallbackSet(const SignalSpyCallbackSet &callbacks);
 
     /*! Returns the source code location @p object was created at. */
-    SourceLocation objectCreationSourceLocation(QObject *object) const;
+    static SourceLocation objectCreationSourceLocation(QObject *object) ;
     /*! Returns the entire stack trace for the creation of @p object. */
-    Execution::Trace objectCreationStackTrace(QObject *object) const;
+    static Execution::Trace objectCreationStackTrace(QObject *object) ;
 
     ///@cond internal
     QObject *window() const;
@@ -278,7 +278,7 @@ private slots:
     void shutdown();
 
     void processQueuedObjectChanges();
-    void handleObjectDestroyed(QObject *obj);
+    static void handleObjectDestroyed(QObject *obj);
 
 private:
     friend class ProbeCreator;
@@ -288,7 +288,7 @@ private:
      * about every QObject creation/destruction.
      * @since 2.0
      */
-    QT_DEPRECATED bool hasReliableObjectTracking() const;
+    static QT_DEPRECATED bool hasReliableObjectTracking() ;
 
     void objectFullyConstructed(QObject *obj);
 
@@ -302,7 +302,7 @@ private:
 
     /*! Check if we are capable of showing widgets. */
     static bool canShowWidgets();
-    void showInProcessUi();
+    static void showInProcessUi();
 
     static void createProbe(bool findExisting);
     void resendServerAddress();

--- a/core/probeguard.h
+++ b/core/probeguard.h
@@ -53,7 +53,7 @@ public:
     static bool insideProbe();
 protected:
     ProbeGuard(bool newState);
-    void setInsideProbe(bool inside);
+    static void setInsideProbe(bool inside);
 private:
     Q_DISABLE_COPY(ProbeGuard)
     bool m_previousState;

--- a/core/probesettings.cpp
+++ b/core/probesettings.cpp
@@ -77,7 +77,7 @@ private slots:
 
 private:
     Q_INVOKABLE void run();
-    void setRootPathFromProbePath(const QString &probePath);
+    static void setRootPathFromProbePath(const QString &probePath);
     QLocalSocket *m_socket = nullptr;
     QWaitCondition m_waitCondition;
     QMutex m_mutex;

--- a/core/propertyaggregator.cpp
+++ b/core/propertyaggregator.cpp
@@ -163,9 +163,8 @@ void PropertyAggregator::slotPropertyChanged(int first, int last)
         if (pa == source) {
             emit propertyChanged(first + offset, last + offset);
             return;
-        } else {
-            offset += pa->count();
         }
+        offset += pa->count();
     }
 }
 
@@ -179,9 +178,8 @@ void PropertyAggregator::slotPropertyAdded(int first, int last)
         if (pa == source) {
             emit propertyAdded(first + offset, last + offset);
             return;
-        } else {
-            offset += pa->count();
         }
+        offset += pa->count();
     }
 }
 
@@ -195,8 +193,7 @@ void PropertyAggregator::slotPropertyRemoved(int first, int last)
         if (pa == source) {
             emit propertyRemoved(first + offset, last + offset);
             return;
-        } else {
-            offset += pa->count();
         }
+        offset += pa->count();
     }
 }

--- a/core/tools/messagehandler/messagehandler.h
+++ b/core/tools/messagehandler/messagehandler.h
@@ -57,7 +57,7 @@ public slots:
     void generateFullTrace() override;
 
 private slots:
-    void ensureHandlerInstalled();
+    static void ensureHandlerInstalled();
     void handleFatalMessage(const GammaRay::DebugMessage &message);
     void messageSelected(const QItemSelection &selection);
 

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.h
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.h
@@ -48,7 +48,7 @@ public:
     explicit MetaObjectBrowser(Probe *probe, QObject *parent = nullptr);
 
 public Q_SLOTS:
-    void rescanMetaTypes();
+    static void rescanMetaTypes();
 
 private Q_SLOTS:
     void objectSelectionChanged(const QItemSelection &selection);

--- a/core/tools/metaobjectbrowser/metaobjecttreemodel.cpp
+++ b/core/tools/metaobjectbrowser/metaobjecttreemodel.cpp
@@ -189,7 +189,7 @@ QModelIndex MetaObjectTreeModel::indexForMetaObject(const QMetaObject *metaObjec
     return index(row, 0, parentIndex);
 }
 
-const QMetaObject *MetaObjectTreeModel::metaObjectForIndex(const QModelIndex &index) const
+const QMetaObject *MetaObjectTreeModel::metaObjectForIndex(const QModelIndex &index) 
 {
     if (!index.isValid())
         return nullptr;

--- a/core/tools/metaobjectbrowser/metaobjecttreemodel.h
+++ b/core/tools/metaobjectbrowser/metaobjecttreemodel.h
@@ -64,7 +64,7 @@ public:
 
 private:
     QModelIndex indexForMetaObject(const QMetaObject *metaObject) const;
-    const QMetaObject *metaObjectForIndex(const QModelIndex &index) const;
+    static const QMetaObject *metaObjectForIndex(const QModelIndex &index) ;
 
 
 private slots:

--- a/core/tools/objectinspector/objectinspector.h
+++ b/core/tools/objectinspector/objectinspector.h
@@ -54,7 +54,7 @@ private slots:
     void objectSelected(QObject *object);
 
 private:
-    void registerPCExtensions();
+    static void registerPCExtensions();
 
     static void scanForConnectionIssues();
     static void scanForThreadAffinityIssues();

--- a/core/tools/objectinspector/outboundconnectionsmodel.cpp
+++ b/core/tools/objectinspector/outboundconnectionsmodel.cpp
@@ -85,7 +85,7 @@ QVector<AbstractConnectionsModel::Connection> OutboundConnectionsModel::outbound
             if (c->isSlotObject)
                 conn.slotIndex = -1;
             else
-            conn.slotIndex = c->method();
+                conn.slotIndex = c->method();
             conn.type = c->connectionType;
             c = c->nextConnectionList;
             connections.push_back(conn);

--- a/launcher/core/injector/debuggerinjector.h
+++ b/launcher/core/injector/debuggerinjector.h
@@ -106,7 +106,7 @@ private:
         Out
     };
 
-    void processLog(DebuggerInjector::Orientation orientation, bool isError, const QString &text);
+    static void processLog(DebuggerInjector::Orientation orientation, bool isError, const QString &text);
 };
 }
 

--- a/launcher/core/injector/injectorstyleplugin.cpp
+++ b/launcher/core/injector/injectorstyleplugin.cpp
@@ -50,7 +50,7 @@ QStyle *InjectorStylePlugin::create(const QString &)
     return nullptr;
 }
 
-QStringList InjectorStylePlugin::keys() const
+QStringList InjectorStylePlugin::keys() 
 {
     return QStringList() << QStringLiteral("gammaray-injector");
 }

--- a/launcher/core/injector/injectorstyleplugin.h
+++ b/launcher/core/injector/injectorstyleplugin.h
@@ -38,10 +38,10 @@ class InjectorStylePlugin : public QStylePlugin
     Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QStyleFactoryInterface" FILE "injectorstyle.json")
 public:
     QStyle *create(const QString &) override;
-    QStringList keys() const;
+    static QStringList keys() ;
 
 private:
-    void inject();
+    static void inject();
 };
 }
 

--- a/launcher/core/networkdiscoverymodel.cpp
+++ b/launcher/core/networkdiscoverymodel.cpp
@@ -41,7 +41,7 @@
 
 using namespace GammaRay;
 
-bool NetworkDiscoveryModel::ServerInfo::operator==(const NetworkDiscoveryModel::ServerInfo &other)
+bool NetworkDiscoveryModel::ServerInfo::operator==(const NetworkDiscoveryModel::ServerInfo &other) const
 {
     return url == other.url;
 }

--- a/launcher/core/networkdiscoverymodel.h
+++ b/launcher/core/networkdiscoverymodel.h
@@ -70,7 +70,7 @@ private:
     QUdpSocket *m_socket;
 
     struct ServerInfo {
-        bool operator==(const ServerInfo &other);
+        bool operator==(const ServerInfo &other) const;
         qint32 version;
         QUrl url;
         QString label;

--- a/launcher/core/probeabi.cpp
+++ b/launcher/core/probeabi.cpp
@@ -138,7 +138,7 @@ void ProbeABI::setIsDebug(bool debug)
     d->isDebug = debug;
 }
 
-bool ProbeABI::isDebugRelevant() const
+bool ProbeABI::isDebugRelevant() 
 {
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
     return true;

--- a/launcher/core/probeabi.h
+++ b/launcher/core/probeabi.h
@@ -63,7 +63,7 @@ public:
     bool isDebug() const;
     void setIsDebug(bool debug);
     /*! Returns @c true if debug vs. release is changing the ABI. */
-    bool isDebugRelevant() const;
+    static bool isDebugRelevant() ;
 
     /*! Compiler ABI is currently only relevant for MSVC vs. Mingw. */
     QString compiler() const;

--- a/launcher/core/probeabidetector.cpp
+++ b/launcher/core/probeabidetector.cpp
@@ -63,7 +63,7 @@ ProbeABI ProbeABIDetector::abiForQtCore(const QString &path) const
     return abi;
 }
 
-QString ProbeABIDetector::qtCoreFromLsof(qint64 pid) const
+QString ProbeABIDetector::qtCoreFromLsof(qint64 pid) 
 {
     QString lsofExe;
     lsofExe = QStandardPaths::findExecutable(QStringLiteral("lsof"));

--- a/launcher/core/probeabidetector.h
+++ b/launcher/core/probeabidetector.h
@@ -52,7 +52,7 @@ public:
     ProbeABI abiForProcess(qint64 pid) const;
 
     /*! Returns the full path to QtCore used by the given executable. */
-    QString qtCoreForExecutable(const QString &path) const;
+    static QString qtCoreForExecutable(const QString &path) ;
 
     /*! Returns the full path to QtCore used by the process with PID @p pid. */
     QString qtCoreForProcess(quint64 pid) const;
@@ -73,12 +73,12 @@ private:
     /*! Detect the ABI of the given QtCore DLL.
      *  This needs to be implemented for every platform.
      */
-    ProbeABI detectAbiForQtCore(const QString &path) const;
+    static ProbeABI detectAbiForQtCore(const QString &path) ;
 
     /*! Path to the QtCore DLL for @p pid, using the lsof tool
      *  on UNIX-like systems.
      */
-    QString qtCoreFromLsof(qint64 pid) const;
+    static QString qtCoreFromLsof(qint64 pid) ;
 
     mutable QHash<QString, ProbeABI> m_abiForQtCoreCache;
 };

--- a/launcher/core/probeabidetector_dummy.cpp
+++ b/launcher/core/probeabidetector_dummy.cpp
@@ -35,7 +35,7 @@
 
 using namespace GammaRay;
 
-QString ProbeABIDetector::qtCoreForExecutable(const QString &path) const
+QString ProbeABIDetector::qtCoreForExecutable(const QString &path)
 {
     Q_UNUSED(path);
     return QString();
@@ -47,7 +47,7 @@ QString ProbeABIDetector::qtCoreForProcess(quint64 pid) const
     return QString();
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path) const
+ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     Q_UNUSED(path);
     return ProbeABI::fromString(GAMMARAY_PROBE_ABI);

--- a/launcher/core/probeabidetector_elf.cpp
+++ b/launcher/core/probeabidetector_elf.cpp
@@ -59,7 +59,7 @@ static QString qtCoreFromLdd(const QString &path)
     return QString();
 }
 
-QString ProbeABIDetector::qtCoreForExecutable(const QString &path) const
+QString ProbeABIDetector::qtCoreForExecutable(const QString &path) 
 {
     // TODO: add fast version reading the ELF file directly?
     return qtCoreFromLdd(path);
@@ -187,7 +187,7 @@ static QString archFromELF(const QString &path)
     return QString();
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path) const
+ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path) 
 {
     if (path.isEmpty())
         return ProbeABI();

--- a/launcher/core/probeabidetector_mac.cpp
+++ b/launcher/core/probeabidetector_mac.cpp
@@ -156,7 +156,7 @@ static QString resolveRPath(const QString &path, const QStringList &rpaths)
     return path;
 }
 
-QString ProbeABIDetector::qtCoreForExecutable(const QString &path) const
+QString ProbeABIDetector::qtCoreForExecutable(const QString &path)
 {
     auto qtCorePath = qtCoreFromOtool(resolveBundlePath(path));
     qtCorePath = resolveRPath(qtCorePath, readRPaths(path));
@@ -232,7 +232,7 @@ static ProbeABI abiFromMachO(const QString &path, const uchar *data, qint64 size
     return abi;
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path) const
+ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     if (path.isEmpty())
         return ProbeABI();

--- a/launcher/core/probeabidetector_win.cpp
+++ b/launcher/core/probeabidetector_win.cpp
@@ -160,7 +160,7 @@ QString absoluteExecutablePath(const QString &path)
     return path;
 }
 
-QString ProbeABIDetector::qtCoreForExecutable(const QString &path) const
+QString ProbeABIDetector::qtCoreForExecutable(const QString &path)
 {
     const auto exe = absoluteExecutablePath(path);
     const auto searchPaths = dllSearchPaths(exe);
@@ -247,7 +247,7 @@ static bool isDebugBuild(const QString &qtCoreDll)
     return qtCoreDll.endsWith(QLatin1String("d.dll"), Qt::CaseInsensitive);
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path) const
+ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     ProbeABI abi;
     if (path.isEmpty())

--- a/launcher/ui/launcherwindow.h
+++ b/launcher/ui/launcherwindow.h
@@ -54,7 +54,7 @@ public:
 
 private slots:
     void tabChanged();
-    void help();
+    static void help();
 
 private:
     Ui::LauncherWindow *ui;

--- a/launcher/ui/launchpage.cpp
+++ b/launcher/ui/launchpage.cpp
@@ -96,7 +96,7 @@ void LaunchPage::writeSettings()
     settings.setValue(QStringLiteral("Launcher/AccessMode"), ui->accessMode->currentIndex());
 }
 
-QStringList LaunchPage::notEmptyString(const QStringList &list) const
+QStringList LaunchPage::notEmptyString(const QStringList &list) 
 {
     QStringList notEmptyStringList;
     const int numberOfArguments = list.count();

--- a/launcher/ui/launchpage.h
+++ b/launcher/ui/launchpage.h
@@ -70,7 +70,7 @@ private slots:
     void detectABI(const QString &path);
 
 private:
-    QStringList notEmptyString(const QStringList &list) const;
+    static QStringList notEmptyString(const QStringList &list) ;
     Ui::LaunchPage *ui;
     QStringListModel *m_argsModel;
     ProbeABIModel *m_abiModel;

--- a/plugins/actioninspector/actioninspector.h
+++ b/plugins/actioninspector/actioninspector.h
@@ -45,13 +45,13 @@ public:
     ~ActionInspector() override;
 
 public Q_SLOTS:
-    void triggerAction(int row);
+    static void triggerAction(int row);
 
 private Q_SLOTS:
     void objectSelected(QObject *obj);
 
 private:
-    void registerMetaTypes();
+    static void registerMetaTypes();
     QItemSelectionModel *m_selectionModel;
 };
 

--- a/plugins/actioninspector/actioninspectorwidget.h
+++ b/plugins/actioninspector/actioninspectorwidget.h
@@ -53,7 +53,7 @@ public:
     ~ActionInspectorWidget() override;
 
 private Q_SLOTS:
-    void triggerAction(const QModelIndex &index);
+    static void triggerAction(const QModelIndex &index);
     void contextMenu(QPoint pos);
     void selectionChanged(const QItemSelection &selection);
 

--- a/plugins/codecbrowser/codecbrowserwidget.h
+++ b/plugins/codecbrowser/codecbrowserwidget.h
@@ -47,7 +47,7 @@ public:
     ~CodecBrowserWidget() override;
 
 private slots:
-    void textChanged(const QString &text);
+    static void textChanged(const QString &text);
 
 private:
     QScopedPointer<Ui::CodecBrowserWidget> ui;

--- a/plugins/fontbrowser/fontdatabasemodel.cpp
+++ b/plugins/fontbrowser/fontdatabasemodel.cpp
@@ -216,7 +216,7 @@ QMap<int, QVariant> FontDatabaseModel::itemData(const QModelIndex &index) const
     return ret;
 }
 
-QString FontDatabaseModel::smoothSizeString(const QString &family, const QString &style) const
+QString FontDatabaseModel::smoothSizeString(const QString &family, const QString &style) 
 {
     QFontDatabase database;
     const auto smoothSizes = database.smoothSizes(family, style);

--- a/plugins/fontbrowser/fontdatabasemodel.h
+++ b/plugins/fontbrowser/fontdatabasemodel.h
@@ -70,7 +70,7 @@ private:
     void ensureModelPopulated() const;
     void populateModel();
 
-    QString smoothSizeString(const QString &family, const QString &style) const;
+    static QString smoothSizeString(const QString &family, const QString &style) ;
 
     QVector<QString> m_families;
     QVector<QVector<QString> > m_styles;

--- a/plugins/guisupport/guisupport.cpp
+++ b/plugins/guisupport/guisupport.cpp
@@ -1136,7 +1136,7 @@ void GuiSupport::registerVariantHandler()
 #endif
 }
 
-QObject *GuiSupport::targetObject(QObject *object) const
+QObject *GuiSupport::targetObject(QObject *object) 
 {
     return object ? object : qobject_cast<QObject *>(qApp);
 }

--- a/plugins/guisupport/guisupport.h
+++ b/plugins/guisupport/guisupport.h
@@ -48,10 +48,10 @@ public:
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
-    void registerMetaTypes();
-    void registerVariantHandler();
+    static void registerMetaTypes();
+    static void registerVariantHandler();
     void discoverObjects();
-    QObject *targetObject(QObject *object) const;
+    static QObject *targetObject(QObject *object) ;
     QIcon createIcon(const QIcon &oldIcon, QWindow *w=nullptr);
     void updateWindowIcon(QWindow *w=nullptr);
     void updateWindowTitle(QWindow *w);

--- a/plugins/network/networkreplymodel.cpp
+++ b/plugins/network/networkreplymodel.cpp
@@ -350,7 +350,7 @@ void NetworkReplyModel::replyDeleted(QNetworkReply* reply, QNetworkAccessManager
     QMetaObject::invokeMethod(this, "updateReplyNode", Qt::AutoConnection, Q_ARG(QNetworkAccessManager*, nam), Q_ARG(GammaRay::NetworkReplyModel::ReplyNode, node));
 }
 
-void NetworkReplyModel::maybePeekResponse(ReplyNode &node, QNetworkReply *reply)
+void NetworkReplyModel::maybePeekResponse(ReplyNode &node, QNetworkReply *reply) const
 {
     if (m_captureResponse) {
         // TODO: Allow whitelisting a set of Content-Type values

--- a/plugins/network/networkreplymodel.h
+++ b/plugins/network/networkreplymodel.h
@@ -97,7 +97,7 @@ private:
 #endif
     void replyDeleted(QNetworkReply *reply, QNetworkAccessManager *nam);
 
-    void maybePeekResponse(ReplyNode &node, QNetworkReply *reply);
+    void maybePeekResponse(ReplyNode &node, QNetworkReply *reply) const;
     Q_INVOKABLE void updateReplyNode(QNetworkAccessManager *nam, const GammaRay::NetworkReplyModel::ReplyNode &newNode);
 
     std::vector<NAMNode> m_nodes;

--- a/plugins/network/networksupport.h
+++ b/plugins/network/networksupport.h
@@ -42,8 +42,8 @@ public:
     ~NetworkSupport() override;
 
 private:
-    void registerMetaTypes();
-    void registerVariantHandler();
+    static void registerMetaTypes();
+    static void registerVariantHandler();
 };
 
 class NetworkSupportFactory : public QObject, public StandardToolFactory<QObject, NetworkSupport>

--- a/plugins/openglsupport/openglsupport.h
+++ b/plugins/openglsupport/openglsupport.h
@@ -46,8 +46,8 @@ public:
     explicit OpenGLSupport(Probe *probe, QObject *parent = nullptr);
 
 private:
-    void registerMetaTypes();
-    void registerVariantHandler();
+    static void registerMetaTypes();
+    static void registerVariantHandler();
 };
 
 class OpenGLSupportFactory : public QObject, public StandardToolFactory<QObject, OpenGLSupport>

--- a/plugins/positioning/positioning.h
+++ b/plugins/positioning/positioning.h
@@ -54,7 +54,7 @@ private slots:
     void objectAdded(QObject *obj);
 
 private:
-    void registerMetaTypes();
+    static void registerMetaTypes();
 
     std::vector<QGeoPositionInfoSource*> m_nonProxyPositionInfoSources;
 };

--- a/plugins/qmlsupport/qmlbindingprovider.cpp
+++ b/plugins/qmlsupport/qmlbindingprovider.cpp
@@ -42,7 +42,7 @@
 
 using namespace GammaRay;
 
-QQmlAbstractBinding *QmlBindingProvider::bindingForProperty(QObject *obj, int propertyIndex) const
+QQmlAbstractBinding *QmlBindingProvider::bindingForProperty(QObject *obj, int propertyIndex) 
 {
     auto data = QQmlData::get(obj);
     if (!data || !data->hasBindingBit(propertyIndex))
@@ -66,7 +66,7 @@ bool QmlBindingProvider::canProvideBindingsFor(QObject *object) const
     return QQmlData::get(object);
 }
 
-void QmlBindingProvider::fetchSourceLocationFor(BindingNode *node, QQmlBinding *binding) const
+void QmlBindingProvider::fetchSourceLocationFor(BindingNode *node, QQmlBinding *binding) 
 {
     QV4::Function *function = binding->function();
     if (function) {

--- a/plugins/qmlsupport/qmlbindingprovider.h
+++ b/plugins/qmlsupport/qmlbindingprovider.h
@@ -57,8 +57,8 @@ public:
 private:
     std::unique_ptr<BindingNode> bindingNodeFromQmlProperty(QQmlProperty property, BindingNode *parent) const;
     BindingNode *bindingNodeFromBinding(QQmlAbstractBinding *binding) const;
-    void fetchSourceLocationFor(BindingNode *node, QQmlBinding *binding) const;
-    QQmlAbstractBinding *bindingForProperty(QObject *obj, int propertyIndex) const;
+    static void fetchSourceLocationFor(BindingNode *node, QQmlBinding *binding) ;
+    static QQmlAbstractBinding *bindingForProperty(QObject *obj, int propertyIndex) ;
 };
 
 }

--- a/plugins/qt3dinspector/3dinspector.h
+++ b/plugins/qt3dinspector/3dinspector.h
@@ -73,11 +73,11 @@ private:
     void frameGraphSelectionChanged(const QItemSelection &selection);
     void selectFrameGraphNode(Qt3DRender::QFrameGraphNode *node);
 
-    void registerCoreMetaTypes();
-    void registerInputMetaTypes();
-    void registerRenderMetaTypes();
-    void registerAnimationMetaTypes();
-    void registerExtensions();
+    static void registerCoreMetaTypes();
+    static void registerInputMetaTypes();
+    static void registerRenderMetaTypes();
+    static void registerAnimationMetaTypes();
+    static void registerExtensions();
 
 private:
     QAbstractItemModel *m_engineModel;

--- a/plugins/qt3dinspector/framegraphmodel.cpp
+++ b/plugins/qt3dinspector/framegraphmodel.cpp
@@ -266,12 +266,12 @@ void FrameGraphModel::objectReparented(QObject *obj)
     }
 }
 
-void FrameGraphModel::connectNode(Qt3DRender::QFrameGraphNode *node)
+void FrameGraphModel::connectNode(Qt3DRender::QFrameGraphNode *node) const
 {
     connect(node, &Qt3DRender::QFrameGraphNode::enabledChanged, this, &FrameGraphModel::nodeEnabledChanged);
 }
 
-void FrameGraphModel::disconnectNode(Qt3DRender::QFrameGraphNode *node)
+void FrameGraphModel::disconnectNode(Qt3DRender::QFrameGraphNode *node) const
 {
     disconnect(node, &Qt3DRender::QFrameGraphNode::enabledChanged, this, &FrameGraphModel::nodeEnabledChanged);
 }

--- a/plugins/qt3dinspector/framegraphmodel.h
+++ b/plugins/qt3dinspector/framegraphmodel.h
@@ -71,8 +71,8 @@ private:
     void removeSubtree(Qt3DRender::QFrameGraphNode *node, bool danglingPointer);
     QModelIndex indexForNode(Qt3DRender::QFrameGraphNode *node) const;
 
-    void connectNode(Qt3DRender::QFrameGraphNode *node);
-    void disconnectNode(Qt3DRender::QFrameGraphNode *node);
+    void connectNode(Qt3DRender::QFrameGraphNode *node) const;
+    void disconnectNode(Qt3DRender::QFrameGraphNode *node) const;
     void nodeEnabledChanged();
 
 private:

--- a/plugins/qt3dinspector/geometryextension/qt3dgeometrytab.h
+++ b/plugins/qt3dinspector/geometryextension/qt3dgeometrytab.h
@@ -79,7 +79,7 @@ protected:
 private:
     Qt3DCore::QComponent *createMaterial(Qt3DCore::QNode *parent);
     Qt3DCore::QComponent *createES2WireframeMaterial(Qt3DCore::QNode *parent);
-    Qt3DCore::QComponent *createSkyboxMaterial(Qt3DCore::QNode *parent);
+    static Qt3DCore::QComponent *createSkyboxMaterial(Qt3DCore::QNode *parent);
     void updateGeometry();
     void resetCamera();
     void computeBoundingVolume(const Qt3DGeometryAttributeData &vertexAttr,

--- a/plugins/qt3dinspector/qt3dentitytreemodel.cpp
+++ b/plugins/qt3dinspector/qt3dentitytreemodel.cpp
@@ -280,12 +280,12 @@ void Qt3DEntityTreeModel::objectReparented(QObject *obj)
     }
 }
 
-void Qt3DEntityTreeModel::connectEntity(Qt3DCore::QEntity *entity)
+void Qt3DEntityTreeModel::connectEntity(Qt3DCore::QEntity *entity) const
 {
     connect(entity, &Qt3DCore::QEntity::enabledChanged, this, &Qt3DEntityTreeModel::entityEnabledChanged);
 }
 
-void Qt3DEntityTreeModel::disconnectEntity(Qt3DCore::QEntity *entity)
+void Qt3DEntityTreeModel::disconnectEntity(Qt3DCore::QEntity *entity) const
 {
     disconnect(entity, &Qt3DCore::QEntity::enabledChanged, this, &Qt3DEntityTreeModel::entityEnabledChanged);
 }

--- a/plugins/qt3dinspector/qt3dentitytreemodel.h
+++ b/plugins/qt3dinspector/qt3dentitytreemodel.h
@@ -73,8 +73,8 @@ private:
     void removeSubtree(Qt3DCore::QEntity *entity, bool danglingPointer);
     QModelIndex indexForEntity(Qt3DCore::QEntity *entity) const;
 
-    void connectEntity(Qt3DCore::QEntity *entity);
-    void disconnectEntity(Qt3DCore::QEntity *entity);
+    void connectEntity(Qt3DCore::QEntity *entity) const;
+    void disconnectEntity(Qt3DCore::QEntity *entity) const;
     void entityEnabledChanged();
 
 private:

--- a/plugins/quickinspector/quickimplicitbindingdependencyprovider.cpp
+++ b/plugins/quickinspector/quickimplicitbindingdependencyprovider.cpp
@@ -41,7 +41,7 @@
 
 using namespace GammaRay;
 
-std::unique_ptr<BindingNode> GammaRay::QuickImplicitBindingDependencyProvider::createBindingNode(QObject* obj, const char *propertyName, BindingNode *parent) const
+std::unique_ptr<BindingNode> GammaRay::QuickImplicitBindingDependencyProvider::createBindingNode(QObject* obj, const char *propertyName, BindingNode *parent) 
 {
     if (!obj || !obj->metaObject())
         return {};

--- a/plugins/quickinspector/quickimplicitbindingdependencyprovider.h
+++ b/plugins/quickinspector/quickimplicitbindingdependencyprovider.h
@@ -55,7 +55,7 @@ public:
     bool canProvideBindingsFor(QObject *object) const override;
 
 private:
-    std::unique_ptr<BindingNode> createBindingNode(QObject *obj, const char *propertyName, BindingNode *parent = nullptr) const;
+    static std::unique_ptr<BindingNode> createBindingNode(QObject *obj, const char *propertyName, BindingNode *parent = nullptr) ;
     void anchorBindings(std::vector<std::unique_ptr<BindingNode>> &dependencies, QQuickAnchors *anchors, int propertyIndex, BindingNode *parent = nullptr) const;
     template<class Func> void childrenRectDependencies(QQuickItem *item, Func addDependency) const;
     template<class Func> void positionerDependencies(QQuickItem *item, Func addDependency) const;

--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -145,9 +145,9 @@ private:
     void selectWindow(QQuickWindow *window);
     void selectItem(QQuickItem *item);
     void selectSGNode(QSGNode *node);
-    void registerMetaTypes();
-    void registerVariantHandlers();
-    void registerPCExtensions();
+    static void registerMetaTypes();
+    static void registerVariantHandlers();
+    static void registerPCExtensions();
     QString findSGNodeType(QSGNode *node) const;
     static void scanForProblems();
 

--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -525,7 +525,7 @@ void AbstractScreenGrabber::itemWindowChanged(QQuickWindow *window)
     }
 }
 
-void AbstractScreenGrabber::connectItemChanges(QQuickItem *item)
+void AbstractScreenGrabber::connectItemChanges(QQuickItem *item) const
 {
     connect(item, &QQuickItem::childrenRectChanged, this, &AbstractScreenGrabber::updateOverlay);
     connect(item, &QQuickItem::rotationChanged, this, &AbstractScreenGrabber::updateOverlay);
@@ -540,7 +540,7 @@ void AbstractScreenGrabber::connectItemChanges(QQuickItem *item)
     connect(item, &QQuickItem::windowChanged, this, &AbstractScreenGrabber::itemWindowChanged);
 }
 
-void AbstractScreenGrabber::disconnectItemChanges(QQuickItem *item)
+void AbstractScreenGrabber::disconnectItemChanges(QQuickItem *item) const
 {
     disconnect(item, &QQuickItem::childrenRectChanged, this, &AbstractScreenGrabber::updateOverlay);
     disconnect(item, &QQuickItem::rotationChanged, this, &AbstractScreenGrabber::updateOverlay);
@@ -555,7 +555,7 @@ void AbstractScreenGrabber::disconnectItemChanges(QQuickItem *item)
     disconnect(item, &QQuickItem::windowChanged, this, &AbstractScreenGrabber::itemWindowChanged);
 }
 
-void AbstractScreenGrabber::connectTopItemChanges(QQuickItem *item)
+void AbstractScreenGrabber::connectTopItemChanges(QQuickItem *item) const
 {
     connect(item, &QQuickItem::childrenRectChanged, this, &AbstractScreenGrabber::updateOverlay);
     connect(item, &QQuickItem::rotationChanged, this, &AbstractScreenGrabber::updateOverlay);
@@ -564,7 +564,7 @@ void AbstractScreenGrabber::connectTopItemChanges(QQuickItem *item)
     connect(item, &QQuickItem::heightChanged, this, &AbstractScreenGrabber::updateOverlay);
 }
 
-void AbstractScreenGrabber::disconnectTopItemChanges(QQuickItem *item)
+void AbstractScreenGrabber::disconnectTopItemChanges(QQuickItem *item) const
 {
     disconnect(item, &QQuickItem::childrenRectChanged, this, &AbstractScreenGrabber::updateOverlay);
     disconnect(item, &QQuickItem::rotationChanged, this, &AbstractScreenGrabber::updateOverlay);

--- a/plugins/quickinspector/quickscreengrabber.h
+++ b/plugins/quickinspector/quickscreengrabber.h
@@ -172,10 +172,10 @@ protected:
 private:
     void itemParentChanged(QQuickItem *parent);
     void itemWindowChanged(QQuickWindow *window);
-    void connectItemChanges(QQuickItem *item);
-    void disconnectItemChanges(QQuickItem *item);
-    void connectTopItemChanges(QQuickItem *item);
-    void disconnectTopItemChanges(QQuickItem *item);
+    void connectItemChanges(QQuickItem *item) const;
+    void disconnectItemChanges(QQuickItem *item) const;
+    void connectTopItemChanges(QQuickItem *item) const;
+    void disconnectTopItemChanges(QQuickItem *item) const;
 
 protected:
     QPointer<QQuickWindow> m_window;

--- a/plugins/sceneinspector/sceneinspector.h
+++ b/plugins/sceneinspector/sceneinspector.h
@@ -67,8 +67,8 @@ private slots:
 
 private:
     QString findBestType(QGraphicsItem *item);
-    void registerGraphicsViewMetaTypes();
-    void registerVariantHandlers();
+    static void registerGraphicsViewMetaTypes();
+    static void registerVariantHandlers();
     void connectToScene();
 
 private:

--- a/plugins/signalmonitor/signalhistorydelegate.cpp
+++ b/plugins/signalmonitor/signalhistorydelegate.cpp
@@ -153,7 +153,7 @@ bool SignalHistoryDelegate::isActive() const
     return m_updateTimer->isActive();
 }
 
-QString SignalHistoryDelegate::toolTipAt(const QModelIndex &index, int position, int width)
+QString SignalHistoryDelegate::toolTipAt(const QModelIndex &index, int position, int width) const
 {
     const QAbstractItemModel * const model = index.model();
     const QVector<qint64> &events

--- a/plugins/signalmonitor/signalhistorydelegate.h
+++ b/plugins/signalmonitor/signalhistorydelegate.h
@@ -60,7 +60,7 @@ public:
     void setActive(bool active);
     bool isActive() const;
 
-    QString toolTipAt(const QModelIndex &index, int position, int width);
+    QString toolTipAt(const QModelIndex &index, int position, int width) const;
 
 signals:
     void visibleIntervalChanged(qint64 value);

--- a/plugins/styleinspector/stylehintmodel.cpp
+++ b/plugins/styleinspector/stylehintmodel.cpp
@@ -326,7 +326,7 @@ int StyleHintModel::doRowCount() const
     return style_hint_count;
 }
 
-QVariant StyleHintModel::styleHintToVariant(QStyle::StyleHint hint, int value) const
+QVariant StyleHintModel::styleHintToVariant(QStyle::StyleHint hint, int value) 
 {
     const auto type = style_hint_table[hint].type;
     switch (type) {

--- a/plugins/styleinspector/stylehintmodel.h
+++ b/plugins/styleinspector/stylehintmodel.h
@@ -52,7 +52,7 @@ protected:
     int doRowCount() const override;
 
 private:
-    QVariant styleHintToVariant(QStyle::StyleHint hint, int value) const;
+    static QVariant styleHintToVariant(QStyle::StyleHint hint, int value) ;
     QVariant styleHintData(QStyle::StyleHint hint) const;
 };
 

--- a/plugins/textdocumentinspector/textdocumentinspector.h
+++ b/plugins/textdocumentinspector/textdocumentinspector.h
@@ -56,7 +56,7 @@ private slots:
     void objectSelected(QObject *obj);
 
 private:
-    void registerMetaTypes();
+    static void registerMetaTypes();
 
     QAbstractItemModel *m_documentsModel;
     QItemSelectionModel *m_documentSelectionModel;

--- a/plugins/textdocumentinspector/textdocumentmodel.h
+++ b/plugins/textdocumentinspector/textdocumentmodel.h
@@ -61,7 +61,7 @@ private:
     void fillFrameIterator(const QTextFrame::iterator &it, QStandardItem *parent);
     void fillTable(QTextTable *table, QStandardItem *parent);
     void fillBlock(const QTextBlock &block, QStandardItem *parent);
-    QStandardItem *formatItem(const QTextFormat &format);
+    static QStandardItem *formatItem(const QTextFormat &format);
     void appendRow(QStandardItem *parent, QStandardItem *item, const QTextFormat &format,
                    const QRectF &boundingBox = QRectF());
 

--- a/plugins/timertop/timermodel.cpp
+++ b/plugins/timertop/timermodel.cpp
@@ -208,9 +208,9 @@ const TimerIdInfo *TimerModel::findTimerInfo(const QModelIndex &index) const
         }
 
         return &it.value();
-    } else {
-        if (index.row() < m_sourceModel->rowCount() + m_freeTimersInfo.count())
-            return &m_freeTimersInfo[index.row() - m_sourceModel->rowCount()];
+    }
+    if (index.row() < m_sourceModel->rowCount() + m_freeTimersInfo.count()) {
+        return &m_freeTimersInfo[index.row() - m_sourceModel->rowCount()];
     }
 
     return nullptr;
@@ -462,9 +462,8 @@ QModelIndex TimerModel::index(int row, int column, const QModelIndex &parent) co
             const QModelIndex sourceIndex = m_sourceModel->index(row, 0);
             QObject *const timerObject = sourceIndex.data(ObjectModel::ObjectRole).value<QObject *>();
             return createIndex(row, column, timerObject);
-        } else {
-            return createIndex(row, column, row - m_sourceModel->rowCount());
         }
+        return createIndex(row, column, row - m_sourceModel->rowCount());
     }
 
     return {};

--- a/plugins/translatorinspector/translatorinspector.h
+++ b/plugins/translatorinspector/translatorinspector.h
@@ -67,7 +67,7 @@ protected:
     bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
-    void registerMetaTypes();
+    static void registerMetaTypes();
 
     QItemSelectionModel *m_selectionModel;
     QItemSelectionModel *m_translationsSelectionModel;

--- a/plugins/webinspector/webinspector.h
+++ b/plugins/webinspector/webinspector.h
@@ -39,7 +39,7 @@ public:
     explicit WebInspector(Probe *probe, QObject *parent = nullptr);
 
 private slots:
-    void objectAdded(QObject *obj);
+    static void objectAdded(QObject *obj);
 };
 
 class WebInspectorFactory : public QObject, public ToolFactory

--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -272,7 +272,7 @@ void WidgetInspectorServer::updateWidgetPreview()
     m_remoteView->sendFrame(frame);
 }
 
-QVector<QRect> WidgetInspectorServer::tabFocusChain(QWidget* window) const
+QVector<QRect> WidgetInspectorServer::tabFocusChain(QWidget* window) 
 {
     QVector<QRect> r;
     QSet<QWidget*> widgets;

--- a/plugins/widgetinspector/widgetinspectorserver.h
+++ b/plugins/widgetinspector/widgetinspectorserver.h
@@ -73,11 +73,11 @@ private:
                                            GammaRay::RemoteViewInterface::RequestMode mode, int& bestCandidate) const;
     void callExternalExportAction(const char *name, QWidget *widget, const QString &fileName);
     QImage imageForWidget(QWidget *widget);
-    void registerWidgetMetaTypes();
-    void registerVariantHandlers();
+    static void registerWidgetMetaTypes();
+    static void registerVariantHandlers();
     void discoverObjects();
     void checkFeatures();
-    QVector<QRect> tabFocusChain(QWidget *window) const;
+    static QVector<QRect> tabFocusChain(QWidget *window) ;
 
 private slots:
     void widgetSelectionChanged(const QItemSelection &selection);

--- a/plugins/widgetinspector/widgettreemodel.cpp
+++ b/plugins/widgetinspector/widgettreemodel.cpp
@@ -46,7 +46,7 @@ WidgetTreeModel::WidgetTreeModel(QObject *parent)
 {
 }
 
-QPair<int, QVariant> WidgetTreeModel::defaultSelectedItem() const
+QPair<int, QVariant> WidgetTreeModel::defaultSelectedItem() 
 {
     // select the first QMainwindow window (if any) in the widget model
     return QPair<int, QVariant>(ObjectModel::ObjectRole,

--- a/plugins/widgetinspector/widgettreemodel.h
+++ b/plugins/widgetinspector/widgettreemodel.h
@@ -43,7 +43,7 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QMap<int, QVariant> itemData(const QModelIndex &index) const override;
 
-    Q_INVOKABLE QPair<int, QVariant> defaultSelectedItem() const;
+    Q_INVOKABLE static QPair<int, QVariant> defaultSelectedItem() ;
 
 protected:
     bool filterAcceptsObject(QObject *object) const override;

--- a/plugins/wlcompositorinspector/logview.cpp
+++ b/plugins/wlcompositorinspector/logview.cpp
@@ -511,7 +511,7 @@ public:
       }
     }
 
-    qint64 round(qint64 time, int direction)
+    static qint64 round(qint64 time, int direction)
     {
       qint64 v = time % 200;
       return time + direction * v;

--- a/plugins/wlcompositorinspector/logview.cpp
+++ b/plugins/wlcompositorinspector/logview.cpp
@@ -344,13 +344,13 @@ public:
       scrollbar->setValue(scrollbar->maximum());
   }
 
-  void reset()
+  void reset() const
   {
     m_view->m_lines.clear();
     m_view->resize(0, 0);
   }
 
-  void updateSize()
+  void updateSize() const
   {
     QSizeF lineSize = m_view->m_lines.last().text.size();
 

--- a/plugins/wlcompositorinspector/wlcompositorinspector.cpp
+++ b/plugins/wlcompositorinspector/wlcompositorinspector.cpp
@@ -162,7 +162,7 @@ public:
         }
     }
 
-    void setCurrentClient(QWaylandClient *client)
+    void setCurrentClient(QWaylandClient *client) const
     {
         emit m_inspector->setLoggingClient(client ? client->processId() : 0);
     }
@@ -273,7 +273,7 @@ public:
         delete res;
     }
 
-    wl_resource *resource(uint32_t id)
+    wl_resource *resource(uint32_t id) const
     {
       return wl_client_get_object(m_client->client(), id);
     }

--- a/tests/attachhelper.h
+++ b/tests/attachhelper.h
@@ -46,7 +46,7 @@ public:
 public slots:
     void attach();
     void processStarted();
-    void processFinished(int);
+    static void processFinished(int);
 
 private:
     QTimer *m_timer;

--- a/tests/benchsuite.h
+++ b/tests/benchsuite.h
@@ -38,7 +38,7 @@ class BenchSuite : public QObject
 
 private slots:
     void iconForObject();
-    void probe_objectAdded();
+    static void probe_objectAdded();
 };
 }
 

--- a/tests/bindinginspectortest.cpp
+++ b/tests/bindinginspectortest.cpp
@@ -232,12 +232,12 @@ private slots:
     void cleanup();
     void testMockProvider();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-    void testQmlBindingProvider_data();
-    void testQmlBindingProvider();
+    static void testQmlBindingProvider_data();
+    static void testQmlBindingProvider();
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    void testQtQuickProvider_data();
-    void testQtQuickProvider();
+    static void testQtQuickProvider_data();
+    static void testQtQuickProvider();
 #endif
     void testModel();
     void testModelDataChanged();

--- a/tests/codecmodeltest.cpp
+++ b/tests/codecmodeltest.cpp
@@ -38,7 +38,7 @@ class CodecModelTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void modelTest()
+    static void modelTest()
     {
         AllCodecsModel allCodecs;
         ModelTest tester(&allCodecs);

--- a/tests/earlyexittest.cpp
+++ b/tests/earlyexittest.cpp
@@ -47,7 +47,7 @@ class EarlyExitTest : public QObject
 {
     Q_OBJECT
 private:
-    bool hasInjector(const char *type) const
+    static bool hasInjector(const char *type) 
     {
         auto injector = InjectorFactory::createInjector(type);
         if (!injector)
@@ -57,7 +57,7 @@ private:
     }
 
 private slots:
-    void testNonExistingTarget()
+    static void testNonExistingTarget()
     {
         LaunchOptions options;
 #ifdef Q_OS_MAC
@@ -83,7 +83,7 @@ private slots:
             QTest::newRow("lldb") << QStringLiteral("lldb");
     }
 
-    void testNonExistingTargetDebugger()
+    static void testNonExistingTargetDebugger()
     {
         QFETCH(QString, injectorType);
         if (injectorType.isEmpty())
@@ -106,7 +106,7 @@ private slots:
         QVERIFY(!launcher.errorMessage().isEmpty());
     }
 
-    void test()
+    static void test()
     {
         LaunchOptions options;
         options.setUiMode(LaunchOptions::NoUi);
@@ -136,7 +136,7 @@ private slots:
             QTest::newRow("lldb") << QStringLiteral("lldb");
     }
 
-    void testStop()
+    static void testStop()
     {
         QFETCH(QString, injectorType);
 

--- a/tests/enumpropertytest.cpp
+++ b/tests/enumpropertytest.cpp
@@ -115,7 +115,7 @@ public:
     }
 
 private slots:
-    void testEnumToString_data()
+    static void testEnumToString_data()
     {
         QTest::addColumn<QVariant>("variant", nullptr);
         QTest::addColumn<QByteArray>("name", nullptr);
@@ -219,7 +219,7 @@ private slots:
         QTest::newRow("ns object as int, semi-qualified enum in different object") << QVariant::fromValue<int>(MyNS::MyObject::MyValue2) << QByteArray("MyObject::MyEnum") << &MyNS::MyOtherObject::staticMetaObject << QStringLiteral("MyValue2");
     }
 
-    void testEnumToString()
+    static void testEnumToString()
     {
         QFETCH(QVariant, variant);
         QFETCH(QByteArray, name);

--- a/tests/executiontest.cpp
+++ b/tests/executiontest.cpp
@@ -49,14 +49,14 @@ private slots:
         QVERIFY(Execution::isReadOnlyData(this->metaObject()->superClass()));
     }
 
-    void benchmarkReadOnlyData()
+    static void benchmarkReadOnlyData()
     {
         QBENCHMARK {
             Execution::isReadOnlyData(&QObject::staticMetaObject);
         }
     }
 
-    void testStackTrace()
+    static void testStackTrace()
     {
         if (!Execution::stackTracingAvailable())
             return;
@@ -69,7 +69,7 @@ private slots:
         }
     }
 
-    void benchmarkStackTrace()
+    static void benchmarkStackTrace()
     {
         if (!Execution::stackTracingAvailable())
             return;
@@ -79,7 +79,7 @@ private slots:
         }
     }
 
-    void benchmarkResolveStackTrace()
+    static void benchmarkResolveStackTrace()
     {
         if (!Execution::stackTracingAvailable())
             return;

--- a/tests/fontdatabasemodeltest.cpp
+++ b/tests/fontdatabasemodeltest.cpp
@@ -36,7 +36,7 @@ class FontDatabaseModelTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void modelTest()
+    static void modelTest()
     {
         FontDatabaseModel model;
         ModelTest tester(&model);

--- a/tests/launchertest.cpp
+++ b/tests/launchertest.cpp
@@ -56,7 +56,7 @@ class LauncherTest : public QObject
 {
     Q_OBJECT
 private:
-    bool hasInjector(const char *type) const
+    static bool hasInjector(const char *type) 
     {
         auto injector = InjectorFactory::createInjector(type);
         if (!injector)
@@ -76,7 +76,7 @@ private slots:
             QTest::newRow("windll") << QStringLiteral("windll");
     }
 
-    void testLauncher()
+    static void testLauncher()
     {
         QFETCH(QString, injectorType);
         if (injectorType.isEmpty())
@@ -111,7 +111,7 @@ private slots:
     }
 
 #ifdef HAVE_QT_WIDGETS
-    void testLauncherStyle()
+    static void testLauncherStyle()
     {
         LaunchOptions options;
         options.setUiMode(LaunchOptions::NoUi);
@@ -142,7 +142,7 @@ private slots:
     }
 #endif
 
-    void testAttach()
+    static void testAttach()
     {
         QProcess target;
         target.setProcessChannelMode(QProcess::ForwardedChannels);

--- a/tests/launcheruiiptest.cpp
+++ b/tests/launcheruiiptest.cpp
@@ -54,7 +54,7 @@ private slots:
         m_localServer.close();
     }
 
-    void testUrl_data()
+    static void testUrl_data()
     {
         QTest::addColumn<QString>("userInput", nullptr);
         QTest::addColumn<QString>("expectedParsed", nullptr);
@@ -81,7 +81,7 @@ private slots:
         QTest::newRow("::ffff:192.168.15.2") << "::ffff:192.168.15.2" << "tcp://[::ffff:192.168.15.2]:11732" << true << true;
     }
 
-    void testUrl()
+    static void testUrl()
     {
         QFETCH(QString, userInput);
         QFETCH(QString, expectedParsed);
@@ -104,7 +104,7 @@ private slots:
         QCOMPARE(lineEdit->actions().contains(connectPage.m_implicitPortWarningSign), autoPortWarning);
     }
 
-    void testHostNames_data()
+    static void testHostNames_data()
     {
         QTest::addColumn<QString>("userInput", nullptr);
         QTest::addColumn<bool>("isValid", nullptr);
@@ -114,7 +114,7 @@ private slots:
         QTest::newRow("tcp://localhost:11732") << "tcp://localhost:11732" << true;
     }
 
-    void testHostNames()
+    static void testHostNames()
     {
         QFETCH(QString, userInput);
         QFETCH(bool, isValid);

--- a/tests/manual/messagemodeltest.h
+++ b/tests/manual/messagemodeltest.h
@@ -44,10 +44,10 @@ public:
     MessageGenerator();
 
 private slots:
-    void generateDebug();
-    void generateWarning();
-    void generateCritical();
-    void generateFatal(); //FIXME: Q_RETURN fails on some configurations
+    static void generateDebug();
+    static void generateWarning();
+    static void generateCritical();
+    static void generateFatal(); //FIXME: Q_RETURN fails on some configurations
 };
 }
 

--- a/tests/metaobjecttest.cpp
+++ b/tests/metaobjecttest.cpp
@@ -40,7 +40,7 @@ class MetaObjectTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testMetaObject()
+    static void testMetaObject()
     {
         QVERIFY(MetaObjectRepository::instance()->hasMetaObject(QStringLiteral("QThread")));
         auto *mo = MetaObjectRepository::instance()->metaObject(QStringLiteral("QThread"));
@@ -57,7 +57,7 @@ private slots:
         QVERIFY(!superMo->superClass(0));
     }
 
-    void testMemberProperty()
+    static void testMemberProperty()
     {
         auto *mo = MetaObjectRepository::instance()->metaObject(QStringLiteral("QThread"));
         QVERIFY(mo->propertyCount() >= 7); // depends on Qt version
@@ -79,7 +79,7 @@ private slots:
         QCOMPARE(prop->isReadOnly(), false);
     }
 
-    void testStaticProperty()
+    static void testStaticProperty()
     {
         auto *mo = MetaObjectRepository::instance()->metaObject(QStringLiteral("QCoreApplication"));
         QVERIFY(mo);

--- a/tests/metatypemodeltest.cpp
+++ b/tests/metatypemodeltest.cpp
@@ -51,7 +51,7 @@ class MetaTypeModelTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testModel()
+    static void testModel()
     {
         MetaTypesModel srcModel;
         MetaTypesClientModel model;

--- a/tests/methodmodeltest.cpp
+++ b/tests/methodmodeltest.cpp
@@ -71,7 +71,7 @@ private slots:
         srcModel.setMetaObject(nullptr);
     }
 
-    void testModel()
+    static void testModel()
     {
         ObjectMethodModel srcModel;
         ClientMethodModel model;
@@ -93,7 +93,7 @@ private slots:
         QCOMPARE(model.rowCount(), 0);
     }
 
-    void testToolTip_data()
+    static void testToolTip_data()
     {
         QTest::addColumn<QString>("name", nullptr);
         QTest::addColumn<QString>("toolTip", nullptr);
@@ -102,7 +102,7 @@ private slots:
         QTest::newRow("revision") << "revisionedSlot" << "147";
     }
 
-    void testToolTip()
+    static void testToolTip()
     {
         QFETCH(QString, name);
         QFETCH(QString, toolTip);

--- a/tests/multisignalmappertest.cpp
+++ b/tests/multisignalmappertest.cpp
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    QMetaMethod method(QObject *obj, const char *name)
+    static QMetaMethod method(QObject *obj, const char *name)
     {
         return obj->metaObject()->method(obj->metaObject()->indexOfSignal(name));
     }

--- a/tests/multithreadingtest.cpp
+++ b/tests/multithreadingtest.cpp
@@ -61,7 +61,7 @@ class MultiThreadingTest : public BaseProbeTest
 {
     Q_OBJECT
 private slots:
-    void testCreateDestroy_data()
+    static void testCreateDestroy_data()
     {
         QTest::addColumn<int>("batchSize", nullptr);
         QTest::addColumn<int>("delay", nullptr);

--- a/tests/networkselectionmodeltest.cpp
+++ b/tests/networkselectionmodeltest.cpp
@@ -89,7 +89,7 @@ protected:
     void objectDestroyed(Protocol::ObjectAddress, const QString &, QObject *) override {}
 
 signals:
-    void message(const GammaRay::Message &msg);
+    void message(const GammaRay::Message &);
 };
 
 class FakeNetworkSelectionModel : public NetworkSelectionModel

--- a/tests/networkselectionmodeltest.cpp
+++ b/tests/networkselectionmodeltest.cpp
@@ -123,7 +123,7 @@ class NetworkSelectionModelTest : public QObject
 {
     Q_OBJECT
 private:
-    void fillModel(QStandardItemModel *model)
+    static void fillModel(QStandardItemModel *model)
     {
         model->appendRow(new QStandardItem(QStringLiteral("Row 1")));
         model->appendRow(new QStandardItem(QStringLiteral("Row 2")));
@@ -133,7 +133,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         qRegisterMetaType<QItemSelection>();
         qRegisterMetaType<QModelIndex>();
@@ -143,7 +143,7 @@ private slots:
         QVERIFY(Endpoint::isConnected());
     }
 
-    void cleanupTestCase()
+    static void cleanupTestCase()
     {
         delete FakeEndpoint::instance();
     }

--- a/tests/objectinstancetest.cpp
+++ b/tests/objectinstancetest.cpp
@@ -43,7 +43,7 @@ class ObjectInstanceTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testQtObject()
+    static void testQtObject()
     {
         QObject obj;
 
@@ -60,7 +60,7 @@ private slots:
         QCOMPARE(oi.object(), oi2.object());
     }
 
-    void testMetaObjectVariantPointer()
+    static void testMetaObjectVariantPointer()
     {
         QDateTime dt;
 
@@ -79,7 +79,7 @@ private slots:
         QVERIFY(!(oi == oi2));
     }
 
-    void testMetaObjectVariantValue()
+    static void testMetaObjectVariantValue()
     {
         QDateTime dt;
 
@@ -101,7 +101,7 @@ private slots:
         QVERIFY(oi == oi2);
     }
 
-    void testUnknownVariantValue()
+    static void testUnknownVariantValue()
     {
         CustomType t;
 
@@ -110,7 +110,7 @@ private slots:
         QCOMPARE(oi.typeName(), QByteArray("CustomType"));
     }
 
-    void testUnknownVariantPointer()
+    static void testUnknownVariantPointer()
     {
         CustomType t;
 

--- a/tests/probeabidetectortest.cpp
+++ b/tests/probeabidetectortest.cpp
@@ -40,7 +40,7 @@ class ProbeABIDetectorTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testDetectExecutable()
+    static void testDetectExecutable()
     {
         ProbeABIDetector detector;
         QVERIFY(!detector.qtCoreForExecutable(QCoreApplication::applicationFilePath()).isEmpty());
@@ -48,7 +48,7 @@ private slots:
         QCOMPARE(abi.id(), QStringLiteral(GAMMARAY_PROBE_ABI));
     }
 
-    void testDetectProcess()
+    static void testDetectProcess()
     {
         ProbeABIDetector detector;
         QVERIFY(!detector.qtCoreForProcess(QCoreApplication::applicationPid()).isEmpty());
@@ -56,7 +56,7 @@ private slots:
         QCOMPARE(abi.id(), QStringLiteral(GAMMARAY_PROBE_ABI));
     }
 
-    void testContainsQtCore_data()
+    static void testContainsQtCore_data()
     {
         QTest::addColumn<QString>("line", nullptr);
         QTest::addColumn<bool>("isQtCore", nullptr);
@@ -96,7 +96,7 @@ private slots:
         QTest::newRow("libQt") << "libQt.dylib" << false;
     }
 
-    void testContainsQtCore()
+    static void testContainsQtCore()
     {
         QFETCH(QString, line);
         QFETCH(bool, isQtCore);

--- a/tests/probeabitest.cpp
+++ b/tests/probeabitest.cpp
@@ -37,7 +37,7 @@ class ProbeABITest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testIsValid()
+    static void testIsValid()
     {
         ProbeABI abi;
         QVERIFY(!abi.isValid());
@@ -57,7 +57,7 @@ private slots:
         QVERIFY(abi.isValid());
     }
 
-    void testToString_data()
+    static void testToString_data()
     {
         QTest::addColumn<QString>("id", nullptr);
         QTest::addColumn<int>("majorVersion", nullptr);
@@ -80,7 +80,7 @@ private slots:
 #endif
     }
 
-    void testToString()
+    static void testToString()
     {
         QFETCH(QString, id);
         QFETCH(int, majorVersion);
@@ -100,7 +100,7 @@ private slots:
         QCOMPARE(abi.id(), id);
     }
 
-    void testFromString_data()
+    static void testFromString_data()
     {
         QTest::addColumn<QString>("id", nullptr);
         QTest::addColumn<bool>("valid", nullptr);
@@ -135,7 +135,7 @@ private slots:
 #endif
     }
 
-    void testFromString()
+    static void testFromString()
     {
         QFETCH(QString, id);
         QFETCH(bool, valid);
@@ -166,7 +166,7 @@ private slots:
 #endif
     }
 
-    void testDisplayString_data()
+    static void testDisplayString_data()
     {
         QTest::addColumn<QString>("id", nullptr);
         QTest::addColumn<QString>("display", nullptr);
@@ -184,7 +184,7 @@ private slots:
 #endif
     }
 
-    void testDisplayString()
+    static void testDisplayString()
     {
         QFETCH(QString, id);
         QFETCH(QString, display);
@@ -193,7 +193,7 @@ private slots:
         QCOMPARE(abi.displayString(), display);
     }
 
-    void testProbeABICompat()
+    static void testProbeABICompat()
     {
 #ifndef Q_OS_WIN
         const ProbeABI targetABI = ProbeABI::fromString(QStringLiteral("qt5_2-x86_64"));
@@ -241,7 +241,7 @@ private slots:
         QCOMPARE(targetABI.isCompatible(incompatABI), !compilerAbiMatters);
     }
 
-    void testProbeABISort()
+    static void testProbeABISort()
     {
         ProbeABI qt52;
         qt52.setQtVersion(5, 2);

--- a/tests/probesettingstest.cpp
+++ b/tests/probesettingstest.cpp
@@ -42,7 +42,7 @@ class ProbeSettingsTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testSettingsRoundtrip()
+    static void testSettingsRoundtrip()
     {
         Paths::setRootPath(QCoreApplication::applicationDirPath() + QStringLiteral("/.."));
 

--- a/tests/problemreportertest.cpp
+++ b/tests/problemreportertest.cpp
@@ -74,7 +74,7 @@ class FaultyMetaObjectBaseClass : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(UnregisteredType someProp READ someProp CONSTANT)
-    UnregisteredType someProp() const { return {}; }
+    static UnregisteredType someProp() { return {}; }
 };
 
 class FaultyMetaObjectClass : public FaultyMetaObjectBaseClass
@@ -84,9 +84,9 @@ class FaultyMetaObjectClass : public FaultyMetaObjectBaseClass
     Q_PROPERTY(UnregisteredType someProp READ someProp CONSTANT)
 
 public:
-    Q_INVOKABLE void noop(UnregisteredType param) { Q_UNUSED(param) }
+    Q_INVOKABLE static void noop(UnregisteredType param) { Q_UNUSED(param) }
 
-    UnregisteredType someProp() const { return {}; }
+    static UnregisteredType someProp() { return {}; }
 };
 
 namespace GammaRay {
@@ -118,13 +118,13 @@ private slots:
         availableCheckersModelTest.reset(new ModelTest(ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.AvailableProblemCheckersModel"))));
     }
 
-    void cleanup()
+    static void cleanup()
     {
         ProblemCollector::instance()->clearScans();
         QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
     }
 
-    void testDuplicates()
+    static void testDuplicates()
     {
         QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
 
@@ -141,7 +141,7 @@ private slots:
         ProblemCollector::removeProblem(QStringLiteral("9skjlksdjb"));
     }
 
-    void testMultipleSourceLocations()
+    static void testMultipleSourceLocations()
     {
         QCOMPARE(ProblemCollector::instance()->problems().size(), 0);
 
@@ -180,7 +180,7 @@ private slots:
         ProblemCollector::removeProblem(QStringLiteral("abcdefg"));
     }
 
-    void testScans()
+    static void testScans()
     {
         auto standardCheckersCount = ProblemCollector::instance()->availableCheckers().size();
         ProblemCollector::registerProblemChecker(QStringLiteral("Dummy"),
@@ -228,7 +228,7 @@ private slots:
         ProblemCollector::instance()->availableCheckers().erase(dummyChecker);
     }
 
-    void testAvailableScansModel()
+    static void testAvailableScansModel()
     {
         auto model = ObjectBroker::model(QStringLiteral("com.kdab.GammaRay.AvailableProblemCheckersModel"));
         auto rowCount = model->rowCount();
@@ -283,7 +283,7 @@ private slots:
     }
 
 #ifdef QT_QML_LIB
-    void testBindingLoopChecker()
+    static void testBindingLoopChecker()
     {
         QQmlEngine engine;
         QQmlComponent c(&engine);
@@ -314,7 +314,7 @@ private slots:
     }
 #endif
 
-    void testConnectionIssues()
+    static void testConnectionIssues()
     {
         QVERIFY(ProblemCollector::instance()->isCheckerRegistered("com.kdab.GammaRay.ObjectInspector.ConnectionsCheck"));
 
@@ -384,7 +384,7 @@ private slots:
 
     }
 
-    void testMetaTypeChecks()
+    static void testMetaTypeChecks()
     {
         std::unique_ptr<QObject> obj(new FaultyMetaObjectClass);
         QTest::qWait(1);
@@ -425,7 +425,7 @@ private slots:
     }
 
 #ifdef HAVE_QT_WIDGETS
-    void testActionValidator()
+    static void testActionValidator()
     {
         QAction *a1 = new QAction(QStringLiteral("Action 1"), qApp);
         a1->setShortcut(QKeySequence(QStringLiteral("Ctrl+K")));

--- a/tests/propertyadaptortest.cpp
+++ b/tests/propertyadaptortest.cpp
@@ -51,7 +51,7 @@ class PropertyAdaptorTest : public QObject
 {
     Q_OBJECT
 private:
-    void testProperty(PropertyAdaptor *adaptor, const char *name, const char *typeName,
+    static void testProperty(PropertyAdaptor *adaptor, const char *name, const char *typeName,
                       const char *className, PropertyData::AccessFlags flags)
     {
         for (int i = 0; i < adaptor->count(); ++i) {
@@ -67,7 +67,7 @@ private:
         QVERIFY(!"property not found");
     }
 
-    void verifyPropertyData(PropertyAdaptor *adaptor)
+    static void verifyPropertyData(PropertyAdaptor *adaptor)
     {
         for (int i = 0; i < adaptor->count(); ++i) {
             auto data = adaptor->propertyData(i);
@@ -77,7 +77,7 @@ private:
         }
     }
 
-    int indexOfProperty(PropertyAdaptor *adaptor, const char *name)
+    static int indexOfProperty(PropertyAdaptor *adaptor, const char *name)
     {
         for (int i = 0; i < adaptor->count(); ++i) {
             auto prop = adaptor->propertyData(i);
@@ -88,7 +88,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         MetaObject *mo;
         MO_ADD_METAOBJECT0(QPen);

--- a/tests/propertymodeltest.cpp
+++ b/tests/propertymodeltest.cpp
@@ -51,7 +51,7 @@ private slots:
         createProbe();
     }
 
-    void testPropertyModel()
+    static void testPropertyModel()
     {
         PropertyTestObject obj;
         obj.setProperty("dynamicProperty", 5);
@@ -86,7 +86,7 @@ private slots:
         QVERIFY(!moRow.sibling(moRow.row(), 1).data(Qt::DisplayRole).toString().isEmpty());
     }
 
-    void testMetaObject()
+    static void testMetaObject()
     {
         AggregatedPropertyModel model;
         model.setObject(ObjectInstance(nullptr, &Gadget::staticMetaObject));
@@ -97,7 +97,7 @@ private slots:
         QVERIFY(qmoRow.isValid());
     }
 
-    void testChangeNotification()
+    static void testChangeNotification()
     {
         ChangingPropertyObject obj;
         AggregatedPropertyModel model;
@@ -126,7 +126,7 @@ private slots:
         QCOMPARE(removeSpy.size(), 1);
     }
 
-    void testGadgetRO()
+    static void testGadgetRO()
     {
         PropertyTestObject obj;
         AggregatedPropertyModel model;
@@ -139,7 +139,7 @@ private slots:
         QVERIFY((idx.flags() & Qt::ItemIsEditable) == 0);
     }
 
-    void testGadgetRW()
+    static void testGadgetRW()
     {
         PropertyTestObject obj;
         AggregatedPropertyModel model;

--- a/tests/qmetaobjectvalidatortest.cpp
+++ b/tests/qmetaobjectvalidatortest.cpp
@@ -44,8 +44,8 @@ class QMetaObjectValidatorTest : public QObject
     Q_PROPERTY(UnknownCustomType failUnknownType READ failUnknownType)
     Q_PROPERTY(KnownCustomType knownType READ knownType)
 public:
-    UnknownCustomType failUnknownType() const { return {}; }
-    KnownCustomType knownType() const { return {}; }
+    static UnknownCustomType failUnknownType() { return {}; }
+    static KnownCustomType knownType() { return {}; }
 
 signals:
     void destroyed();
@@ -55,7 +55,7 @@ public slots:
     void knownParameter(KnownCustomType) {}
 
 private slots:
-    void testSignalOverride()
+    static void testSignalOverride()
     {
         for (int i = staticMetaObject.methodOffset(); i < staticMetaObject.methodCount(); ++i) {
             const auto method = staticMetaObject.method(i);
@@ -70,7 +70,7 @@ private slots:
         }
     }
 
-    void testParameterTypes()
+    static void testParameterTypes()
     {
         for (int i = staticMetaObject.methodOffset(); i < staticMetaObject.methodCount(); ++i) {
             const auto method = staticMetaObject.method(i);
@@ -81,7 +81,7 @@ private slots:
         }
     }
 
-    void testPropertyType()
+    static void testPropertyType()
     {
         for (int i = staticMetaObject.propertyOffset(); i < staticMetaObject.propertyCount(); ++i) {
             const auto property = staticMetaObject.property(i);
@@ -92,7 +92,7 @@ private slots:
         }
     }
 
-    void testObject()
+    static void testObject()
     {
         QCOMPARE(QMetaObjectValidator::check(&staticMetaObject),
                  QMetaObjectValidatorResult::SignalOverride |

--- a/tests/qmlsupporttest.cpp
+++ b/tests/qmlsupporttest.cpp
@@ -52,7 +52,7 @@ class QmlSupportTest : public QObject
 {
     Q_OBJECT
 private:
-    int indexOfProperty(PropertyAdaptor *adaptor, const char *name)
+    static int indexOfProperty(PropertyAdaptor *adaptor, const char *name)
     {
         for (int i = 0; i < adaptor->count(); ++i) {
             auto prop = adaptor->propertyData(i);
@@ -63,7 +63,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         PropertyAdaptorFactory::registerFactory(QmlListPropertyAdaptorFactory::instance());
         PropertyAdaptorFactory::registerFactory(QmlAttachedPropertyAdaptorFactory::instance());

--- a/tests/quickinspectorbench.cpp
+++ b/tests/quickinspectorbench.cpp
@@ -80,7 +80,7 @@ private slots:
     }
 
 private:
-    QVector<QQuickItem *> createItems(QQuickItem* parent)
+    static QVector<QQuickItem *> createItems(QQuickItem* parent)
     {
         const int numberOfItems = 10000;
         QVector<QQuickItem *> items;

--- a/tests/quickinspectorpickingtest.cpp
+++ b/tests/quickinspectorpickingtest.cpp
@@ -49,7 +49,7 @@ class QuickInspectorPickingTest : public QObject
 {
     Q_OBJECT
 private:
-    void createProbe()
+    static void createProbe()
     {
         Paths::setRelativeRootPath(GAMMARAY_INVERSE_BIN_DIR);
         qputenv("GAMMARAY_ProbePath", Paths::probePath(GAMMARAY_PROBE_ABI).toUtf8());
@@ -60,7 +60,7 @@ private:
         QTest::qWait(1); // event loop re-entry
     }
 
-    bool waitForSignal(QSignalSpy *spy, bool keepResult = false)
+    static bool waitForSignal(QSignalSpy *spy, bool keepResult = false)
     {
         if (spy->isEmpty())
             spy->wait(1000);
@@ -92,7 +92,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         qRegisterMetaType<QItemSelection>();
     }
@@ -121,7 +121,7 @@ private slots:
         QTest::qWait(1);
     }
 
-    void testItemPicking_data()
+    static void testItemPicking_data()
     {
         QTest::addColumn<QString>("qmlFile", nullptr);
         QTest::addColumn<QString>("pickedObjectId", nullptr);

--- a/tests/quickinspectortest.cpp
+++ b/tests/quickinspectortest.cpp
@@ -72,7 +72,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         qRegisterMetaType<QItemSelection>();
     }

--- a/tests/quickinspectortest2.cpp
+++ b/tests/quickinspectortest2.cpp
@@ -50,7 +50,7 @@ protected:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         qRegisterMetaType<QItemSelection>();
     }
@@ -74,7 +74,7 @@ private slots:
         QTest::qWait(1);
     }
 
-    void testPreviewFetchingThrottler_data()
+    static void testPreviewFetchingThrottler_data()
     {
         QTest::addColumn<bool>("clientIsReplying", nullptr);
         QTest::newRow("no-reply") << false;

--- a/tests/remotemodeltest.cpp
+++ b/tests/remotemodeltest.cpp
@@ -59,7 +59,7 @@ public:
     }
 
 signals:
-    void message(const GammaRay::Message &msg);
+    void message(const GammaRay::Message &);
 
 private slots:
     void deliverMessage(const QByteArray &ba)
@@ -98,7 +98,7 @@ public:
     }
 
 signals:
-    void message(const GammaRay::Message &msg);
+    void message(const GammaRay::Message &);
 
 private:
     void sendMessage(const Message &msg) const override

--- a/tests/remotemodeltest.cpp
+++ b/tests/remotemodeltest.cpp
@@ -117,7 +117,7 @@ class RemoteModelTest : public QObject
 {
     Q_OBJECT
 private:
-    bool waitForData(const QModelIndex &idx)
+    static bool waitForData(const QModelIndex &idx)
     {
         if (idx.data(RemoteModelRole::LoadingState).value<RemoteModelNodeState::NodeStates>() == RemoteModelNodeState::NoState)
             return true; // data already present
@@ -138,7 +138,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         FakeRemoteModelServer::setup();
         FakeRemoteModel::setup();

--- a/tests/selflocatortest.cpp
+++ b/tests/selflocatortest.cpp
@@ -41,13 +41,13 @@ class SelfLocatorTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testFindMe()
+    static void testFindMe()
     {
         qDebug() << SelfLocator::findMe();
         QCOMPARE(QCoreApplication::applicationFilePath(), SelfLocator::findMe());
     }
 
-    void testRootPath()
+    static void testRootPath()
     {
         qDebug() << Paths::rootPath();
         QVERIFY(!Paths::rootPath().isEmpty());

--- a/tests/selftesttest.cpp
+++ b/tests/selftesttest.cpp
@@ -38,7 +38,7 @@ class SelfTestTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void runSelfTest()
+    static void runSelfTest()
     {
         Paths::setRelativeRootPath(GAMMARAY_INVERSE_BIN_DIR);
         SelfTest selfTest;

--- a/tests/shared/propertytestobject.h
+++ b/tests/shared/propertytestobject.h
@@ -44,7 +44,7 @@ public:
     int prop1() const { return m_prop1; }
     void setProp1(int v) { m_prop1 = v; }
     void resetProp1() { m_prop1 = 5; }
-    Q_INVOKABLE void someMethod();
+    Q_INVOKABLE static void someMethod();
 
 private:
     int m_prop1 = 42;

--- a/tests/shared/variantpropertyobject.cpp
+++ b/tests/shared/variantpropertyobject.cpp
@@ -54,7 +54,7 @@ QPointer<QObject> VariantPropertyObject::trackingObject() const
     return m_object.data();
 }
 
-QVector<int> VariantPropertyObject::widgetVector() const
+QVector<int> VariantPropertyObject::widgetVector() 
 {
     QVector<int> vec;
     vec << 5;

--- a/tests/shared/variantpropertyobject.h
+++ b/tests/shared/variantpropertyobject.h
@@ -46,7 +46,7 @@ public:
 
     QSharedPointer<QObject> sharedObject() const;
     QPointer<QObject> trackingObject() const;
-    QVector<int> widgetVector() const;
+    static QVector<int> widgetVector() ;
 
 private:
     QSharedPointer<QObject> m_object;

--- a/tests/signalspycallbacktest.cpp
+++ b/tests/signalspycallbacktest.cpp
@@ -71,7 +71,7 @@ private slots:
         QVERIFY(s2.isNull());
     }
 
-    void cleanupTestCase()
+    static void cleanupTestCase()
     {
         // explicitly delete the probe as our usual cleanup doesn't work since we will
         // not get qApp::aboutToQuit() from QTest::qExec(), and then we end up with

--- a/tests/sourcelocationtest.cpp
+++ b/tests/sourcelocationtest.cpp
@@ -37,7 +37,7 @@ class SourceLocationTest : public QObject
 {
     Q_OBJECT
 private slots:
-    void testZeroAndOneBasedNumbering()
+    static void testZeroAndOneBasedNumbering()
     {
         SourceLocation loc;
         loc = SourceLocation::fromZeroBased(QUrl(QStringLiteral("file:///some/file")), 0, 0);
@@ -66,7 +66,7 @@ private slots:
         QStringLiteral("/some/file:78:87");
     }
 
-    void testDisplayString_data()
+    static void testDisplayString_data()
     {
         QTest::addColumn<QUrl>("url", nullptr);
         QTest::addColumn<int>("line", nullptr);
@@ -94,7 +94,7 @@ private slots:
             "qrc:///main.qml:1:1") << true;
     }
 
-    void testDisplayString()
+    static void testDisplayString()
     {
         QFETCH(QUrl, url);
         QFETCH(int, line);

--- a/tests/test_connections.h
+++ b/tests/test_connections.h
@@ -110,9 +110,9 @@ public:
 public slots:
     void startTests();
 private slots:
-    void run_data();
-    void run();
-    void threading();
+    static void run_data();
+    static void run();
+    static void threading();
 private:
     int m_argc;
     char **m_argv;

--- a/tests/toolmanagertest.cpp
+++ b/tests/toolmanagertest.cpp
@@ -46,7 +46,7 @@ class ToolManagerTest : public BaseProbeTest
 {
     Q_OBJECT
 private:
-    int visibleRowCount(QAbstractItemModel *model)
+    static int visibleRowCount(QAbstractItemModel *model)
     {
         int count = 0;
         for (int i = 0; i < model->rowCount(); ++i) {
@@ -58,7 +58,7 @@ private:
     }
 
 private slots:
-    void initTestCase()
+    static void initTestCase()
     {
         qRegisterMetaType<QVector<ToolInfo> >();
         new ClientToolManager;
@@ -155,7 +155,7 @@ private slots:
     }
 
 private:
-    void testHasBasicTools(bool actionInspectorEnabled)
+    static void testHasBasicTools(bool actionInspectorEnabled)
     {
         bool hasBasicTools = false;
         const ToolInfo *actionInspector = nullptr;
@@ -229,7 +229,7 @@ private:
         QVERIFY(supportedToolIds.contains(QStringLiteral("gammaray_actioninspector")));
     }
 
-    void testClearance()
+    static void testClearance()
     {
         QSignalSpy resetSpy(ClientToolManager::instance()->model(), &QAbstractItemModel::modelReset);
         ClientToolManager::instance()->clear();

--- a/tests/widgettest.cpp
+++ b/tests/widgettest.cpp
@@ -39,7 +39,7 @@ class WidgetTest : public BaseProbeTest
 {
     Q_OBJECT
 private:
-    int visibleRowCount(QAbstractItemModel *model)
+    static int visibleRowCount(QAbstractItemModel *model)
     {
         int count = 0;
         for (int i = 0; i < model->rowCount(); ++i) {

--- a/ui/codeeditor/codeeditor.cpp
+++ b/ui/codeeditor/codeeditor.cpp
@@ -302,7 +302,7 @@ bool CodeEditor::isFoldable(const QTextBlock &block) const
 #endif
 }
 
-bool CodeEditor::isFolded(const QTextBlock &block) const
+bool CodeEditor::isFolded(const QTextBlock &block) 
 {
     if (!block.isValid())
         return false;

--- a/ui/codeeditor/codeeditor.h
+++ b/ui/codeeditor/codeeditor.h
@@ -73,7 +73,7 @@ private:
 
     QTextBlock blockAtPosition(int y) const;
     bool isFoldable(const QTextBlock &block) const;
-    bool isFolded(const QTextBlock &block) const;
+    static bool isFolded(const QTextBlock &block) ;
     void toggleFold(const QTextBlock &startBlock);
 
     static KSyntaxHighlighting::Repository *s_repository;

--- a/ui/helpcontroller.cpp
+++ b/ui/helpcontroller.cpp
@@ -49,7 +49,7 @@ struct HelpControllerPrivate
     HelpControllerPrivate() = default;
 
     void startProcess();
-    void sendCommand(const QByteArray &cmd);
+    void sendCommand(const QByteArray &cmd) const;
 
     QString assistantPath;
     QString qhcPath;
@@ -81,7 +81,7 @@ void HelpControllerPrivate::startProcess()
     sendCommand("expandToc 2;");
 }
 
-void HelpControllerPrivate::sendCommand(const QByteArray &cmd)
+void HelpControllerPrivate::sendCommand(const QByteArray &cmd) const
 {
     if (!proc) {
         return;

--- a/ui/itemdelegate.cpp
+++ b/ui/itemdelegate.cpp
@@ -73,7 +73,7 @@ QString ItemDelegateInterface::defaultDisplayText(const QModelIndex &index) cons
     return display;
 }
 
-const QWidget *ItemDelegateInterface::widget(const QStyleOptionViewItem &option) const
+const QWidget *ItemDelegateInterface::widget(const QStyleOptionViewItem &option) 
 {
     const QStyleOptionViewItem &opt(option);
     return opt.widget;

--- a/ui/itemdelegate.h
+++ b/ui/itemdelegate.h
@@ -53,7 +53,7 @@ public:
 protected:
     QString defaultDisplayText(const QModelIndex &index) const;
 
-    const QWidget *widget(const QStyleOptionViewItem &option) const;
+    static const QWidget *widget(const QStyleOptionViewItem &option) ;
     QStyle *style(const QStyleOptionViewItem &option) const;
 
 private:

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -78,13 +78,13 @@ signals:
     void targetQuitRequested();
 
 private slots:
-    void help();
+    static void help();
     void configureFeedback();
     void about();
     void aboutPlugins();
     void aboutKDAB();
 
-    void showMessageStatistics();
+    static void showMessageStatistics();
 
     void toolSelected();
     bool selectTool(const QString &id);

--- a/ui/propertyeditor/propertyenumeditor.cpp
+++ b/ui/propertyeditor/propertyenumeditor.cpp
@@ -152,6 +152,7 @@ bool PropertyEnumEditorModel::setData(const QModelIndex &index, const QVariant &
             m_value.setValue(m_value.value() | elem.value());
         else if (value.toInt() == Qt::Unchecked)
             m_value.setValue(m_value.value() & ~elem.value());
+
         emit dataChanged(this->index(0,0), this->index(rowCount() - 1, 0)); // mask flags can change multiple rows
         return true;
     }

--- a/ui/tools/messagehandler/messagehandlerwidget.h
+++ b/ui/tools/messagehandler/messagehandlerwidget.h
@@ -52,7 +52,7 @@ public:
 private slots:
     void fatalMessageReceived(const QString &app, const QString &message, const QTime &time,
                               const QStringList &backtrace);
-    void copyToClipboard(const QString &message);
+    static void copyToClipboard(const QString &message);
     void messageContextMenu(const QPoint &pos);
     void stackTraceContextMenu(QPoint pos);
     void saveFileAllLogConfig();

--- a/ui/tools/resourcebrowser/resourcebrowserwidget.h
+++ b/ui/tools/resourcebrowser/resourcebrowserwidget.h
@@ -58,7 +58,7 @@ private slots:
     void setupLayout();
     void resourceDeselected();
     void resourceSelected(const QByteArray &contents, int line, int column);
-    void resourceDownloaded(const QString &targetFilePath, const QByteArray &contents);
+    static void resourceDownloaded(const QString &targetFilePath, const QByteArray &contents);
 
     void handleCustomContextMenu(const QPoint &pos);
 

--- a/ui/uistatemanager.cpp
+++ b/ui/uistatemanager.cpp
@@ -297,7 +297,7 @@ bool UIStateManager::eventFilter(QObject *object, QEvent *event)
     return result;
 }
 
-QString UIStateManager::widgetName(QWidget *widget) const
+QString UIStateManager::widgetName(QWidget *widget) 
 {
     return (widget->objectName().isEmpty()
             ? QString::fromLatin1(widget->metaObject()->className())
@@ -374,7 +374,7 @@ bool UIStateManager::checkWidget(QWidget *widget) const
     return true;
 }
 
-int UIStateManager::percentToInt(const QString &size) const
+int UIStateManager::percentToInt(const QString &size) 
 {
     return size.left(size.length() -1).toInt(); // clazy:exclude=qstring-ref due to Qt4 support
 }

--- a/ui/uistatemanager.h
+++ b/ui/uistatemanager.h
@@ -93,13 +93,13 @@ protected:
     ///@cond internal
     bool eventFilter(QObject *object, QEvent *event) override;
 
-    QString widgetName(QWidget *widget) const;
+    static QString widgetName(QWidget *widget) ;
     QString widgetPath(QWidget *widget) const;
     QString widgetGeometryKey(QWidget *widget) const;
     QString widgetStateKey(QWidget *widget) const;
     QString widgetStateSectionsKey(QWidget *widget) const;
     bool checkWidget(QWidget *widget) const;
-    int percentToInt(const QString &size) const;
+    static int percentToInt(const QString &size) ;
 
 protected slots:
     void restoreWindowState();


### PR DESCRIPTION
When writing code especially using clangd, there are a lot of warnings which make it hard to focus. This change addresses most of these.