### PR TITLE
Launcher/Attach: Initially sort apps by PID, descending

### DIFF
--- a/launcher/ui/attachdialog.cpp
+++ b/launcher/ui/attachdialog.cpp
@@ -58,7 +58,7 @@ AttachDialog::AttachDialog(QWidget *parent, Qt::WindowFlags f)
     ui->view->setModel(m_proxyModel);
     // hide state
     ui->view->hideColumn(ProcessModel::StateColumn);
-    ui->view->sortByColumn(ProcessModel::NameColumn, Qt::AscendingOrder);
+    ui->view->sortByColumn(ProcessModel::PIDColumn, Qt::DescendingOrder);
     ui->view->setSortingEnabled(true);
 
     ui->view->setEditTriggers(QAbstractItemView::NoEditTriggers);


### PR DESCRIPTION
Arguably, more often than not, developer wants to debug an application that has been recently launched, probably it would also be the first or second after GammaRay launcher itself.