### PR TITLE
remoteview: Update Qt version checks

### DIFF
--- a/common/remoteviewinterface.cpp
+++ b/common/remoteviewinterface.cpp
@@ -110,7 +110,7 @@ QDataStream &operator<<(QDataStream &s, const QList<QTouchEvent::TouchPoint> &po
     return s;
 }
 
-#if QT_VERSION <= QT_VERSION_CHECK(6, 3, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
 template<class T, class TouchPoint>
 void setPointValue(QDataStream &s, TouchPoint &p, void (TouchPoint::*func)(T))
 {
@@ -136,7 +136,7 @@ QDataStream &operator>>(QDataStream &s, QList<QTouchEvent::TouchPoint> &points)
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     for (int i = 0; i < count; ++i) {
-#if QT_VERSION <= QT_VERSION_CHECK(6, 3, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
         QMutableEventPoint p;
 #else
         QEventPoint p;
@@ -160,14 +160,14 @@ QDataStream &operator>>(QDataStream &s, QList<QTouchEvent::TouchPoint> &points)
         quint64 v;
 
         s >> v;
-#if QT_VERSION <= QT_VERSION_CHECK(6, 3, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
         p.setPressTimestamp(v);
 #else
         QMutableEventPoint::setPressTimestamp(p, v);
 #endif
 
         s >> v;
-#if QT_VERSION <= QT_VERSION_CHECK(6, 3, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
         p.setTimestamp(v);
 #else
         QMutableEventPoint::setTimestamp(p, v);

--- a/ui/remoteviewwidget.cpp
+++ b/ui/remoteviewwidget.cpp
@@ -899,14 +899,14 @@ QTouchEvent::TouchPoint RemoteViewWidget::mapToSource(const QTouchEvent::TouchPo
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 
-#if QT_VERSION > QT_VERSION_CHECK(6, 3, 0)
-    QMutableEventPoint::update(point, p);
-#define SET_POINT_VALUE(func, val) \
-    QMutableEventPoint::func(p, (val))
-#else
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
     QMutableEventPoint mut = QMutableEventPoint::constFrom(point);
 #define SET_POINT_VALUE(func, value) \
     mut.func(value)
+#else
+    QMutableEventPoint::update(point, p);
+#define SET_POINT_VALUE(func, val) \
+    QMutableEventPoint::func(p, (val))
 #endif
 
     SET_POINT_VALUE(setScenePosition, mapToSource(point.scenePos()));
@@ -927,7 +927,7 @@ QTouchEvent::TouchPoint RemoteViewWidget::mapToSource(const QTouchEvent::TouchPo
     SET_POINT_VALUE(setPressTimestamp, point.pressTimestamp());
     SET_POINT_VALUE(setEllipseDiameters, point.ellipseDiameters());
 
-#if QT_VERSION <= QT_VERSION_CHECK(6, 3, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
     p = mut;
 #endif
 


### PR DESCRIPTION
QMutableEventPoint was made a private type in Qt 6.3.0, so that version should be included in the ones that avoid creating instances of it.

Fixes #784