### PR TITLE
Optimize SignalHistoryModel

### DIFF
--- a/plugins/signalmonitor/signalhistorymodel.h
+++ b/plugins/signalmonitor/signalhistorymodel.h
@@ -99,11 +99,15 @@ private slots:
     void onObjectFavorited(QObject *object);
     void onObjectUnfavorited(QObject *object);
     void onSignalEmitted(QObject *sender, int signalIndex);
+    void insertPendingObjects();
 
 private:
     QVector<Item *> m_tracedObjects;
     QHash<QObject *, int> m_itemIndex;
     QSet<QObject*> m_favorites;
+
+    QTimer *m_delayInsertTimer;
+    QVector<Item*> m_objectsToBeInserted;
 };
 } // namespace GammaRay
 


### PR DESCRIPTION
When there are a lot of objects being added, SignalHistoryModel really
slows down the target. So, instead of adding rows one by one, add them
in groups with a delay.

Tested with nheko matrix client.