### PR TITLE
Provide gdb errors to the user

### DIFF
--- a/launcher/core/injector/debuggerinjector.cpp
+++ b/launcher/core/injector/debuggerinjector.cpp
@@ -244,5 +244,8 @@ void DebuggerInjector::processLog(DebuggerInjector::Orientation orientation, boo
             std::cerr << qPrintable(output) << std::endl;
         else
             std::cout << qPrintable(output) << std::endl;
+    } else {
+        if (isError)
+            std::cerr << qPrintable(text.trimmed()) << std::endl;
     }
 }


### PR DESCRIPTION
Attaching to a running process after it got recompiled can fail, but it used to just fail silently.

If the user sees those errors, then it's clearer what the problem is:

Error reading attached process's symbol file.
warning: .dynamic section for "libFooBar.so" is not at the expected address (wrong library or version mismatch?)
: No such file or directory.
No symbol "dlopen" in current context.
Error reading attached process's symbol file.
: No such file or directory.
No symbol "gammaray_probe_attach" in current context.

It's a bit verbose, but at least it's clear that attaching failed. On success, there's no output.