### PR TITLE
Launcher page: explain why the error button is disabled

### DIFF
--- a/launcher/core/probeabi.cpp
+++ b/launcher/core/probeabi.cpp
@@ -222,7 +222,7 @@ ProbeABI ProbeABI::fromString(const QString &id)
 QString ProbeABI::displayString() const
 {
     if (!isValid())
-        return QString();
+        return ProbeABIContext::tr("Unknown ABI");
 
     QStringList details;
 #ifdef Q_OS_WIN

--- a/launcher/ui/launchpage.h
+++ b/launcher/ui/launchpage.h
@@ -58,6 +58,8 @@ private slots:
     void detectABI(const QString &path);
 
 private:
+    bool fileIsExecutable() const;
+
     static QStringList notEmptyString(const QStringList &list);
     Ui::LaunchPage *ui;
     QStringListModel *m_argsModel;

--- a/launcher/ui/launchpage.ui
+++ b/launcher/ui/launchpage.ui
@@ -151,6 +151,16 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QLabel" name="errorLabel">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Sometimes is not trivial to realize that the ABI for the binary you're trying to launch is not available