### PR TITLE
Make it possible to start Qt 6 Mac applications

### DIFF
--- a/launcher/core/probeabidetector.cpp
+++ b/launcher/core/probeabidetector.cpp
@@ -37,7 +37,7 @@ ProbeABI ProbeABIDetector::abiForExecutable(const QString &path) const
     // they want to run
     for (const ProbeABI &abi : abis) {
         if (abi.architecture() == QSysInfo::currentCpuArchitecture()) {
-                return abi;
+            return abi;
         }
     }
     return abis[0];
@@ -53,7 +53,7 @@ ProbeABI ProbeABIDetector::abiForProcess(qint64 pid) const
     // forced to run a particular abi if the OS supports so
     for (const ProbeABI &abi : abis) {
         if (abi.architecture() == QSysInfo::currentCpuArchitecture()) {
-                return abi;
+            return abi;
         }
     }
     return abis[0];

--- a/launcher/core/probeabidetector.h
+++ b/launcher/core/probeabidetector.h
@@ -56,19 +56,19 @@ private:
     /*! Returns the ABI of the given QtCore DLL.
      *  Implementation of abiForXXX() should call this as it implements caching.
      */
-    ProbeABI abiForQtCore(const QString &path) const;
+    QVector<ProbeABI> abiForQtCore(const QString &path) const;
 
     /*! Detect the ABI of the given QtCore DLL.
      *  This needs to be implemented for every platform.
      */
-    static ProbeABI detectAbiForQtCore(const QString &path);
+    static QVector<ProbeABI> detectAbiForQtCore(const QString &path);
 
     /*! Path to the QtCore DLL for @p pid, using the lsof tool
      *  on UNIX-like systems.
      */
     static QString qtCoreFromLsof(qint64 pid);
 
-    mutable QHash<QString, ProbeABI> m_abiForQtCoreCache;
+    mutable QHash<QString, QVector<ProbeABI>> m_abiForQtCoreCache;
 };
 }
 

--- a/launcher/core/probeabidetector_dummy.cpp
+++ b/launcher/core/probeabidetector_dummy.cpp
@@ -35,8 +35,8 @@ QString ProbeABIDetector::qtCoreForProcess(quint64 pid) const
     return QString();
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
+QVector<ProbeABI> ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     Q_UNUSED(path);
-    return ProbeABI::fromString(GAMMARAY_PROBE_ABI);
+    return { ProbeABI::fromString(GAMMARAY_PROBE_ABI) };
 }

--- a/launcher/core/probeabidetector_elf.cpp
+++ b/launcher/core/probeabidetector_elf.cpp
@@ -175,10 +175,10 @@ static QString archFromELF(const QString &path)
     return QString();
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
+QVector<ProbeABI> ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     if (path.isEmpty())
-        return ProbeABI();
+        return {};
 
     // try to find the version
     ProbeABI abi = qtVersionFromFileName(path);
@@ -189,5 +189,5 @@ ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
     const QString arch = archFromELF(path);
     abi.setArchitecture(arch);
 
-    return abi;
+    return {abi};
 }

--- a/launcher/core/probeabidetector_elf.cpp
+++ b/launcher/core/probeabidetector_elf.cpp
@@ -189,5 +189,5 @@ QVector<ProbeABI> ProbeABIDetector::detectAbiForQtCore(const QString &path)
     const QString arch = archFromELF(path);
     abi.setArchitecture(arch);
 
-    return {abi};
+    return { abi };
 }

--- a/launcher/core/probeabidetector_mac.cpp
+++ b/launcher/core/probeabidetector_mac.cpp
@@ -218,8 +218,7 @@ static QVector<ProbeABI> abiFromMachO(const QString &path, const uchar *data, qi
     const quint32 magic = *reinterpret_cast<const quint32 *>(data);
 
     switch (magic) {
-    case FAT_CIGAM:
-    {
+    case FAT_CIGAM: {
         const fat_header *header = reinterpret_cast<const fat_header *>(data);
         for (unsigned long i = 0; i < OSSwapInt32(header->nfat_arch); ++i) {
             const fat_arch *arch_header = reinterpret_cast<const fat_arch *>(data + sizeof(fat_header) + sizeof(fat_arch) * i);

--- a/launcher/core/probeabidetector_win.cpp
+++ b/launcher/core/probeabidetector_win.cpp
@@ -268,5 +268,5 @@ QVector<ProbeABI> ProbeABIDetector::detectAbiForQtCore(const QString &path)
         abi.setCompilerVersion(compilerVersionFromLibraries(libs));
     }
 
-    return {abi};
+    return { abi };
 }

--- a/launcher/core/probeabidetector_win.cpp
+++ b/launcher/core/probeabidetector_win.cpp
@@ -238,27 +238,27 @@ static bool isDebugBuild(const QString &qtCoreDll)
     return qtCoreDll.endsWith(QLatin1String("d.dll"), Qt::CaseInsensitive);
 }
 
-ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
+QVector<ProbeABI> ProbeABIDetector::detectAbiForQtCore(const QString &path)
 {
     ProbeABI abi;
     if (path.isEmpty())
-        return abi;
+        return {};
 
     Version version = fileVersion(path);
     if (version.major == -1)
-        return abi;
+        return {};
 
     abi.setQtVersion(version.major, version.minor);
 
     // architecture and dependent libraries
     PEFile f(path);
     if (!f.isValid())
-        return ProbeABI();
+        return {};
 
     // architecture
     abi.setArchitecture(f.architecture());
     if (abi.architecture().isEmpty())
-        return ProbeABI();
+        return {};
 
     // compiler and debug mode
     QStringList libs = f.imports();
@@ -268,5 +268,5 @@ ProbeABI ProbeABIDetector::detectAbiForQtCore(const QString &path)
         abi.setCompilerVersion(compilerVersionFromLibraries(libs));
     }
 
-    return abi;
+    return {abi};
 }


### PR DESCRIPTION
Qt 6 libs are now fat libraries, i.e. they contain both the amd64 and the arm64 libraries inside, so we need a way to say that a given Qt supports more than one architecture.