### PR TITLE
QuickInspector: Add UnsupportedScreenGrabber

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -1146,7 +1146,12 @@ static const MetaEnum::Value<QSGRendererInterface::GraphicsApi> qsg_graphics_api
     E(Direct3D12), // Should just remove this? See QTBUG-79925
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
-    E(OpenVG)
+    E(OpenVG),
+#endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    E(Direct3D11),
+    E(Vulkan),
+    E(Metal),
 #endif
 };
 

--- a/plugins/quickinspector/quickscreengrabber.h
+++ b/plugins/quickinspector/quickscreengrabber.h
@@ -118,8 +118,13 @@ public:
         enum GraphicsApi {
             Unknown = 0,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            Software = 1,
-            OpenGL = 3
+            Software,
+            OpenVG,
+            OpenGL,
+            Direct3D11,
+            Vulkan,
+            Metal,
+            Null,
 #else
             Software,
             OpenGL,
@@ -233,6 +238,24 @@ private:
     QSGSoftwareRenderer *softwareRenderer() const;
 
     bool m_isGrabbing = false;
+    QPointF m_lastItemPosition;
+};
+#endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+class UnsupportedScreenGrabber : public AbstractScreenGrabber
+{
+    Q_OBJECT
+public:
+    explicit UnsupportedScreenGrabber(QQuickWindow *window);
+    ~UnsupportedScreenGrabber() override;
+
+    void requestGrabWindow(const QRectF &userViewport) override;
+    void drawDecorations() override;
+
+private:
+    void updateOverlay() override;
+
     QPointF m_lastItemPosition;
 };
 #endif


### PR DESCRIPTION
With Qt6 there are a lot more backends and on Windows/Mac Qt can default
to a backend other than opengl which can confuse the user. The
unsupported backend shows a helpful message to the user so that they
can change the backend and use the live view