### PR TITLE
Adapt to QSortFilterProxyModel changes in Qt 6.6

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -52,6 +52,7 @@ set(gammaray_common_srcs
     remoteviewframe.cpp
     transferimage.cpp
     commonutils.cpp
+    recursiveproxymodelbase.cpp
 )
 
 add_library(
@@ -151,6 +152,7 @@ if(NOT GAMMARAY_PROBE_ONLY_BUILD)
         translator.h
         commonutils.h
         favoriteobjectinterface.h
+        recursiveproxymodelbase.h
     )
 
     ecm_generate_pri_file(

--- a/common/objectidfilterproxymodel.cpp
+++ b/common/objectidfilterproxymodel.cpp
@@ -17,7 +17,7 @@
 using namespace GammaRay;
 
 ObjectIdsFilterProxyModel::ObjectIdsFilterProxyModel(QObject *parent)
-    : KRecursiveFilterProxyModel(parent)
+    : RecursiveProxyModelBase(parent)
 {
 }
 
@@ -45,7 +45,7 @@ bool ObjectIdsFilterProxyModel::acceptRow(int source_row, const QModelIndex &sou
 {
     // shortcut for the common case, the object id stuff below allocates memory and does expensive model lookups
     if (m_ids.isEmpty()) {
-        return KRecursiveFilterProxyModel::acceptRow(source_row, source_parent);
+        return RecursiveProxyModelBase::acceptRow(source_row, source_parent);
     }
 
     const QModelIndex source_index = sourceModel()->index(source_row, 0, source_parent);
@@ -58,7 +58,7 @@ bool ObjectIdsFilterProxyModel::acceptRow(int source_row, const QModelIndex &sou
         return false;
     }
 
-    return KRecursiveFilterProxyModel::acceptRow(source_row, source_parent);
+    return RecursiveProxyModelBase::acceptRow(source_row, source_parent);
 }
 
 bool ObjectIdsFilterProxyModel::filterAcceptsObjectId(const GammaRay::ObjectId &id) const

--- a/common/objectidfilterproxymodel.h
+++ b/common/objectidfilterproxymodel.h
@@ -15,18 +15,18 @@
 #define GAMMARAY_OBJECTIDFILTERPROXYMODEL_H
 
 #include "gammaray_common_export.h"
-#include "3rdparty/kde/krecursivefilterproxymodel.h"
 
 #include <common/objectid.h>
+#include <common/recursiveproxymodelbase.h>
 
 namespace GammaRay {
 
 /**
- * @brief A KRecursiveFilterProxyModel for ObjectIds.
+ * @brief A RecursiveFilterProxyModel for ObjectIds.
  *
  * Filter in and sort according to the objects list.
  */
-class GAMMARAY_COMMON_EXPORT ObjectIdsFilterProxyModel : public KRecursiveFilterProxyModel
+class GAMMARAY_COMMON_EXPORT ObjectIdsFilterProxyModel : public RecursiveProxyModelBase
 {
     Q_OBJECT
 

--- a/common/recursiveproxymodelbase.cpp
+++ b/common/recursiveproxymodelbase.cpp
@@ -1,0 +1,18 @@
+/*
+  recursiveproxymodelbase.cpp
+
+  This file is part of GammaRay, the Qt application inspection and manipulation tool.
+
+  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Waqar Ahmed <waqar.ahmed@kdab.com>
+
+  SPDX-License-Identifier: GPL-2.0-or-later
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+#include "recursiveproxymodelbase.h"
+
+bool RecursiveProxyModelBase::acceptRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    return QSortFilterProxyModel::filterAcceptsRow(sourceRow, sourceParent);
+}

--- a/common/recursiveproxymodelbase.h
+++ b/common/recursiveproxymodelbase.h
@@ -1,0 +1,53 @@
+/*
+  recursiveproxymodelbase.h
+
+  This file is part of GammaRay, the Qt application inspection and manipulation tool.
+
+  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  Author: Waqar Ahmed <waqar.ahmed@kdab.com>
+
+  SPDX-License-Identifier: GPL-2.0-or-later
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#ifndef GAMMARAY_RECURSIVEPROXYMODELBASE_H
+#define GAMMARAY_RECURSIVEPROXYMODELBASE_H
+
+#include "gammaray_common_export.h"
+
+#include <QtGlobal>
+
+/**
+ * NOTE: This class can be removed once we raise our minimum Qt version to 5.10 or above
+ */
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
+#include <kde/krecursivefilterproxymodel.h>
+#define GAMMARAY_PROXY_BASE_CLASS KRecursiveFilterProxyModel
+#else
+#include <QSortFilterProxyModel>
+#define GAMMARAY_PROXY_BASE_CLASS QSortFilterProxyModel
+#endif
+
+class GAMMARAY_COMMON_EXPORT RecursiveProxyModelBase : public
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+                                                       KRecursiveFilterProxyModel
+#else
+                                                       QSortFilterProxyModel
+#endif
+{
+public:
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    using KRecursiveFilterProxyModel::KRecursiveFilterProxyModel;
+#else
+    RecursiveProxyModelBase(QObject *parent)
+        : QSortFilterProxyModel(parent)
+    {
+        setRecursiveFilteringEnabled(true);
+    }
+#endif
+
+    virtual bool acceptRow(int sourceRow, const QModelIndex &sourceParent) const;
+};
+#endif

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -24,8 +24,7 @@
 #include <common/objectbroker.h>
 #include <common/metatypedeclarations.h>
 #include <common/tools/metaobjectbrowser/qmetaobjectmodel.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
@@ -38,7 +37,7 @@ MetaObjectBrowser::MetaObjectBrowser(Probe *probe, QObject *parent)
     , m_motm(new MetaObjectTreeModel(this))
     , m_model(nullptr)
 {
-    auto model = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto model = new ServerProxyModel<RecursiveProxyModelBase>(this);
     model->addRole(QMetaObjectModel::MetaObjectIssues);
     model->addRole(QMetaObjectModel::MetaObjectInvalid);
     model->setSourceModel(m_motm);

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -32,8 +32,7 @@
 #include <core/problemcollector.h>
 #include <core/util.h>
 #include <remote/serverproxymodel.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QCoreApplication>
 #include <QItemSelectionModel>
@@ -53,7 +52,7 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
                                                       "com.kdab.GammaRay.ObjectInspector"),
                                                   this);
 
-    auto proxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto proxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     proxy->setSourceModel(probe->objectTreeModel());
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ObjectInspectorTree"), proxy);
 

--- a/core/tools/resourcebrowser/resourcefiltermodel.cpp
+++ b/core/tools/resourcebrowser/resourcefiltermodel.cpp
@@ -20,7 +20,7 @@
 using namespace GammaRay;
 
 ResourceFilterModel::ResourceFilterModel(QObject *parent)
-    : KRecursiveFilterProxyModel(parent)
+    : RecursiveProxyModelBase(parent)
 {
 }
 
@@ -30,5 +30,5 @@ bool ResourceFilterModel::filterAcceptsRow(int source_row, const QModelIndex &so
     const QString path = index.data(ResourceModel::FilePathRole).toString();
     if (path == QLatin1String(":/gammaray") || path.startsWith(QLatin1String(":/gammaray/")))
         return false;
-    return KRecursiveFilterProxyModel::filterAcceptsRow(source_row, source_parent);
+    return RecursiveProxyModelBase::filterAcceptsRow(source_row, source_parent);
 }

--- a/core/tools/resourcebrowser/resourcefiltermodel.h
+++ b/core/tools/resourcebrowser/resourcefiltermodel.h
@@ -14,10 +14,10 @@
 #ifndef GAMMARAY_RESOURCEBROWSER_RESOURCEFILTERMODEL_H
 #define GAMMARAY_RESOURCEBROWSER_RESOURCEFILTERMODEL_H
 
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 namespace GammaRay {
-class ResourceFilterModel : public KRecursiveFilterProxyModel
+class ResourceFilterModel : public RecursiveProxyModelBase
 {
     Q_OBJECT
 public:

--- a/plugins/mimetypes/mimetypes.cpp
+++ b/plugins/mimetypes/mimetypes.cpp
@@ -14,7 +14,7 @@
 #include "mimetypes.h"
 #include "mimetypesmodel.h"
 
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 using namespace GammaRay;
 
@@ -22,7 +22,7 @@ MimeTypes::MimeTypes(Probe *probe, QObject *parent)
     : QObject(parent)
 {
     auto model = new MimeTypesModel(this);
-    auto proxy = new KRecursiveFilterProxyModel(this);
+    auto proxy = new RecursiveProxyModelBase(this);
     proxy->setSourceModel(model);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.MimeTypeModel"), proxy);
 }

--- a/plugins/modelinspector/modelinspector.cpp
+++ b/plugins/modelinspector/modelinspector.cpp
@@ -20,8 +20,7 @@
 
 #include <core/remote/serverproxymodel.h>
 #include <common/objectbroker.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
@@ -41,7 +40,7 @@ ModelInspector::ModelInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, modelModelSource, &ModelModel::objectAdded);
     connect(probe, &Probe::objectDestroyed, modelModelSource, &ModelModel::objectRemoved);
 
-    auto modelModelProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto modelModelProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     modelModelProxy->setSourceModel(modelModelSource);
     m_modelModel = modelModelProxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ModelModel"), m_modelModel);

--- a/plugins/qt3dinspector/3dinspector.cpp
+++ b/plugins/qt3dinspector/3dinspector.cpp
@@ -27,8 +27,7 @@
 
 #include <common/modelevent.h>
 #include <common/objectbroker.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <Qt3DRender/QAbstractTexture>
 #include <Qt3DRender/QAbstractTextureImage>
@@ -98,7 +97,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_entityModel, &Qt3DEntityTreeModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_entityModel, &Qt3DEntityTreeModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_entityModel, &Qt3DEntityTreeModel::objectReparented);
-    auto entityProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto entityProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     entityProxy->setSourceModel(m_entityModel);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.Qt3DInspector.sceneModel"), entityProxy);
     m_entitySelectionModel = ObjectBroker::selectionModel(entityProxy);
@@ -108,7 +107,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_frameGraphModel, &FrameGraphModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_frameGraphModel, &FrameGraphModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_frameGraphModel, &FrameGraphModel::objectReparented);
-    auto frameGraphProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto frameGraphProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     frameGraphProxy->setSourceModel(m_frameGraphModel);
     probe->registerModel(QStringLiteral(
                              "com.kdab.GammaRay.Qt3DInspector.frameGraphModel"),

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -34,6 +34,7 @@
 #include <common/probecontrollerinterface.h>
 #include <common/problem.h>
 #include <common/remoteviewframe.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <core/enumrepositoryserver.h>
 #include <core/metaenum.h>
@@ -51,8 +52,6 @@
 #include <core/paintanalyzer.h>
 #include <core/bindingaggregator.h>
 #include <core/problemcollector.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
 
 #include <QQuickItem>
 #include <QQuickWindow>
@@ -385,7 +384,7 @@ QuickInspector::QuickInspector(Probe *probe, QObject *parent)
     m_windowModel = proxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickWindowModel"), m_windowModel);
 
-    auto filterProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto filterProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     filterProxy->setSourceModel(m_itemModel);
     filterProxy->addRole(ObjectModel::ObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickItemModel"), filterProxy);
@@ -405,7 +404,7 @@ QuickInspector::QuickInspector(Probe *probe, QObject *parent)
     connect(m_itemSelectionModel, &QItemSelectionModel::selectionChanged,
             this, &QuickInspector::itemSelectionChanged);
 
-    filterProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    filterProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     filterProxy->setSourceModel(m_sgModel);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickSceneGraphModel"), filterProxy);
 

--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -31,8 +31,7 @@
 #include <common/endpoint.h>
 #include <common/metatypedeclarations.h>
 #include <common/objectmodel.h>
-
-#include <kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QGraphicsEffect>
 #include <QGraphicsItem>
@@ -91,7 +90,7 @@ SceneInspector::SceneInspector(Probe *probe, QObject *parent)
             this, &SceneInspector::sceneSelected);
 
     m_sceneModel = new SceneModel(this);
-    auto sceneProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto sceneProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     sceneProxy->setSourceModel(m_sceneModel);
     sceneProxy->addRole(ObjectModel::ObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.SceneGraphModel"), sceneProxy);

--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -41,8 +41,7 @@
 #include "common/paths.h"
 #include <common/probecontrollerinterface.h>
 #include <common/remoteviewframe.h>
-
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QAction>
 #include <QAbstractItemView>
@@ -112,7 +111,7 @@ WidgetInspectorServer::WidgetInspectorServer(Probe *probe, QObject *parent)
     auto *widgetFilterProxy = new WidgetTreeModel(this);
     widgetFilterProxy->setSourceModel(probe->objectTreeModel());
 
-    auto widgetSearchProxy = new ServerProxyModel<KRecursiveFilterProxyModel>(this);
+    auto widgetSearchProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     widgetSearchProxy->setSourceModel(widgetFilterProxy);
     widgetSearchProxy->addRole(ObjectModel::ObjectIdRole);
 

--- a/plugins/wlcompositorinspector/wlcompositorinspector.cpp
+++ b/plugins/wlcompositorinspector/wlcompositorinspector.cpp
@@ -35,7 +35,6 @@
 #include <core/objecttypefilterproxymodel.h>
 #include <core/singlecolumnobjectproxymodel.h>
 #include <core/remote/serverproxymodel.h>
-#include <3rdparty/kde/krecursivefilterproxymodel.h>
 #include <core/remoteviewserver.h>
 
 #include <wayland-server.h>

--- a/ui/tools/objectinspector/enumstab.cpp
+++ b/ui/tools/objectinspector/enumstab.cpp
@@ -17,8 +17,7 @@
 
 #include <ui/searchlinecontroller.h>
 #include <common/objectbroker.h>
-
-#include "kde/krecursivefilterproxymodel.h"
+#include <common/recursiveproxymodelbase.h>
 
 #include <QSortFilterProxyModel>
 
@@ -37,7 +36,7 @@ EnumsTab::~EnumsTab() = default;
 
 void EnumsTab::setObjectBaseName(const QString &baseName)
 {
-    QSortFilterProxyModel *proxy = new KRecursiveFilterProxyModel(this);
+    QSortFilterProxyModel *proxy = new RecursiveProxyModelBase(this);
     proxy->setDynamicSortFilter(true);
     proxy->setSourceModel(ObjectBroker::model(baseName + '.' + "enums"));
     m_ui->enumView->setModel(proxy);

--- a/ui/visibilityfilterproxymodel.cpp
+++ b/ui/visibilityfilterproxymodel.cpp
@@ -19,7 +19,7 @@
 using namespace GammaRay;
 
 VisibilityFilterProxyModel::VisibilityFilterProxyModel(QObject *parent)
-    : KRecursiveFilterProxyModel(parent)
+    : RecursiveProxyModelBase(parent)
     , m_hideItems(true)
     , m_flagRole(0)
     , m_invisibleMask(0)
@@ -45,7 +45,7 @@ bool VisibilityFilterProxyModel::acceptRow(int source_row, const QModelIndex &so
             return false;
     }
 
-    return KRecursiveFilterProxyModel::acceptRow(source_row, source_parent);
+    return RecursiveProxyModelBase::acceptRow(source_row, source_parent);
 }
 
 void VisibilityFilterProxyModel::setHideItems(bool hideItems)

--- a/ui/visibilityfilterproxymodel.h
+++ b/ui/visibilityfilterproxymodel.h
@@ -15,16 +15,16 @@
 #define GAMMARAY_VISIBILITYFILTERPROXYMODEL_H
 
 #include "gammaray_common_export.h"
-#include "3rdparty/kde/krecursivefilterproxymodel.h"
+#include "common/recursiveproxymodelbase.h"
 
 namespace GammaRay {
 
 /**
- * @brief A KRecursiveFilterProxyModel for ObjectIds.
+ * @brief A RecursiveFilterProxyModel for ObjectIds.
  *
  * Filter in and sort according to the objects list.
  */
-class VisibilityFilterProxyModel : public KRecursiveFilterProxyModel
+class VisibilityFilterProxyModel : public RecursiveProxyModelBase
 {
     Q_OBJECT
 


### PR DESCRIPTION
The private slots are gone in Qt 6.6. We can just use QSortFilterProxyModel instead directly with Qt >= 5.10