### PR TITLE
Add Github Actions CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        build-type:
+          - ''
+          - '-DGAMMARAY_CLIENT_ONLY_BUILD=1'
+#          - '-DGAMMARAY_PROBE_ONLY_BUILD=1 -DGAMMARAY_BUILD_UI=0'
+        qt-version: ['5.15.*', '6.4.*']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure Python (Linux)
+      if: ${{ runner.os }} == 'linux'
+      run: |
+        sudo python3 -m pip install wheel
+        sudo python3 -m pip install --upgrade setuptools
+        sudo python3 -m pip install 'py7zr==0.19.*'
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: ${{ matrix.qt-version }}
+        cache: true
+        setup-python: false
+    - name: Configure
+      run: |
+        MATRIX_QT_VERSION=${{ matrix.qt-version }}
+        QT_MAJOR_VERSION=${MATRIX_QT_VERSION:0:1}
+        if [ $QT_MAJOR_VERSION == "6" ]; then
+          EXTRA_CMAKE_FLAGS="-DGAMMARAY_QT6_BUILD=1 -DQT_MAJOR_VERSION=${QT_MAJOR_VERSION}";
+        fi
+        cmake -B _build -S . \
+          ${{ matrix.build-type }} ${EXTRA_CMAKE_FLAGS}
+    - name: Build
+      run: |
+        cmake --build _build
+    - name: Install
+      run: |
+        cmake --install _build --prefix ./install
+    - name: Deploy (Linux) - Disabled due to GammaRay GLIBC_2.28 requirement
+      if: false
+      run: |
+        sudo apt install libfuse2
+        wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+        chmod a+x linuxdeployqt*.AppImage
+        unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+        ./linuxdeployqt*.AppImage ./install/usr/share/applications/GammaRay.desktop -bundle-non-qt-libs
+        # Workaround for https://github.com/probonopd/linuxdeployqt/issues/83
+        ./linuxdeployqt*.AppImage --appimage-extract
+        ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-launcher
+        ./squashfs-root/usr/bin/patchelf --set-rpath '$ORIGIN/../..' ./appdir/usr/lib/gammaray/libexec/gammaray-client
+        # Apparently the qt_prfxpath in libQt5Core.so
+        # is not relative to libQt5Core.so but to the binary that is being executed, is this clever?
+        ( cd ./appdir/usr/lib/gammaray/ ;  ln -s ../../plugins/ . )
+        ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/GammaRay.desktop -appimage
+        # curl --upload-file ./GammaRay-*.AppImage https://transfer.sh/GammaRay-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -14,7 +14,7 @@ Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@k
 License: GPL-2.0-or-later
 
 #misc config files
-Files: 3rdparty/*/qt_attribution.json .clang-format .clang-tidy .clangd .clazy .cmake-format.py .codespellrc .emacs-dirvars .git-blame-ignore-revs .gitattributes .gitignore .kateconfig .krazy .mdlrc .mdlrc.rb .pep8 .pre-commit-config.yaml .pylintrc .qmake.conf .tag .travis.yml appveyor.ini appveyor.yml distro/* format.config.uncrustify.4_spaces *.qdocconf format_sources docs/collection/gammaray.qhcp.cmake examples/yocto/gammaray_git*.bb probe/gammaray_probe-android-dependencies.xml docs/api/Doxyfile.cmake
+Files: 3rdparty/*/qt_attribution.json .clang-format .clang-tidy .clangd .clazy .cmake-format.py .codespellrc .emacs-dirvars .git-blame-ignore-revs .gitattributes .gitignore .kateconfig .krazy .mdlrc .mdlrc.rb .pep8 .pre-commit-config.yaml .pylintrc .qmake.conf .tag .travis.yml appveyor.ini appveyor.yml distro/* format.config.uncrustify.4_spaces *.qdocconf format_sources docs/collection/gammaray.qhcp.cmake examples/yocto/gammaray_git*.bb probe/gammaray_probe-android-dependencies.xml docs/api/Doxyfile.cmake .github/workflows/*.yml
 Copyright: 2010-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 


### PR DESCRIPTION
After discovering that `GAMMARAY_CLIENT_ONLY_BUILD`s are broken in the repo (#766, fix proposed in #765), I realized that there were no CI **builds** being done (which would've caught that).

(There are buildbot CI jobs being run against the repo, but they're not public. So for anyone outside of KDAB, there's no way to know _what_ they test. Presumably, not client-only builds! And also not Qt6 builds, based on the job names.)

So, this PR adds Github Actions configuration to run a set of GammaRay build and install tests on every push to, and pull request against, the `master` branch.

- Both `ubuntu-latest` and `macos-latest` platforms are tested
- Two versions of Qt are tested: `5.15.*` and `6.4.*`
- For each os+Qt, two builds are done:
  1. Using default options
  2. Configured with `-DGAMMARAY_CLIENT_ONLY_BUILD=1`

These CI builds are **EXPECTED TO FAIL**, currently. This PR depends on my PR #765, which will fix client-only builds in the `master` branch.

#### Other notes
* `-DGAMMARAY_PROBE_ONLY_BUILD=1` builds are currently not tested, because they require a more complicated setup involving an existing build tree. However, I do plan to work on an update to the CI configuration that would test them, by using a second build job (not second step) which depends on the first, and uses the existing build trees from the standard build to perform a second probe-only build for a different Qt version. A future PR will add testing of probe-only build runs.

* The CI workflow file incorporates the `linuxdeployqt` steps from the old Travis CI configuration. However, they are currently disabled with an `if: false` rule. This is necessary due to the AppImage tools' shortsighted **requirement** that AppImages be generated on the oldest possible platforms available.

  That platform is currently `ubuntu-18.04`, which is both (a) deprecated by GitHub, and more importantly, (b) shipped with a glibc version that lacks the GLIBC_2.28 symbols required to build GammaRay's `master` branch. This makes building an AppImage of GammaRay impossible, based on the rules imposed by the AppImage project.
