### PR TITLE
Fix build on VxWorks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@
 #  Enable Precompiled Headers support
 #  Default=false
 #
+# -DGAMMARAY_ENABLE_KDE_KITEMMODELS=[true|false]
+#  Build a set of item models extending the Qt model-view framework
+#  Default=true
+#
 # -DENABLE_GOLD_LINKER=[true|false]
 #  Use GNU gold linker
 #  Default=false
@@ -802,7 +806,10 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/3rdparty ${CMAKE_BIN
 
 include(KDQtInstallPaths) #to set QT_INSTALL_FOO variables
 add_subdirectory(cmake)
-add_subdirectory(3rdparty/kde)
+set(GAMMARAY_ENABLE_KDE_KITEMMODELS_DEFAULT ON)
+if(GAMMARAY_ENABLE_KDE_KITEMMODELS)
+    add_subdirectory(3rdparty/kde)
+endif()
 add_subdirectory(common)
 add_subdirectory(core)
 add_subdirectory(probe)

--- a/cmake/GammaRayMacros.cmake
+++ b/cmake/GammaRayMacros.cmake
@@ -84,7 +84,7 @@ macro(gammaray_add_plugin _target_name)
     gammaray_set_rpath(${_target_name} ${PROBE_PLUGIN_INSTALL_DIR})
 
     install(TARGETS ${_target_name} DESTINATION ${PROBE_PLUGIN_INSTALL_DIR})
-    if(MSVC)
+    if(MSVC AND GAMMARAY_PLUGIN_TYPE STREQUAL SHARED)
         install(
             FILES "$<TARGET_PDB_FILE_DIR:${_target_name}>/$<TARGET_PDB_FILE_NAME:${_target_name}>"
             DESTINATION ${PROBE_PLUGIN_INSTALL_DIR}

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -172,7 +172,7 @@ if(NOT GAMMARAY_PROBE_ONLY_BUILD)
 else()
     install(TARGETS gammaray_common ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
-if(MSVC)
+if(MSVC AND GAMMARAY_LIBRARY_TYPE STREQUAL SHARED)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:gammaray_common>/$<TARGET_PDB_FILE_NAME:gammaray_common>"
         DESTINATION ${BIN_INSTALL_DIR}

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -119,7 +119,7 @@ QStringList pluginPaths(const QString &probeABI)
         addPluginPath(l, path);
 #endif
     }
-#endif  // QT_CONFIG(library)
+#endif // QT_CONFIG(library)
 
     // based on Qt's own install layout and/or qt.conf
     const auto path = QLibraryInfo::location(QLibraryInfo::PluginsPath);
@@ -144,7 +144,7 @@ QStringList targetPluginPaths(const QString &probeABI)
         addPluginPath(l, path + QLatin1String("/gammaray/" GAMMARAY_PLUGIN_VERSION "/") + probeABI + QLatin1String("/target"));
         addPluginPath(l, path + QLatin1String("/gammaray-target"));
     }
-#endif  // QT_CONFIG(library)
+#endif // QT_CONFIG(library)
 
     // based on Qt's own install layout and/or qt.conf
     const auto path = QLibraryInfo::location(QLibraryInfo::PluginsPath);

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -109,6 +109,7 @@ QStringList pluginPaths(const QString &probeABI)
     addPluginPath(l, rootPath() + QLatin1String("/" GAMMARAY_PLUGIN_INSTALL_DIR "/" GAMMARAY_PLUGIN_VERSION "/") + probeABI);
     addPluginPath(l, rootPath() + QLatin1String("/" GAMMARAY_PLUGIN_INSTALL_DIR));
 
+#if QT_CONFIG(library)
     // based on Qt plugin search paths
     foreach (const auto &path, QCoreApplication::libraryPaths()) {
         addPluginPath(l, path + QLatin1String("/gammaray/" GAMMARAY_PLUGIN_VERSION "/") + probeABI);
@@ -118,6 +119,7 @@ QStringList pluginPaths(const QString &probeABI)
         addPluginPath(l, path);
 #endif
     }
+#endif  // QT_CONFIG(library)
 
     // based on Qt's own install layout and/or qt.conf
     const auto path = QLibraryInfo::location(QLibraryInfo::PluginsPath);
@@ -136,11 +138,13 @@ QStringList targetPluginPaths(const QString &probeABI)
     addPluginPath(l, rootPath() + QLatin1String("/" GAMMARAY_TARGET_PLUGIN_INSTALL_DIR "/" GAMMARAY_PLUGIN_VERSION "/") + probeABI);
     addPluginPath(l, rootPath() + QLatin1String("/" GAMMARAY_TARGET_PLUGIN_INSTALL_DIR));
 
+#if QT_CONFIG(library)
     // based on Qt plugin search paths
     foreach (const auto &path, QCoreApplication::libraryPaths()) {
         addPluginPath(l, path + QLatin1String("/gammaray/" GAMMARAY_PLUGIN_VERSION "/") + probeABI + QLatin1String("/target"));
         addPluginPath(l, path + QLatin1String("/gammaray-target"));
     }
+#endif  // QT_CONFIG(library)
 
     // based on Qt's own install layout and/or qt.conf
     const auto path = QLibraryInfo::location(QLibraryInfo::PluginsPath);

--- a/common/plugininfo.cpp
+++ b/common/plugininfo.cpp
@@ -19,7 +19,9 @@
 #include <QDebug>
 #include <QDir>
 #include <QFileInfo>
+#if QT_CONFIG(library)
 #include <QLibrary>
+#endif
 #include <QLocale>
 #include <QCoreApplication>
 #include <QJsonArray>
@@ -33,8 +35,13 @@ PluginInfo::PluginInfo() = default;
 
 PluginInfo::PluginInfo(const QString &path)
 {
+#if QT_CONFIG(library)
+    const bool isLibrary = QLibrary::isLibrary(path);
+#else
+    const bool isLibrary = false;
+#endif
     // OSX has broken QLibrary::isLibrary() - QTBUG-50446
-    if (QLibrary::isLibrary(path) || path.endsWith(Paths::pluginExtension(), Qt::CaseInsensitive))
+    if (isLibrary || path.endsWith(Paths::pluginExtension(), Qt::CaseInsensitive))
         initFromJSON(path);
 }
 
@@ -138,9 +145,11 @@ QObject *PluginInfo::staticInstance() const
 
 void PluginInfo::initFromJSON(const QString &path)
 {
+#if QT_CONFIG(library)
     const QPluginLoader loader(path);
     const QJsonObject metaData = loader.metaData();
     initFromJSON(metaData);
+#endif
     m_path = path;
 }
 

--- a/common/proxyfactorybase.cpp
+++ b/common/proxyfactorybase.cpp
@@ -43,6 +43,7 @@ void ProxyFactoryBase::loadPlugin()
     if (m_factory)
         return;
 
+#if QT_CONFIG(library)
     if (!pluginInfo().isStatic()) {
         QPluginLoader loader(pluginInfo().path(), this);
         m_factory = loader.instance();
@@ -54,6 +55,9 @@ void ProxyFactoryBase::loadPlugin()
     } else {
         m_factory = pluginInfo().staticInstance();
     }
+#else
+    m_factory = pluginInfo().staticInstance();
+#endif
 
     if (m_factory)
         m_factory->setParent(this);

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -211,7 +211,7 @@ if(NOT GAMMARAY_PROBE_ONLY_BUILD)
 else()
     install(TARGETS gammaray_core ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
-if(MSVC)
+if(MSVC AND GAMMARAY_LIBRARY_TYPE STREQUAL SHARED)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:gammaray_core>/$<TARGET_PDB_FILE_NAME:gammaray_core>"
         DESTINATION ${BIN_INSTALL_DIR}

--- a/core/metaobjectrepository.cpp
+++ b/core/metaobjectrepository.cpp
@@ -118,7 +118,9 @@ void MetaObjectRepository::initQObjectTypes()
     MO_ADD_PROPERTY_ST(QCoreApplication, closingDown);
     MO_ADD_PROPERTY_ST(QCoreApplication, isQuitLockEnabled);
     MO_ADD_PROPERTY_ST(QCoreApplication, isSetuidAllowed);
+#if QT_CONFIG(library)
     MO_ADD_PROPERTY_ST(QCoreApplication, libraryPaths);
+#endif
     MO_ADD_PROPERTY_ST(QCoreApplication, startingUp);
 
     MO_ADD_METAOBJECT1(QAbstractItemModel, QObject);

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -454,7 +454,7 @@ void Probe::showInProcessUi()
         else
             factory();
     }
-#endif  // QT_CONFIG(library)
+#endif // QT_CONFIG(library)
     IF_DEBUG(cout << "creation done" << endl;)
 }
 

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -47,7 +47,9 @@
 #include <QGuiApplication>
 #include <QWindow>
 #include <QDir>
