### PR TITLE
INSTALL: Use MarkDown, not WikiMarkup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,7 @@ To build a debug version pass `-DCMAKE_BUILD_TYPE=Debug` to cmake.
 You'll find more information on this in the wiki:
 <https://github.com/KDAB/GammaRay/wiki/Cross-compiling-GammaRay>
 
-== Force a probe only build ==
+## Force a probe only build
 If you already built GammaRay in the past and that you want to support more probes,
 you don't need to rebuild entirely GammaRay for this specific Qt version.
 You can instead just build the GammaRay probe for the new Qt version and install it

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,6 +121,7 @@ You'll find more information on this in the wiki:
 <https://github.com/KDAB/GammaRay/wiki/Cross-compiling-GammaRay>
 
 ## Force a probe only build
+
 If you already built GammaRay in the past and that you want to support more probes,
 you don't need to rebuild entirely GammaRay for this specific Qt version.
 You can instead just build the GammaRay probe for the new Qt version and install it


### PR DESCRIPTION
I caught this one while looking at the markdownlint issues (#767): One of the lines in `INSTALL.md` has a `== wikimarkup heading ==` not a `## markdown heading`.