### PR TITLE
Fix the KDAB logo

### DIFF
--- a/launcher/ui/promolabel.cpp
+++ b/launcher/ui/promolabel.cpp
@@ -52,5 +52,6 @@ void PromoLabel::updatePixmap()
 {
     // load image and adapt it to user's foreground color
     const QImage image = UIResources::themedImage(themeFileName(), this);
-    setPixmap(UIResources::tintedPixmap(image, palette().windowText().color()));
+    const QPixmap pixmap = UIResources::tintedPixmap(image, palette().windowText().color());
+    setPixmap(pixmap.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 }

--- a/ui/uiresources.cpp
+++ b/ui/uiresources.cpp
@@ -175,7 +175,6 @@ QString UIResources::themedFilePath(UIResources::ThemeEntryType type, const QStr
 QImage UIResources::tintedImage(const QImage &image, const QColor &color)
 {
     QImage img(image.size(), QImage::Format_ARGB32_Premultiplied);
-    img.setDevicePixelRatio(image.devicePixelRatio());
 
     QPainter painter(&img);
     painter.setCompositionMode(QPainter::CompositionMode_Source);


### PR DESCRIPTION
The KDAB logo featured in the launcher is broken on anything but 1x scale:

![image](https://github.com/KDAB/GammaRay/assets/54911369/0f004f03-ba23-4b24-b5aa-7ba38defe7ff)

With a couple of lines, we can let the logo shine again :)

![image](https://github.com/KDAB/GammaRay/assets/54911369/26e007fb-b262-48b1-b5d3-1eaa4b270cc2)

(It seems like the 2x graphic is low resolution, but that's a separate problem)