### PR TITLE
Pan with Middle mouse button in remote view

### DIFF
--- a/ui/remoteviewwidget.h
+++ b/ui/remoteviewwidget.h
@@ -229,6 +229,7 @@ private:
     QPointF m_currentMousePosition; // in view coordinates
     QPoint m_measurementStartPosition; // in source coordinates
     QPoint m_measurementEndPosition; // in source coordinates
+    QCursor m_cursorBeforeMmbPan;
     bool m_hasMeasurement;
     ObjectIdsFilterProxyModel *m_pickProxyModel;
     VisibilityFilterProxyModel *m_invisibleItemsProxyModel;


### PR DESCRIPTION
Allow panning with middle mouse button regardless of the current interaction mode.

This reduces the need to switch the interaction mode in the remote view when the area where the user wants to look at is out of the view.