### PR TITLE
Clear DEBUGINFOD_URLS

### DIFF
--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -199,6 +199,8 @@ Probe::Probe(QObject *parent)
     , m_queueTimer(new QTimer(this))
     , m_server(nullptr)
 {
+    qputenv("DEBUGINFOD_URLS", QByteArray());
+
     Q_ASSERT(thread() == qApp->thread());
     IF_DEBUG(cout << "attaching GammaRay probe" << endl;)
 


### PR DESCRIPTION
On systems that have DEBUGINFOD_URLS set, starting gammaray often just
freezes the target because symbols are being downloaded.