### PR TITLE
Add zsh completions (compdef) for gammaray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,6 +732,8 @@ else()
         CACHE PATH "Install location of Qt Assistant help files."
     )
     gammaray_convert_to_relative_path(QCH_INSTALL_DIR)
+    set(ZSHAUTOCOMPLETE_INSTALL_DIR "${DATAROOTDIR}/zsh/site-functions")
+
     if(WIN32)
         set(PLUGIN_INSTALL_DIR "plugins/gammaray")
         set(LIBEXEC_INSTALL_DIR "${BIN_INSTALL_DIR}")

--- a/launcher/cli/CMakeLists.txt
+++ b/launcher/cli/CMakeLists.txt
@@ -32,6 +32,13 @@ gammaray_set_rpath(gammaray ${BIN_INSTALL_DIR})
 install(
     TARGETS gammaray ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
+if(ZSHAUTOCOMPLETE_INSTALL_DIR)
+    install(
+        FILES completions/gammaray.zsh
+        RENAME _gammaray
+        DESTINATION ${ZSHAUTOCOMPLETE_INSTALL_DIR}
+    )
+endif()
 if(MSVC)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:gammaray>/$<TARGET_PDB_FILE_NAME:gammaray>"

--- a/launcher/cli/completions/gammaray.zsh
+++ b/launcher/cli/completions/gammaray.zsh
@@ -1,0 +1,90 @@
+#compdef gammaray
+
+# This file is part of GammaRay, the Qt application inspection and manipulation tool.
+#
+# SPDX-FileCopyrightText: 2013-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# Author: ivan tkachenko <me@ratijas.tk>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later OR LicenseRef-KDAB-GammaRay
+#
+# Licensees holding valid commercial KDAB GammaRay licenses may use this file in
+# accordance with GammaRay Commercial License Agreement provided with the Software.
+#
+# Contact info@kdab.com if any conditions of this licensing are not clear to you.
+
+function _gammaray-probe() {
+  local -a probes names descriptions
+
+  probes=( ${(f)"$(_call_program gammaray-probes $service --list-probes)"} )
+  names=( ${probes%% *} )
+  descriptions=( ${${probes#* \(}%\)} )
+
+  _describe -t probe 'probe' \
+    descriptions names
+}
+
+function _gammaray-injector() {
+  local -a injectors=( gdb lldb style preload windll )
+  local expl
+
+  _wanted injector expl 'injector' \
+    compadd -- $injectors
+}
+
+function _gammaray-listen() {
+  local -a addresses=( 'tcp://0.0.0.0' 'tcp://[::]' )
+  local expl
+
+  if (( $+commands[ip] && $+commands[jq] )); then
+    addresses+=( ${(f)"$(
+      ip -j a |
+      jq --raw-output '
+        .[].addr_info[] |
+        if .family == "inet"
+          then "tcp://\(.local)"
+        elif .family == "inet6"
+          then "tcp://[\(.local)]"
+        else null end
+      '
+    )"} )
+  else
+    addresses+=( 'tcp://127.0.0.1' )
+  fi
+
+  # sanitize special characters
+  addresses=( ${addresses//:/\:} )
+
+  _wanted address expl 'address' \
+    compadd -- $addresses
+}
+
+function _gammaray-host-port() {
+  if compset -P '*://*:' ; then
+    _numbers -t port port
+  elif compset -P '*://' ; then
+    _hosts -qS:
+  else
+    compadd -S "" 'tcp://'
+  fi
+}
+
+_arguments \
+  '(* -)--list-probes[list all installed probes]' \
+  '--probe[specify which probe to use]:abi:_gammaray-probe' \
+  '(-i --injector)'{-i,--injector}'[set injection type]:injector:_gammaray-injector' \
+  '--self-test[run self tests, of everything or the specified injector]::injector:_gammaray-injector' \
+  '(-o --injector-override)'{-o,--injector-override}'[Override the injector executable if handled (requires -i/--injector)]:executable: _command_names -e' \
+  "--inject-only[only inject the probe, don't show the UI]" \
+  '(--inprocess --listen)--inprocess[use in-process UI]' \
+  '(--inprocess --listen --no-listen)--listen[specify the address the server should listen on]:address:_gammaray-listen' \
+  '(--inprocess --listen --no-listen)--no-listen[disables remote access entirely (implies --inprocess)]' \
+  - '(H)' \
+    '(* -)'{-h,--help}'[print program help and exit]' \
+    '(* -)'{-v,--version}'[print program version and exit]' \
+  - pid \
+    '--pid[attach to running Qt application]:pid:_pids' \
+  - connect \
+    '--connect[connect to an already injected target]:host[\:port]:_gammaray-host-port' \
+  - application \
+    ':program: _command_names -e' \
+    '*::program arguments: _normal'


### PR DESCRIPTION
This patch brings zsh completions for every option documented in `--help` output of GammaRay.

![image](https://user-images.githubusercontent.com/6737986/210473290-e461aa5c-a19f-4c7d-a600-59b80ad434b4.png)

![image](https://user-images.githubusercontent.com/6737986/210474243-7eaed20f-f56f-41a9-b92f-74e93a11affe.png)

Features:
- [x] completions for probes with displayed human-readable descriptions while completing actual names;
- [x] basic completions for probes (there's no CLI to fetch list of valid probes for current platform though)
- [x] listen & connect addresses are handled separately, for better or worse;
- [x] `--pid`, `--connect` & `<application> <args>` are actually mutually exclusive. Typing one onto the command line prevents others from being considered for completions.
- [x] `<args>` are completed as normal arguments for any "completable"  `<application>`.

I might need help with CMake stuff for cross-platform. Specifically, I have no idea where to install this compdef on OS X.