### PR TITLE
Fix CI by switching to JS markdownlint, adding override comment to README

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,3 @@
+{
+  "MD029": { "style": "ordered" }
+}

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,0 @@
-style ".mdlrc.rb"

--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -1,4 +1,0 @@
-all
-rule 'MD013', :line_length => 100, :tables => false
-rule 'MD029', :style => :ordered
-exclude_rule 'MD033'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,10 @@ repos:
     exclude: (cmake/Toolchain-QNX|.py.cmake|.h.cmake|.rc.cmake|Doxyfile.cmake|gammaray.qhcp.cmake)
   - id: cmake-format
     exclude: (cmake/Toolchain-QNX|.py.cmake|.h.cmake|.rc.cmake|Doxyfile.cmake|gammaray.qhcp.cmake)
-- repo: https://github.com/markdownlint/markdownlint
-  rev: v0.12.0
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  rev: v0.6.0
   hooks:
-  - id: markdownlint
-    entry: mdl
-    language: ruby
+  - id: markdownlint-cli2
     files: \.(md|mdown|markdown)$
 - repo: https://github.com/fsfe/reuse-tool
   rev: v1.0.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 # Installing GammaRay
 
-Please see the comments at the top of CMakeLists.txt for the available configuration options
-you can pass to CMake.
+Please see the comments at the top of CMakeLists.txt for the available
+configuration options you can pass to CMake.
 
 ## Requirements
 
