### PR TITLE
Show potential launcher errors in a message box

### DIFF
--- a/launcher/cli/main.cpp
+++ b/launcher/cli/main.cpp
@@ -32,6 +32,7 @@
 
 #ifdef HAVE_QT_WIDGETS
 #include <QApplication>
+#include <QMessageBox>
 #else
 #include <QCoreApplication>
 #endif
@@ -330,10 +331,20 @@ int main(int argc, char **argv)
     }
 
     Launcher launcher(options);
-    QObject::connect(&launcher, SIGNAL(finished()), &app, SLOT(quit()));
-    QObject::connect(&launcher, SIGNAL(attached()), &app, SLOT(quit()));
-    if (!launcher.start())
+    if (!launcher.start()) {
+        #ifdef HAVE_QT_WIDGETS
+                QMessageBox errorBox;
+                errorBox.setWindowTitle("Launcher Error");
+                errorBox.setIcon(QMessageBox::Icon::Critical);
+                errorBox.setTextFormat(Qt::MarkdownText);
+                errorBox.setText(launcher.errorMessage() + "\nSee https://github.com/KDAB/GammaRay/wiki/Known-Issues for troubleshooting");
+                errorBox.exec();
+        #endif
         return launcher.exitCode();
+    } else {
+        QObject::connect(&launcher, SIGNAL(finished()), &app, SLOT(quit()));
+        QObject::connect(&launcher, SIGNAL(attached()), &app, SLOT(quit()));
+    }
     auto result = app.exec();
     return result == 0 ? launcher.exitCode() : result;
 }

--- a/launcher/cli/main.cpp
+++ b/launcher/cli/main.cpp
@@ -332,14 +332,14 @@ int main(int argc, char **argv)
 
     Launcher launcher(options);
     if (!launcher.start()) {
-        #ifdef HAVE_QT_WIDGETS
-                QMessageBox errorBox;
-                errorBox.setWindowTitle("Launcher Error");
-                errorBox.setIcon(QMessageBox::Icon::Critical);
-                errorBox.setTextFormat(Qt::MarkdownText);
-                errorBox.setText(launcher.errorMessage() + "\nSee https://github.com/KDAB/GammaRay/wiki/Known-Issues for troubleshooting");
-                errorBox.exec();
-        #endif
+#ifdef HAVE_QT_WIDGETS
+        QMessageBox errorBox;
+        errorBox.setWindowTitle("Launcher Error");
+        errorBox.setIcon(QMessageBox::Icon::Critical);
+        errorBox.setTextFormat(Qt::MarkdownText);
+        errorBox.setText(launcher.errorMessage() + "\nSee https://github.com/KDAB/GammaRay/wiki/Known-Issues for troubleshooting");
+        errorBox.exec();
+#endif
         return launcher.exitCode();
     } else {
         QObject::connect(&launcher, SIGNAL(finished()), &app, SLOT(quit()));

--- a/launcher/core/launcher.cpp
+++ b/launcher/core/launcher.cpp
@@ -157,7 +157,7 @@ bool Launcher::start()
         Q_ASSERT(!errorStrings.isEmpty());
         std::cerr << "Potential errors:" << std::endl;
         for (const QString &errorString : qAsConst(errorStrings)) {
-            std::cerr << "  Error: " << qPrintable(errorString) << std::endl;
+            injectorError(-1, errorString);
         }
         std::cerr << std::endl;
 
@@ -172,6 +172,8 @@ bool Launcher::start()
         } else {
             injectorError(-1, tr("Injector %1 not found.").arg(d->options.injectorType()));
         }
+        std::cerr << "See <https://github.com/KDAB/GammaRay/wiki/Known-Issues> for troubleshooting"
+                  << std::endl;
         return false;
     }
 
@@ -213,6 +215,8 @@ bool Launcher::start()
             errorMessage += tr("\nError: %1").arg(d->injector->errorString());
         }
         injectorError(d->injector->exitCode() ? d->injector->exitCode() : 1, errorMessage);
+        std::cerr << "See <https://github.com/KDAB/GammaRay/wiki/Known-Issues> for troubleshooting"
+                  << std::endl;
         return false;
     }
     return true;
@@ -300,12 +304,11 @@ void Launcher::injectorFinished()
 void Launcher::injectorError(int exitCode, const QString &errorMessage)
 {
     d->exitCode = exitCode;
-    d->errorMessage = errorMessage;
+    d->errorMessage += errorMessage + "\n\n";
 
     d->state |= InjectorFailed;
     std::cerr << qPrintable(errorMessage) << std::endl;
-    std::cerr << "See <https://github.com/KDAB/GammaRay/wiki/Known-Issues> for troubleshooting"
-              << std::endl;
+
     checkDone();
 }
 


### PR DESCRIPTION
A common thing I run into is trying to launch GammaRay and when injecting, it suddenly closes. This is because injector errors are printed into console instead of the gui, even when launched via it. These are the same potential launcher errors found under Self-Test, but those are easily missable. Now, if built with Qt Widgets - the injector will display a message box showing the errors it has collected:

![image](https://user-images.githubusercontent.com/54911369/219403462-dadfe11b-c665-47bf-883a-dc6c884c69a7.png)

To do this, I made `Launcher::injectorError()` stack every error it has collected, and moved around some of the logging (like printing out potential launcher errors, because calling `injectorError()` will handle that for us). I'm not too happy with copy & pasting around the troubleshooting lines (because `injectorError()` could be called multiple times), but I'm not sure if it's worth adding a new function for. 