### PR TITLE
Fix crash when using the software renderer

### DIFF
--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -763,7 +763,7 @@ void SoftwareScreenGrabber::drawDecorations()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 9, 3)
     auto renderer = softwareRenderer();
-    if (!renderer)
+    if (!renderer || !renderer->currentPaintDevice())
         return;
     QPainter p(renderer->currentPaintDevice());
     p.setClipRegion(renderer->flushRegion());


### PR DESCRIPTION
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==84890==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000111d654b0 bp 0x00016dbf8120 sp 0x00016dbf8020 T0)
==84890==The signal is caused by a UNKNOWN memory access.
==84890==Hint: address points to the zero page.
    #0 0x111d654b0 in QPainterPrivate::attachPainterPrivate(QPainter*, QPaintDevice*) qpainter.cpp:242
    #1 0x111d6931c in QPainter::QPainter(QPaintDevice*) qpainter.cpp:1466
    #2 0x12bc00dd8 in GammaRay::SoftwareScreenGrabber::drawDecorations()+0x168 (gammaray_quickinspector.so:arm64+0x48dd8)
    #3 0x12bc004f4 in GammaRay::SoftwareScreenGrabber::windowAfterRendering()+0x34 (gammaray_quickinspector.so:arm64+0x484f4)
    #4 0x1142334e4 in void doActivate<true>(QObject*, int, void**) qobject.cpp:3972
    #5 0x112547b78 in QQuickWindowPrivate::renderSceneGraph(QSize const&, QSize const&) qquickwindow.cpp:664
    #6 0x1125669ac in QSGSoftwareRenderLoop::renderWindow(QQuickWindow*, bool) qsgsoftwarerenderloop.cpp:142
    #7 0x11254a7f4 in QQuickWindow::event(QEvent*) qquickwindow.cpp
    #8 0x1141eb3f8 in QCoreApplicationPrivate::notify_helper(QObject*, QEvent*) qcoreapplication.cpp:1193
    #9 0x1141eaf60 in QCoreApplication::notifyInternal2(QObject*, QEvent*) qcoreapplication.cpp:1026
    #10 0x111ca8620 in QPlatformWindow::deliverUpdateRequest() qplatformwindow.cpp:774
    #11 0x119dc7e30 in QCocoaWindow::deliverUpdateRequest() qcocoawindow.mm:1581
    #12 0x119db37bc in QCocoaScreen::deliverUpdateRequests() qcocoascreen.mm:454
```