### PR TITLE
Fix invokeMethod issues with Qt 6.5

### DIFF
--- a/common/endpoint.cpp
+++ b/common/endpoint.cpp
@@ -221,9 +221,11 @@ void Endpoint::invokeObjectLocal(QObject *object, const char *method,
                                  const QVariantList &args)
 {
     Q_ASSERT(args.size() <= 10);
-    QVector<MethodArgument> a(10);
+    MethodArgument m[10] = {};
+    QGenericArgument a[10] = {};
     for (int i = 0; i < args.size(); ++i) {
-        a[i] = MethodArgument(args.at(i));
+        m[i] = MethodArgument(args.at(i));
+        a[i] = QGenericArgument(m[i]);
     }
 
     QMetaObject::invokeMethod(object, method, a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8],


### PR DESCRIPTION
Since https://codereview.qt-project.org/c/qt/qtbase/+/422745 there is a new variadic version of QMetaObject::invokeMethod().

However this new variadic version is not compatible with our usage in `Endpoint::invokeObjectLocal()`, as we just dump all 10 parameters at once without caring about the actual function arity.
Theoretically this could be fixed by manually adding 10 if-branches for the correct arity.

However the second much bigger issue is that we don't know the type at compile time, and thus would end up hardcoding all parameter types to `MethodArgument`.

Hence to fix this, we revert back to the non-variadic version by explicitly calling `QMetaObject::invokeMethod()` with `QGenericArgument` as parameters.

Please see the commit message for more details.

Fixes #777
