### PR TITLE
Fix client-only builds with the quckinspector enabled

### DIFF
--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -68,21 +68,23 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
         Qt::QuickPrivate
         gammaray_kitemmodels
     )
-endif()
 
-if(TARGET Qt::Gui_GLESv2)
-    include(CheckCXXSourceCompiles)
-    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
-    check_cxx_source_compiles("int main() {return 0;}" CAN_LINK_GUI_GLESV2)
-    if(CAN_LINK_GUI_GLESV2)
-        set(HAVE_GLESv2 TRUE)
-        target_link_libraries(gammaray_quickinspector Qt::Gui_GLESv2)
+    if(TARGET Qt::Gui_GLESv2)
+        include(CheckCXXSourceCompiles)
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
+        check_cxx_source_compiles("int main() {return 0;}" CAN_LINK_GUI_GLESV2)
+        if(CAN_LINK_GUI_GLESV2)
+            set(HAVE_GLESv2 TRUE)
+            target_link_libraries(gammaray_quickinspector Qt::Gui_GLESv2)
+        endif()
+    endif()
+
+    #the Qt::Gui_GLESv2 target is not set on Android (up to qt5.13, at least)
+    if(ANDROID AND NOT TARGET Qt::Gui_GLESv2)
+        target_link_libraries(gammaray_quickinspector GLESv2)
     endif()
 endif()
-#the Qt::Gui_GLESv2 target is not set on Android (up to qt5.13, at least)
-if(ANDROID AND NOT TARGET Qt::Gui_GLESv2)
-    target_link_libraries(gammaray_quickinspector GLESv2)
-endif()
+
 
 if(GAMMARAY_BUILD_UI)
     # ui plugin

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -12,18 +12,33 @@ if(NOT TARGET Qt::Quick)
 endif()
 
 # shared stuff
