### PR TITLE
Fix invokeMethod failure with alias param

### DIFF
--- a/common/remoteviewinterface.h
+++ b/common/remoteviewinterface.h
@@ -75,7 +75,11 @@ public slots:
 
 signals:
     void reset();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    void elementsAtReceived(const QList<GammaRay::ObjectId> &ids, int bestCandidate);
+#else
     void elementsAtReceived(const GammaRay::ObjectIds &ids, int bestCandidate);
+#endif
     void frameUpdated(const GammaRay::RemoteViewFrame &frame);
 
 private:

--- a/plugins/quickinspector/quickinspectorinterface.cpp
+++ b/plugins/quickinspector/quickinspectorinterface.cpp
@@ -58,6 +58,7 @@ QuickInspectorInterface::QuickInspectorInterface(QObject *parent)
 {
     ObjectBroker::registerObject<QuickInspectorInterface *>(this);
     StreamOperators::registerOperators<Features>();
+    qRegisterMetaType<Features>("QFlags<GammaRay::QuickInspectorInterface::Feature>");
     StreamOperators::registerOperators<RenderMode>();
     StreamOperators::registerOperators<QuickItemGeometry>();
     StreamOperators::registerOperators<QVector<QuickItemGeometry>>();

--- a/plugins/quickinspector/quickinspectorinterface.h
+++ b/plugins/quickinspector/quickinspectorinterface.h
@@ -86,7 +86,7 @@ public slots:
     virtual void setSlowMode(bool slow) = 0;
 
 signals:
-    void features(GammaRay::QuickInspectorInterface::Features features);
+    void features(QFlags<GammaRay::QuickInspectorInterface::Feature> features);
     void serverSideDecorationChanged(bool enabled);
     void overlaySettings(const GammaRay::QuickDecorationsSettings &settings);
     void slowModeChanged(bool slow);


### PR DESCRIPTION
Starting from Qt 6.5, invokeMethod has changed a lot. For normal users this doesn't matter too much, but for us, who still use the QGenericArgument way it breaks things. InvokeMethod with QGenericArg no longer checks aliases of a given argument and thus fails to call the method.

To work around this, use the actual types in the signals instead.

The QGenericArgument overload of invokeMethod is marked for removal in Qt7, so we might need to do it by hand in future but for now this will work.