### PR TITLE
Fix GAMMARAY_CLIENT_ONLY_BUILD

### DIFF
--- a/plugins/qmlsupport/CMakeLists.txt
+++ b/plugins/qmlsupport/CMakeLists.txt
@@ -33,10 +33,11 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
         Qt::Qml
         Qt::QmlPrivate
     )
-endif()
 
-if(NOT QtQml_VERSION VERSION_LESS 5.10 OR TARGET Qt6::Qml)
-    target_sources(gammaray_qmlsupport PUBLIC qmlbindingprovider.cpp)
+    if(NOT QtQml_VERSION VERSION_LESS 5.10 OR TARGET Qt6::Qml)
+        target_sources(gammaray_qmlsupport PUBLIC qmlbindingprovider.cpp)
+    endif()
+
 endif()
 
 # ui plugin

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,15 +234,15 @@ target_link_libraries(
     metaobjecttest gammaray_core
 )
 
-gammaray_add_probe_test(problemreportertest problemreportertest.cpp $<TARGET_OBJECTS:modeltestobj>)
-target_link_libraries(
-    problemreportertest gammaray_core
-)
-if(TARGET Qt::Qml)
-    target_link_libraries(problemreportertest Qt::Qml)
-endif()
-if(TARGET Qt::Widgets)
-    target_link_libraries(problemreportertest Qt::Widgets)
+if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
+    gammaray_add_probe_test(problemreportertest problemreportertest.cpp $<TARGET_OBJECTS:modeltestobj>)
+    target_link_libraries(problemreportertest gammaray_core)
+    if(TARGET Qt::Qml)
+        target_link_libraries(problemreportertest Qt::Qml)
+    endif()
+    if(TARGET Qt::Widgets)
+        target_link_libraries(problemreportertest Qt::Widgets)
+    endif()
 endif()
 
 gammaray_add_test(objectinstancetest objectinstancetest.cpp)
@@ -265,10 +265,10 @@ if(HAVE_QT_WIDGETS)
     target_link_libraries(enumpropertytest gammaray_core Qt::Gui Qt::Widgets)
 endif()
 
-gammaray_add_probe_test(propertymodeltest propertymodeltest.cpp $<TARGET_OBJECTS:modeltestobj>)
-target_link_libraries(
-    propertymodeltest gammaray_core gammaray_shared_test_data
-)
+if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
+    gammaray_add_probe_test(propertymodeltest propertymodeltest.cpp $<TARGET_OBJECTS:modeltestobj>)
+    target_link_libraries(propertymodeltest gammaray_core gammaray_shared_test_data)
+endif()
 
 gammaray_add_test(qmetaobjectvalidatortest qmetaobjectvalidatortest.cpp)
 target_link_libraries(


### PR DESCRIPTION
The `target_sources(gammaray_qmlsupport ...)` call needs to be inside the `if(NOT GAMMARAY_CLIENT_ONLY_BUILD)`, because that target won't be defined during a client-only build.

Currently, attempting a `GAMMARAY_CLIENT_ONLY_BUILD` on Qt6 with `Qt6::Qml` available results in:

```text
CMake Error at plugins/qmlsupport/CMakeLists.txt:42 (target_sources):
  Cannot specify sources for target "gammaray_qmlsupport" which is not built
  by this project.
```

Fixes #766 