### PR TITLE
Pretty-print XML and show images from HTTP Response

### DIFF
--- a/plugins/network/networkreplymodel.cpp
+++ b/plugins/network/networkreplymodel.cpp
@@ -95,6 +95,8 @@ NetworkReply::ContentType contentType(const QVariant &v)
         return NetworkReply::Json;
     } else if (v.toString().contains(QLatin1String("application/xml"))) {
         return NetworkReply::Xml;
+    } else if (v.toString().startsWith(QLatin1String("image/"))) {
+        return NetworkReply::Image;
     }
     return NetworkReply::Unknown;
 }

--- a/plugins/network/networkreplymodel.cpp
+++ b/plugins/network/networkreplymodel.cpp
@@ -93,6 +93,8 @@ NetworkReply::ContentType contentType(const QVariant &v)
 {
     if (v.toString().contains(QLatin1String("application/json"))) {
         return NetworkReply::Json;
+    } else if (v.toString().contains(QLatin1String("application/xml"))) {
+        return NetworkReply::Xml;
     }
     return NetworkReply::Unknown;
 }

--- a/plugins/network/networkreplymodeldefs.h
+++ b/plugins/network/networkreplymodeldefs.h
@@ -33,6 +33,7 @@ enum ContentType
 {
     Unknown = 0,
     Json = 1,
+    Xml = 2
 };
 }
 

--- a/plugins/network/networkreplymodeldefs.h
+++ b/plugins/network/networkreplymodeldefs.h
@@ -33,7 +33,8 @@ enum ContentType
 {
     Unknown = 0,
     Json = 1,
-    Xml = 2
+    Xml = 2,
+    Image = 4
 };
 }
 

--- a/plugins/network/networkreplywidget.cpp
+++ b/plugins/network/networkreplywidget.cpp
@@ -28,6 +28,7 @@
 #include <QJsonDocument>
 #include <QBuffer>
 #include <QXmlStreamReader>
+#include <QLabel>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QTextCodec>
@@ -73,6 +74,8 @@ NetworkReplyWidget::NetworkReplyWidget(QWidget *parent)
         auto response = objColumn.data(NetworkReplyModelRole::ReplyResponseRole).toByteArray();
         const auto contentType = ( NetworkReply::ContentType )objColumn.data(NetworkReplyModelRole::ReplyContentType).toInt();
 
+        ui->imageLabel->clear();
+
         switch (contentType) {
         case NetworkReply::Json:
             response = QJsonDocument::fromJson(response).toJson(QJsonDocument::JsonFormat::Indented);
@@ -101,6 +104,10 @@ NetworkReplyWidget::NetworkReplyWidget(QWidget *parent)
             response.swap(formattedResponse);
             break;
         }
+        case NetworkReply::Image:
+            ui->imageLabel->setPixmap(QPixmap::fromImage(QImage::fromData(response)));
+            response.clear();
+            break;
         default:
             break;
         }

--- a/plugins/network/networkreplywidget.ui
+++ b/plugins/network/networkreplywidget.ui
@@ -44,6 +44,11 @@
          <bool>true</bool>
         </property>
        </widget>
+       <widget class="QLabel" name="imageLabel">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+       </widget>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Right now we pretty-print JSON when displaying HTTP responses. This adds support for doing the same for XML, and also for rendering images.