### PR TITLE
Add LSP/clangd stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ CMakeLists.txt.user
 *.qmlc
 callgrind.out.*
 perf.data*
+/compile_commands.json
+.cache
 
 # from kdiff3
 *.BACKUP.*


### PR DESCRIPTION
Useful for kdesrc-build setup as well as for other forms of linking compile_commands.json into source directory.