### PR TITLE
ModelModel: ignore models that belong to other threads

### DIFF
--- a/plugins/modelinspector/modelmodel.cpp
+++ b/plugins/modelinspector/modelmodel.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "modelmodel.h"
+#include <QThread>
 
 using namespace GammaRay;
 
@@ -74,6 +75,9 @@ QModelIndex ModelModel::index(int row, int column, const QModelIndex &parent) co
 
 void ModelModel::objectAdded(QObject *obj)
 {
+    if (obj->thread() != QThread::currentThread()) { // ignore models in secondary threads, they can be deleted at any time
+        return;
+    }
     QAbstractProxyModel *proxy = qobject_cast<QAbstractProxyModel *>(obj);
     if (proxy) {
         beginResetModel(); // FIXME


### PR DESCRIPTION
They can be deleted at any point in time, crashing ModelModel when it tries to access the model, e.g. in
QAbstractProxyModel::sourceModel().

There's no safe way to do this, so just don't show those models (which can only be used for calculations, not for display, anyway)