### PR TITLE
Fix bug wit unable to attach to a running application. (#655)

### DIFF
--- a/core/aggregatedpropertymodel.h
+++ b/core/aggregatedpropertymodel.h
@@ -35,6 +35,8 @@
 #include <QHash>
 #include <QVector>
 
+#include <unordered_map>
+
 namespace GammaRay {
 class PropertyAdaptor;
 class PropertyData;
@@ -81,7 +83,7 @@ private slots:
 
 private:
     PropertyAdaptor *m_rootAdaptor = nullptr;
-    mutable QHash<PropertyAdaptor *, QVector<PropertyAdaptor *> > m_parentChildrenMap;
+    mutable std::unordered_map<PropertyAdaptor *, QVector<PropertyAdaptor *> > m_parentChildrenMap;
     bool m_inhibitAdaptorCreation = false;
     bool m_readOnly = false;
 };


### PR DESCRIPTION
It's a problem related to `QHash` since it sometimes makes rehash when we insert a new value. Since `addPropertyAdaptor` updates `m_parentChildrenMap` we shouldn't save the reference before inserting new data because after rehash the reference becomes invalid.