### PR TITLE
Detach probe on exit

### DIFF
--- a/ui/mainwindow.cpp
+++ b/ui/mainwindow.cpp
@@ -561,6 +561,12 @@ void MainWindow::navigateToCode(const QUrl &url, int lineNumber, int columnNumbe
     }
 }
 
+void MainWindow::closeEvent(QCloseEvent *e)
+{
+    detachProbe();
+    QMainWindow::closeEvent(e);
+}
+
 void MainWindow::logTransmissionRate(quint64 bytesRead, quint64 bytesWritten)
 {
     const double transmissionRateRX = (bytesRead * 8 / 1024.0 / 1024.0); // in Mpbs

--- a/ui/mainwindow.h
+++ b/ui/mainwindow.h
@@ -96,6 +96,9 @@ private slots:
     void logTransmissionRate(quint64 bytesRead, quint64 bytesWritten);
     void setCodeNavigationIDE(QAction *action);
 
+protected:
+    void closeEvent(QCloseEvent *) override;
+
 private:
     QWidget *createErrorPage(const QModelIndex &index);
 


### PR DESCRIPTION
When the client is gone the overlay widget is not useful anymore