-set(gammaray_quickinspector_shared_srcs quickinspectorinterface.cpp quickitemgeometry.cpp
-                                        quickdecorationsdrawer.cpp materialextension/materialextensioninterface.cpp
+set(gammaray_quickinspector_shared_srcs
+
+    quickinspectorinterface.cpp
+    quickitemgeometry.cpp
+    quickdecorationsdrawer.cpp
+    materialextension/materialextensioninterface.cpp
 )
 
-add_library(gammaray_quickinspector_shared STATIC ${gammaray_quickinspector_shared_srcs})
-target_link_libraries(gammaray_quickinspector_shared gammaray_common Qt::Gui Qt::Quick)
+add_library(gammaray_quickinspector_shared STATIC
+    ${gammaray_quickinspector_shared_srcs}
+)
+target_link_libraries(gammaray_quickinspector_shared
+    gammaray_common
+    Qt::Gui
+    Qt::Quick
+)
 
-set_target_properties(gammaray_quickinspector_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_compile_features(gammaray_quickinspector_shared PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})
+set_target_properties(gammaray_quickinspector_shared PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+target_compile_features(gammaray_quickinspector_shared PUBLIC
+    ${GAMMARAY_REQUIRED_CXX_FEATURES}
+)
 
 if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
     set(gammaray_quickinspector_srcs
+
         quickinspector.cpp
         quickanchorspropertyadaptor.cpp
         quickitemmodel.cpp
@@ -33,9 +48,8 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
     )
 
     if(NOT QT_NO_OPENGL)
-        list(
-            APPEND
-            gammaray_quickinspector_srcs
+        list(APPEND gammaray_quickinspector_srcs
+
             materialextension/materialextension.cpp
             materialextension/materialshadermodel.cpp
             materialextension/qquickopenglshadereffectmaterialadaptor.cpp
@@ -49,19 +63,18 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
     gammaray_add_plugin(
         gammaray_quickinspector
         JSON
-        gammaray_quickinspector.json
+            gammaray_quickinspector.json
         SOURCES
-        ${gammaray_quickinspector_srcs}
+            ${gammaray_quickinspector_srcs}
     )
 
     if(NOT Qt5Quick_VERSION VERSION_LESS 5.7 OR TARGET Qt6::Quick)
-        target_sources(
-            gammaray_quickinspector PUBLIC ${CMAKE_CURRENT_LIST_DIR}/quickimplicitbindingdependencyprovider.cpp
+        target_sources(gammaray_quickinspector PUBLIC
+            ${CMAKE_CURRENT_LIST_DIR}/quickimplicitbindingdependencyprovider.cpp
         )
     endif()
 
-    target_link_libraries(
-        gammaray_quickinspector
+    target_link_libraries(gammaray_quickinspector
         gammaray_quickinspector_shared
         gammaray_core
         Qt::Quick
@@ -71,7 +84,7 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
 
     if(TARGET Qt::Gui_GLESv2)
         include(CheckCXXSourceCompiles)
-        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
+        list(APPEND CMAKE_REQUIRED_LIBRARIES Qt::Gui_GLESv2)
         check_cxx_source_compiles("int main() {return 0;}" CAN_LINK_GUI_GLESV2)
         if(CAN_LINK_GUI_GLESV2)
             set(HAVE_GLESv2 TRUE)
@@ -89,6 +102,7 @@ endif()
 if(GAMMARAY_BUILD_UI)
     # ui plugin
     set(gammaray_quickinspector_ui_srcs
+
         quickinspectorwidget.cpp
         quickinspectorclient.cpp
         quickclientitemmodel.cpp
@@ -106,18 +120,25 @@ if(GAMMARAY_BUILD_UI)
     )
 
     if(NOT QT_NO_OPENGL)
-        list(APPEND gammaray_quickinspector_ui_srcs geometryextension/sggeometrytab.cpp
-                geometryextension/sgwireframewidget.cpp
+        list(APPEND gammaray_quickinspector_ui_srcs
+
+            geometryextension/sggeometrytab.cpp
+            geometryextension/sgwireframewidget.cpp
         )
     endif()
 
     gammaray_add_plugin(
         gammaray_quickinspector_ui
         JSON
-        gammaray_quickinspector.json
+            gammaray_quickinspector.json
         SOURCES
-        ${gammaray_quickinspector_ui_srcs}
+            ${gammaray_quickinspector_ui_srcs}
     )
 
-    target_link_libraries(gammaray_quickinspector_ui gammaray_quickinspector_shared gammaray_ui Qt::Quick)
+    target_link_libraries(gammaray_quickinspector_ui
+        gammaray_quickinspector_shared
+        gammaray_ui
+        Qt::Quick
+    )
+
 endif()

--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -6,113 +6,116 @@
 #
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
-if(TARGET Qt::Quick)
-    # shared stuff
-    set(gammaray_quickinspector_shared_srcs quickinspectorinterface.cpp quickitemgeometry.cpp
-                                            quickdecorationsdrawer.cpp materialextension/materialextensioninterface.cpp
+if(NOT TARGET Qt::Quick)
+    # We can't do anything here
+    return()
+endif()
+
+# shared stuff
+set(gammaray_quickinspector_shared_srcs quickinspectorinterface.cpp quickitemgeometry.cpp
+                                        quickdecorationsdrawer.cpp materialextension/materialextensioninterface.cpp
+)
+
+add_library(gammaray_quickinspector_shared STATIC ${gammaray_quickinspector_shared_srcs})
+target_link_libraries(gammaray_quickinspector_shared gammaray_common Qt::Gui Qt::Quick)
+
+set_target_properties(gammaray_quickinspector_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_features(gammaray_quickinspector_shared PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})
+
+if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
+    set(gammaray_quickinspector_srcs
+        quickinspector.cpp
+        quickanchorspropertyadaptor.cpp
+        quickitemmodel.cpp
+        quickscenegraphmodel.cpp
+        quickpaintanalyzerextension.cpp
+        quickscreengrabber.cpp
     )
 
-    add_library(gammaray_quickinspector_shared STATIC ${gammaray_quickinspector_shared_srcs})
-    target_link_libraries(gammaray_quickinspector_shared gammaray_common Qt::Gui Qt::Quick)
-
-    set_target_properties(gammaray_quickinspector_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_compile_features(gammaray_quickinspector_shared PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})
-
-    if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
-        set(gammaray_quickinspector_srcs
-            quickinspector.cpp
-            quickanchorspropertyadaptor.cpp
-            quickitemmodel.cpp
-            quickscenegraphmodel.cpp
-            quickpaintanalyzerextension.cpp
-            quickscreengrabber.cpp
-        )
-
-        if(NOT QT_NO_OPENGL)
-            list(
-                APPEND
-                gammaray_quickinspector_srcs
-                materialextension/materialextension.cpp
-                materialextension/materialshadermodel.cpp
-                materialextension/qquickopenglshadereffectmaterialadaptor.cpp
-                geometryextension/sggeometryextension.cpp
-                geometryextension/sggeometrymodel.cpp
-                textureextension/textureextension.cpp
-                textureextension/qsgtexturegrabber.cpp
-            )
-        endif()
-
-        gammaray_add_plugin(
-            gammaray_quickinspector
-            JSON
-            gammaray_quickinspector.json
-            SOURCES
-            ${gammaray_quickinspector_srcs}
-        )
-
-        if(NOT Qt5Quick_VERSION VERSION_LESS 5.7 OR TARGET Qt6::Quick)
-            target_sources(
-                gammaray_quickinspector PUBLIC ${CMAKE_CURRENT_LIST_DIR}/quickimplicitbindingdependencyprovider.cpp
-            )
-        endif()
-
-        target_link_libraries(
-            gammaray_quickinspector
-            gammaray_quickinspector_shared
-            gammaray_core
-            Qt::Quick
-            Qt::QuickPrivate
-            gammaray_kitemmodels
+    if(NOT QT_NO_OPENGL)
+        list(
+            APPEND
+            gammaray_quickinspector_srcs
+            materialextension/materialextension.cpp
+            materialextension/materialshadermodel.cpp
+            materialextension/qquickopenglshadereffectmaterialadaptor.cpp
+            geometryextension/sggeometryextension.cpp
+            geometryextension/sggeometrymodel.cpp
+            textureextension/textureextension.cpp
+            textureextension/qsgtexturegrabber.cpp
         )
     endif()
 
-    if(TARGET Qt::Gui_GLESv2)
-        include(CheckCXXSourceCompiles)
-        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
-        check_cxx_source_compiles("int main() {return 0;}" CAN_LINK_GUI_GLESV2)
-        if(CAN_LINK_GUI_GLESV2)
-            set(HAVE_GLESv2 TRUE)
-            target_link_libraries(gammaray_quickinspector Qt::Gui_GLESv2)
-        endif()
-    endif()
-    #the Qt::Gui_GLESv2 target is not set on Android (up to qt5.13, at least)
-    if(ANDROID AND NOT TARGET Qt::Gui_GLESv2)
-        target_link_libraries(gammaray_quickinspector GLESv2)
-    endif()
+    gammaray_add_plugin(
+        gammaray_quickinspector
+        JSON
+        gammaray_quickinspector.json
+        SOURCES
+        ${gammaray_quickinspector_srcs}
+    )
 
-    if(GAMMARAY_BUILD_UI)
-        # ui plugin
-        set(gammaray_quickinspector_ui_srcs
-            quickinspectorwidget.cpp
-            quickinspectorclient.cpp
-            quickclientitemmodel.cpp
-            quickitemdelegate.cpp
-            quickitemtreewatcher.cpp
-            quickscenepreviewwidget.cpp
-            quickscenecontrolwidget.cpp
-            quickoverlaylegend.cpp
-            gridsettingswidget.cpp
-            materialextension/materialextensionclient.cpp
-            materialextension/materialtab.cpp
-            textureextension/texturetab.cpp
-            textureextension/textureviewwidget.cpp
-            textureextension/resources.qrc
+    if(NOT Qt5Quick_VERSION VERSION_LESS 5.7 OR TARGET Qt6::Quick)
+        target_sources(
+            gammaray_quickinspector PUBLIC ${CMAKE_CURRENT_LIST_DIR}/quickimplicitbindingdependencyprovider.cpp
         )
-
-        if(NOT QT_NO_OPENGL)
-            list(APPEND gammaray_quickinspector_ui_srcs geometryextension/sggeometrytab.cpp
-                 geometryextension/sgwireframewidget.cpp
-            )
-        endif()
-
-        gammaray_add_plugin(
-            gammaray_quickinspector_ui
-            JSON
-            gammaray_quickinspector.json
-            SOURCES
-            ${gammaray_quickinspector_ui_srcs}
-        )
-
-        target_link_libraries(gammaray_quickinspector_ui gammaray_quickinspector_shared gammaray_ui Qt::Quick)
     endif()
+
+    target_link_libraries(
+        gammaray_quickinspector
+        gammaray_quickinspector_shared
+        gammaray_core
+        Qt::Quick
+        Qt::QuickPrivate
+        gammaray_kitemmodels
+    )
+endif()
+
+if(TARGET Qt::Gui_GLESv2)
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
+    check_cxx_source_compiles("int main() {return 0;}" CAN_LINK_GUI_GLESV2)
+    if(CAN_LINK_GUI_GLESV2)
+        set(HAVE_GLESv2 TRUE)
+        target_link_libraries(gammaray_quickinspector Qt::Gui_GLESv2)
+    endif()
+endif()
+#the Qt::Gui_GLESv2 target is not set on Android (up to qt5.13, at least)
+if(ANDROID AND NOT TARGET Qt::Gui_GLESv2)
+    target_link_libraries(gammaray_quickinspector GLESv2)
+endif()
+
+if(GAMMARAY_BUILD_UI)
+    # ui plugin
+    set(gammaray_quickinspector_ui_srcs
+        quickinspectorwidget.cpp
+        quickinspectorclient.cpp
+        quickclientitemmodel.cpp
+        quickitemdelegate.cpp
+        quickitemtreewatcher.cpp
+        quickscenepreviewwidget.cpp
+        quickscenecontrolwidget.cpp
+        quickoverlaylegend.cpp
+        gridsettingswidget.cpp
+        materialextension/materialextensionclient.cpp
+        materialextension/materialtab.cpp
+        textureextension/texturetab.cpp
+        textureextension/textureviewwidget.cpp
+        textureextension/resources.qrc
+    )
+
+    if(NOT QT_NO_OPENGL)
+        list(APPEND gammaray_quickinspector_ui_srcs geometryextension/sggeometrytab.cpp
+                geometryextension/sgwireframewidget.cpp
+        )
+    endif()
+
+    gammaray_add_plugin(
+        gammaray_quickinspector_ui
+        JSON
+        gammaray_quickinspector.json
+        SOURCES
+        ${gammaray_quickinspector_ui_srcs}
+    )
+
+    target_link_libraries(gammaray_quickinspector_ui gammaray_quickinspector_shared gammaray_ui Qt::Quick)
 endif()


### PR DESCRIPTION
In the spirit of my previous #765, this fixes some places in the `plugins/quickinspector/CMakeLists.txt` where targets that weren't created during a `GAMMARAY_CLIENT_ONLY_BUILD` were being assigned to, causing CMake to abort. I missed these previously because they only affect Windows, as far as I can tell.

I'd suggest reviewing the PR changes as separate commits. Taken all together, it looks like a LOT, because the indentation of nearly every line in the file changed due to some `if()` nesting I removed. (Preferring to do an early return from the file, if we don't have the `Qt::Quick` target, rather than having the **entire** thing wrapped in `if(TARGET Qt::Quick)`.)

I also fixed a lot of formatting, chopping down long commands so that they're more vertical.

But the **only** three actual _code_ changes in the PR are:

1. Replace the outermost `if(TARGET Qt::Quick)` nesting with:
   ```cmake
   if(NOT TARGET Qt::Quick)
       return()
   endif()
   ```

2. Move the `endif()` for `if(NOT GAMMARAY_CLIENT_ONLY_BUILD)` farther down, so it protects more code that can't be run in client-only builds.

3. Replace this call:
   ```cmake
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} Qt::Gui_GLESv2)
   ```
   With:
   ```cmake
   list(APPEND CMAKE_REQUIRED_LIBRARIES Qt::Gui_GLESv2)
   ```