@@ -20,7 +20,8 @@ i.e. when using distro provided Qt make sure you have (or the equivalent for Qt6
 
 - Redhat,Fedora: qt5-qtbase-private-devel
 - Debian,Ubuntu: qtbase5-private-dev qtdeclarative5-private-dev
-- SUSE: libqt5-qtbase-private-headers-devel libqt5-qtdeclarative-private-headers-devel
+- SUSE: libqt5-qtbase-private-headers-devel
+  libqt5-qtdeclarative-private-headers-devel
 
 Optional FOSS packages (eg. KDSME, etc) provide extra functionality.
 See the "Optional Dependencies" section below for more details.
@@ -33,46 +34,48 @@ Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
 Adapt the instructions to suit your cmake generator and operating system.
 
 ```bash
-    cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/path/where/to/install ../path/to/gammaray
-    cmake --build .
-    cmake --build . --target install
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/where/to/install ../path/to/gammaray
+cmake --build .
+cmake --build . --target install
 ```
 
-Your system's installation of Qt will be used by default, which may not be the same as
-the Qt returned by `qmake -v`.  To specify the Qt version to build against use the
-CMake option `CMAKE_PREFIX_PATH` and point it to the folder of your installation:
+Your system's installation of Qt will be used by default, which may not be the
+same as the Qt returned by `qmake -v`.  To specify the Qt version to build
+against use the CMake option `CMAKE_PREFIX_PATH` and point it to the folder of
+your installation:
 
 For example:
 
 ```bash
-    cmake -DCMAKE_PREFIX_PATH=$HOME/Qt/5.11.2/gcc_64 ..
+cmake -DCMAKE_PREFIX_PATH=$HOME/Qt/5.11.2/gcc_64 ..
 ```
 
 or
 
 ```bash
-    set CMAKE_PREFIX_PATH=c:\Qt\5.15.4\msvc2019_64
-    cmake...
+set CMAKE_PREFIX_PATH=c:\Qt\5.15.4\msvc2019_64
+cmake...
 ```
 
-The installation directory defaults to `/usr/local` on UNIX `C:/Program Files` on Windows
-and `/Applications` on MacOS.
+The installation directory defaults to `/usr/local` on UNIX `C:/Program Files`
+on Windows and `/Applications` on MacOS.
 
-Change the installation location by passing the option `-DCMAKE_INSTALL_PREFIX=/install/path` to CMake.
+Change the installation location by passing the option
+`-DCMAKE_INSTALL_PREFIX=/install/path` to CMake.
 
 ### Android
 
 Build on Android:
 
 ```bash
-    mkdir android-build
-    cd android-build
-    export ANDROID_NDK=/path/to/android-ndk
-    cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
-          -DCMAKE_FIND_ROOT_PATH=/android/qt5/install/path \
-          -DCMAKE_INSTALL_PREFIX=/install/path ..
-    make [-j CPU_NUMBER+2]
-    make install
+mkdir android-build
+cd android-build
+export ANDROID_NDK=/path/to/android-ndk
+cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+      -DCMAKE_FIND_ROOT_PATH=/android/qt5/install/path \
+      -DCMAKE_INSTALL_PREFIX=/install/path ..
+make [-j CPU_NUMBER+2]
+make install
 ```
 
 For more information about building CMake projects on Android see
@@ -82,34 +85,37 @@ Using GammaRay on Android:
 
 - add GammaRay probe to your android .pro file
 
-```text
-    myproject.pro
-    ....
-    android: QT += GammaRayProbe
-    ...
-```
+  ```text
+  myproject.pro
+  ....
+  android: QT += GammaRayProbe
+  ...
+  ```
 
 - build & deploy and run your project
 - forward GammaRay's socket
 
-```bash
-    adb forward tcp:11732 localfilesystem:/data/data/YOUR_ANDROID_PACKAGE_NAME(e.g. com.kdab.example)/files/+gammaray_socket
-````
+  ```bash
+  adb forward tcp:11732 \
+   localfilesystem:/data/data/YOUR_ANDROID_PACKAGE_NAME/files/+gammaray_socket
+  ```
+
+  Where `YOUR_ANDROID_PACKAGE_NAME` is e.g. `com.kdab.example`.
 
 - run GammaRay GUI and connect to localhost:11732
 - after you've finished, remove the forward:
 
-```bash
-    adb forward --remove tcp:11732
-```
+  ```bash
+  adb forward --remove tcp:11732
+  ```
 
-or
+  or
 
-```bash
-    adb forward --remove-all
-```
+  ```bash
+  adb forward --remove-all
+  ```
 
-... to remove all forwards
+  ... to remove all forwards
 
 ### Additional notes
 
@@ -120,25 +126,27 @@ To build a debug version pass `-DCMAKE_BUILD_TYPE=Debug` to cmake.
 You'll find more information on this in the wiki:
 <https://github.com/KDAB/GammaRay/wiki/Cross-compiling-GammaRay>
 
-== Force a probe only build ==
-If you already built GammaRay in the past and that you want to support more probes,
-you don't need to rebuild entirely GammaRay for this specific Qt version.
-You can instead just build the GammaRay probe for the new Qt version and install it
-in you previous GammaRay installation.
+## Force a probe only build
+
+If you already built GammaRay in the past and that you want to support more
+probes, you don't need to rebuild entirely GammaRay for this specific Qt
+version. You can instead just build the GammaRay probe for the new Qt version
+and install it in you previous GammaRay installation.
 
 You can make probe only builds that way:
 
 ```bash
-    cmake \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_PREFIX_PATH=/path/to/Qt/version/ \
-        -DGAMMARAY_PROBE_ONLY_BUILD=true \
-        -DGAMMARAY_BUILD_UI=false  \
-        -DCMAKE_INSTALL_PREFIX=/path/to/your/previous/gammaray/prefix \
-        /path/to/gammaray/sources
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH=/path/to/Qt/version/ \
+    -DGAMMARAY_PROBE_ONLY_BUILD=true \
+    -DGAMMARAY_BUILD_UI=false  \
+    -DCMAKE_INSTALL_PREFIX=/path/to/your/previous/gammaray/prefix \
+    /path/to/gammaray/sources
 ```
 
-You can still use any cmake flags you want like `CMAKE_DISABLE_FIND_PACKAGE_<PACKAGE>` etc.
+You can still use any cmake flags you want like
+`CMAKE_DISABLE_FIND_PACKAGE_<PACKAGE>` etc.
 
 ## Optional Dependencies
 
@@ -153,22 +161,24 @@ by passing the option `-DCMAKE_DISABLE_FIND_PACKAGE_<PACKAGE>=True`.
 For instance:
 
 ```bash
-    # tell cmake to ignore VTK
-    cmake -DCMAKE_DISABLE_FIND_PACKAGE_VTK=True
+# tell cmake to ignore VTK
+cmake -DCMAKE_DISABLE_FIND_PACKAGE_VTK=True
 ```
 
 ## RPATH Settings (Linux only)
 
-By default GammaRay will be build with RPATHs set to the absolute install location
-of its dependencies (such as Qt). This is useful for easily using a self-built
-GammaRay, but it might not be what you want when building installers or packages.
+By default GammaRay will be build with RPATHs set to the absolute install
+location of its dependencies (such as Qt). This is useful for easily using
+a self-built GammaRay, but it might not be what you want when building
+installers or packages.
 
 You can therefore change this via the following CMake options:
 
-- `CMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF` will disable settings RPATH to the location
-  of dependencies. It will however still set relative RPATHs between the various
-  GammaRay components. This is typically desired for Linux distros, where GammaRay's
-  dependencies are all in the default search path anyway.
+- `CMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF` will disable settings RPATH to the
+  location of dependencies. It will however still set relative RPATHs between
+  the various GammaRay components. This is typically desired for Linux
+  distros, where GammaRay's dependencies are all in the default search path
+  anyway.
 
-- `CMAKE_INSTALL_RPATH=<path(s)>` will add the specified absolute paths to RPATH,
-  additionally to the relative RPATHs between GammaRay's components.
+- `CMAKE_INSTALL_RPATH=<path(s)>` will add the specified absolute paths to
+  RPATH, additionally to the relative RPATHs between GammaRay's components.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line MD013 -->
 # <a name="title"></a> <img src="/ui/resources/gammaray/ui/light/pixmaps/GammaRay-logo.png" height="350px" title="Logo">
 
 GammaRay is a software introspection tool for Qt applications developed by KDAB.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable-next-line MD013 -->
+<!-- markdownlint-disable-next-line MD013 MD033 -->
 # <a name="title"></a> <img src="/ui/resources/gammaray/ui/light/pixmaps/GammaRay-logo.png" height="350px" title="Logo">
 
 GammaRay is a software introspection tool for Qt applications developed by KDAB.
@@ -22,18 +22,21 @@ Among other things GammaRay can:
 * Browse the QtQuick2 item tree and scenegraph.
 * Inspect shaders and geometry data of QtQuick2 items.
 * Plot object lifetime and emitted signals.
-* Browse the QAbstractProxyModel hierarchy and inspect intermediate results in a proxy model chain.
+* Browse the QAbstractProxyModel hierarchy and inspect intermediate results
+  in a proxy model chain.
 * Visual live inspection of QStateMachines.
 * Browse the item tree of any QGraphicsView scene.
-* Show a live preview of QGraphicsView items, including showing their coordinate system,
-  transformation origin, rotate/zoom/pan, etc.
+* Show a live preview of QGraphicsView items, including showing their
+  coordinate system, transformation origin, rotate/zoom/pan, etc.
 * Intercept translations and change them at runtime.
 * Inspect all building blocks of a QStyle.
 * Show all QTimers and their statistics (number of wakeups, wakeup time, ...)
-* Browse all QTextDocuments, along with the ability to edit them and view their internal structures.
+* Browse all QTextDocuments, along with the ability to edit them and view
+  their internal structures.
 * Act as a complete java script debugger, attachable to any QScriptEngine
   (including the usually not accessible one used by QtQuick1 internally).
-* Perform HTML/CSS/DOM/JS introspection/editing/profiling on any QWebPage, thanks to QWebInspector.
+* Perform HTML/CSS/DOM/JS introspection/editing/profiling on any QWebPage,
+  thanks to QWebInspector.
 * Browse the QResource tree and its content.
 * Show all registered meta types.
 * Show all installed fonts.
@@ -100,6 +103,7 @@ via <https://www.kdab.com/contact>.  KDAB engineers know how to write GammaRay
 plugins and can be contracted to help you get yours working and improve your
 development efficiency.
 
-GammaRay and the GammaRay logo are registered trademarks of Klarälvdalens Datakonsult AB
-in the European Union, the United States and/or other countries.  Other product and
-company names and logos may be trademarks or registered trademarks of their respective companies.
+GammaRay and the GammaRay logo are registered trademarks of Klarälvdalens
+Datakonsult AB in the European Union, the United States and/or other
+countries.  Other product and company names and logos may be trademarks or
+registered trademarks of their respective companies.


### PR DESCRIPTION
The README currently fails markdownlint in the pre-commit CI, because the first line contains an HTML tag that pushes the line length over 80 columns.

@DavidAnson has a (node) JS implementation of markdownlint which offers a number of features over the previous Ruby-based implementation, including the ability to selectively disable/enable rules inline to the linted files via HTML comments.

Switching pre-commit to use DavidAnson/markdownlint-cli2, and adding a comment before the README's first line to disable the line-length check, should allow the file to pass the markdownlint check.