+#if QT_CONFIG(library)
 #include <QLibrary>
+#endif
 #include <QMouseEvent>
 #include <QUrl>
 #include <QThread>
@@ -422,6 +424,7 @@ void Probe::showInProcessUi()
     IF_DEBUG(cout << "creating GammaRay::MainWindow" << endl;)
     ProbeGuard guard;
 
+#if QT_CONFIG(library)
     QLibrary lib;
     foreach (auto path, Paths::pluginPaths(QStringLiteral(GAMMARAY_PROBE_ABI))) {
         path += QStringLiteral("/gammaray_inprocessui");
@@ -451,7 +454,7 @@ void Probe::showInProcessUi()
         else
             factory();
     }
-
+#endif  // QT_CONFIG(library)
     IF_DEBUG(cout << "creation done" << endl;)
 }
 

--- a/probe/CMakeLists.txt
+++ b/probe/CMakeLists.txt
@@ -103,7 +103,7 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
         endif()
     endif()
 
-    if(MSVC)
+    if(MSVC AND GAMMARAY_LIBRARY_TYPE STREQUAL SHARED)
         install(
             FILES "$<TARGET_PDB_FILE_DIR:gammaray_probe>/$<TARGET_PDB_FILE_NAME:gammaray_probe>"
             DESTINATION ${BIN_INSTALL_DIR}


### PR DESCRIPTION
These are fixes for some build issues i found when trying to build GammaRay for VxWorks.

Fixed issues:
- CMake configure step would fail because build script tried to install pdbs for static libraries.
- VxWorks build would fail when trying to build kde item models because VxWorks does not support shared library builds.
- Build would fail in various places because features guarded by `QT_CONFIG(library)` are being used.

Please carefully changes regarding `QT_CONFIG(library)`. I have no idea what these library or plugins are and changes may be incorrect. It seems to me most of them should be fine, but at least one is questionable. `PluginInfo::initFromJSON()` became mostly noop. I think we somehow need to handle static plugins, but i have no idea how.