### PR TITLE
Avoid overwriting with invalid contentType

### DIFF
--- a/plugins/network/networkreplymodel.cpp
+++ b/plugins/network/networkreplymodel.cpp
@@ -421,7 +421,8 @@ void NetworkReplyModel::updateReplyNode(QNetworkAccessManager* nam, const Networ
             (*replyIt).duration = newNode.duration > (*replyIt).duration ? newNode.duration - (*replyIt).duration : 0;
         }
         (*replyIt).size = std::max((*replyIt).size, newNode.size);
-        (*replyIt).contentType = newNode.contentType;
+        if (newNode.contentType != NetworkReply::Unknown)
+            (*replyIt).contentType = newNode.contentType;
 
         const auto idx = createIndex(std::distance(replyIt, (*namIt).replies.rend()) - 1, 0, std::distance(m_nodes.begin(), namIt));
         emit dataChanged(idx, idx.sibling(idx.row(), columnCount() - 1));


### PR DESCRIPTION
updateReplyNode is also called when a QNetworkReply is deleted. This is
the reason that properties such as displayName, response etc are only
conditionally updated. The same should apply to contentType otherwise
the JSON pretty printing does not work.