### PR TITLE
multibuild/CMakeLists: Don't discard user CXXFLAGS

### DIFF
--- a/multibuild/CMakeLists.txt
+++ b/multibuild/CMakeLists.txt
@@ -30,6 +30,7 @@ ExternalProject_Add(
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
     -DBUILD_TESTING=OFF
     -DCMAKE_OBJECT_PATH_MAX=512
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
 )
 
 # hacky way to add a dependency from the default target to the build step


### PR DESCRIPTION
Previously, user-specified CXXFLAGS were discarded for the release
build. Now, they are passed through to the release build.

Fixes #693.