### PR TITLE
3rdparty/qt/resourcemodel: remove stray QT_MODULE

### DIFF
--- a/3rdparty/qt/resourcemodel.h
+++ b/3rdparty/qt/resourcemodel.h
@@ -45,8 +45,6 @@
 #include <QtCore/qabstractitemmodel.h>
 #include <QtCore/qdir.h>
 
-QT_MODULE(Gui)
-
 namespace GammaRay {
 
 class ResourceModelPrivate;


### PR DESCRIPTION
Since qtbase 4ecf82795de54fba530ac9c386f3afff2174edbd, use of QT_MODULE was essentially deprecated (12 years ago!). In 6.5 prelease, it was removed completely in qtbase 8446655f24c38d2d52f56d0369182895b6306026. The macro never did anything and is thus safe to remove.