### PR TITLE
macOS: Correct two NULLs that should be nullptr

### DIFF
--- a/launcher/core/probeabidetector_mac.cpp
+++ b/launcher/core/probeabidetector_mac.cpp
@@ -40,10 +40,10 @@ static QString resolveBundlePath(const QString &bundlePath)
         return bundlePath;
 
     const QByteArray utf8Bundle = fi.absoluteFilePath().toUtf8();
-    CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(NULL,
+    CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(nullptr,
                                                                  reinterpret_cast<const UInt8 *>(utf8Bundle.data()),
                                                                  utf8Bundle.length(), true);
-    CFBundleRef bundle = CFBundleCreate(NULL, bundleUrl);
+    CFBundleRef bundle = CFBundleCreate(nullptr, bundleUrl);
     if (bundle) {
         CFURLRef url = CFBundleCopyExecutableURL(bundle);
         char executableFile[FILENAME_MAX];


### PR DESCRIPTION
`launcher/core/probeabidetector_mac.cpp` (affects only macOS) passed some NULLs to system `CF...()` calls that triggered compile warnings:

```text
[190/717] Building CXX object launcher/core/CMakeFiles/gammaray_launcher.dir/probeabidetector_mac.cpp.o
/Users/runner/work/GammaRay/GammaRay/launcher/core/probeabidetector_mac.cpp:43:66: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
    CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(NULL,
                                                                 ^~~~
                                                                 nullptr
/Applications/Xcode_14.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
/Users/runner/work/GammaRay/GammaRay/launcher/core/probeabidetector_mac.cpp:46:41: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
    CFBundleRef bundle = CFBundleCreate(NULL, bundleUrl);
                                        ^~~~
                                        nullptr
/Applications/Xcode_14.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/stddef.h:84:18: note: expanded from macro 'NULL'
#    define NULL __null
                 ^
2 warnings generated.
```