### PR TITLE
Ignore event dispatcher signals

### DIFF
--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -89,6 +89,10 @@ QAtomicPointer<Probe> Probe::s_instance = QAtomicPointer<Probe>(nullptr);
 namespace GammaRay {
 static void signal_begin_callback(QObject *caller, int method_index, void **argv)
 {
+    // Ignore event dispatcher signals
+    if (caller->inherits("QAbstractEventDispatcher"))
+        return;
+
     if (method_index == 0 || !Probe::instance() || Probe::instance()->filterObject(caller))
         return;
 


### PR DESCRIPTION
There can be thousands of signals coming in from EventDispatchers and they are not useful for a normal app developer. 