### PR TITLE
Exclude markdownlint rule MD041

### DIFF
--- a/.mdlrc.rb
+++ b/.mdlrc.rb
@@ -2,3 +2,4 @@ all
 rule 'MD013', :line_length => 100, :tables => false
 rule 'MD029', :style => :ordered
 exclude_rule 'MD033'
+exclude_rule 'MD041'


### PR DESCRIPTION
Fix the pre-commit CI checks, by ignoring MarkdownLint rule 41. (Replacement for #767, as requested by @winterz.)