### PR TITLE
In Positioning plugin, change Qt version check #ifdefs around changed…

### DIFF
--- a/plugins/positioning/geopositioninfosourcefactory.cpp
+++ b/plugins/positioning/geopositioninfosourcefactory.cpp
@@ -63,7 +63,7 @@ QGeoPositionInfoSource* GeoPositionInfoSourceFactory::positionInfoSource(QObject
 
     // filter anything not applicable
     for (auto it = indexes.begin(); it != indexes.end();) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
         const auto data = metaData.at(*it).toCbor();
 #else
         const auto data = metaData.at(*it).value(QStringLiteral("MetaData")).toObject();
@@ -79,7 +79,7 @@ QGeoPositionInfoSource* GeoPositionInfoSourceFactory::positionInfoSource(QObject
 
     // sort by priority
     std::sort(indexes.begin(), indexes.end(), [metaData](int lhs, int rhs) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
         const auto lData = metaData.at(lhs).toCbor();
         const auto rData = metaData.at(rhs).toCbor();
         return lData.value(QStringLiteral("Priority")).toInteger() > rData.value(QStringLiteral("Priority")).toInteger();
@@ -93,7 +93,7 @@ QGeoPositionInfoSource* GeoPositionInfoSourceFactory::positionInfoSource(QObject
     // actually try the plugins
     QGeoPositionInfoSource *source = nullptr;
     for (auto it = indexes.constBegin(); it != indexes.constEnd(); ++it) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
         const auto data = metaData.at(*it).toCbor();
 #else
         const auto data = metaData.at(*it).value(QStringLiteral("MetaData")).toObject();


### PR DESCRIPTION
In Positioning plugin (plugins/positioning/geopositioninfosourcefactory.cpp), change Qt version check #ifdefs around use of QFactoryLoader metadata object from >= 6.4.0, to >= 6.3.0 instead.

Fixes this compile error when using Qt 6.3.0:
````
plugins/positioning/geopositioninfosourcefactory.cpp:99:50: error: cannot convert ‘QString’ to ‘QtPluginMetaDataKeys’
````


I couldn't find any documentation of exactly what Qt release this change may have first appeared in, I just tested with 6.2.3 and 6.3.0.  