### PR TITLE
Don't leak or crash when copying PaintBuffer

### DIFF
--- a/3rdparty/qt/5.5/private/qpaintbuffer.cpp
+++ b/3rdparty/qt/5.5/private/qpaintbuffer.cpp
@@ -211,7 +211,7 @@ QPaintBuffer &QPaintBuffer::operator=(const QPaintBuffer &other)
     if (other.d_ptr != d_ptr) {
         QPaintBufferPrivate *data = other.d_ptr;
         data->ref.ref();
-        if (d_ptr->ref.deref())
+        if (!d_ptr->ref.deref())
             delete d_ptr;
         d_ptr = data;
     }

--- a/core/paintbuffer.h
+++ b/core/paintbuffer.h
@@ -29,6 +29,8 @@
 #ifndef GAMMARAY_PAINTBUFFER_H
 #define GAMMARAY_PAINTBUFFER_H
 
+#include "gammaray_core_export.h"
+
 #include <config-gammaray.h>
 #include <common/objectid.h>
 #include <QVector>
@@ -104,7 +106,7 @@ private:
     GammaRay::PaintBuffer *m_buffer;
 };
 
-class PaintBuffer : public QPaintBuffer
+class GAMMARAY_CORE_EXPORT PaintBuffer : public QPaintBuffer
 {
 public:
     PaintBuffer();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -377,7 +377,8 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
       widgettest.cpp
       $<TARGET_OBJECTS:modeltestobj>
     )
-    target_link_libraries(widgettest gammaray_core Qt::Widgets)
+    target_link_libraries(widgettest gammaray_core Qt::Widgets Qt::WidgetsPrivate)
+    target_include_directories(widgettest PRIVATE ${CMAKE_SOURCE_DIR}/3rdparty/qt/5.5/)
 
     gammaray_add_probe_test(actiontest
       actiontest.cpp

--- a/tests/widgettest.cpp
+++ b/tests/widgettest.cpp
@@ -27,6 +27,7 @@
 #include "baseprobetest.h"
 
 #include <common/objectbroker.h>
+#include <core/paintbuffer.h>
 
 #include <3rdparty/qt/modeltest.h>
 
@@ -91,6 +92,13 @@ private slots:
         delete w3;
         QTest::qWait(1); // event loop re-entry
         QCOMPARE(visibleRowCount(model), 0);
+    }
+
+    void testPaintBuffer()
+    {
+        PaintBuffer buffer;
+        auto buffer2 = buffer;
+        buffer = PaintBuffer();
     }
 };
 


### PR DESCRIPTION
The operator= was not correctly implemented and would have
deleted the dptr under the wrong situations. This lead to either
crashes or leaks, depending on the usage. The new test e.g. would
crash in ASAN like this:

```
==323914==ERROR: AddressSanitizer: heap-use-after-free on address 0x610000006640 at pc 0x7f6eaeece687 bp 0x7fff018d94b0 sp 0x7fff018d94a0
WRITE of size 4 at 0x610000006640 thread T0
    #0 0x7f6eaeece686 in std::__atomic_base<int>::operator--() /usr/include/c++/12.1.0/bits/atomic_base.h:393
    #1 0x7f6eaeec4861 in bool QAtomicOps<int>::deref<int>(std::atomic<int>&) /usr/include/qt6/QtCore/qatomic_cxx11.h:287
    #2 0x7f6eaeeb8379 in QBasicAtomicInteger<int>::deref() /usr/include/qt6/QtCore/qbasicatomic.h:102
    #3 0x7f6eaf5e6108 in QPaintBuffer::~QPaintBuffer() /home/milian/projects/kdab/rnd/gammaray/3rdparty/qt/5.5/private/qpaintbuffer.cpp:152
    #4 0x7f6eaf3f5e6f in GammaRay::PaintBuffer::~PaintBuffer() /home/milian/projects/kdab/rnd/gammaray/core/paintbuffer.cpp:334
    #5 0x55c59788fbf4 in WidgetTest::testPaintBuffer() /home/milian/projects/kdab/rnd/gammaray/tests/widgettest.cpp:102
```

In a real app I saw leaks like this which now are also gone:

```
Direct leak of 448 byte(s) in 4 object(s) allocated from:
    #0 0x7fcf59ac0672 in operator new(unsigned long) /usr/src/debug/gcc/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x7fcebd341bfc in QPaintBuffer::QPaintBuffer() /home/milian/projects/kdab/rnd/gammaray/3rdparty/qt/5.5/private/qpaintbuffer.cpp:146
    #2 0x7fcebd2f6f32 in GammaRay::PaintBuffer::PaintBuffer() /home/milian/projects/kdab/rnd/gammaray/core/paintbuffer.cpp:321
    #3 0x7fcebd305191 in GammaRay::PaintAnalyzer::reset() /home/milian/projects/kdab/rnd/gammaray/core/paintanalyzer.cpp:94
```