### PR TITLE
Fix build with Qt 6.5

### DIFF
--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -747,7 +747,11 @@ void SoftwareScreenGrabber::requestGrabWindow(const QRectF &userViewport)
     renderer->markDirty();
     winPriv->polishItems();
     winPriv->syncSceneGraph();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    winPriv->renderSceneGraph();
+#else
     winPriv->renderSceneGraph(m_window->size());
+#endif
     renderer->setCurrentPaintDevice(regularRenderDevice);
 #else
     m_grabbedFrame.image = m_window->grabWindow();


### PR DESCRIPTION
`QQuickWindowPrivate::renderSceneGraph()` no longer expects an argument since https://codereview.qt-project.org/c/qt/qtdeclarative/+/447519 which caused the build to fail with Qt 6.5 and upwards.
