### PR TITLE
Don't add the .desktop to the end of the filename in setDesktopFilename

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    QGuiApplication::setDesktopFileName(QStringLiteral("GammaRay.desktop"));
+    QGuiApplication::setDesktopFileName(QStringLiteral("GammaRay"));
 #endif
 
     QApplication app(argc, argv);

--- a/launcher/app/main.cpp
+++ b/launcher/app/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 #endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    QGuiApplication::setDesktopFileName(QStringLiteral("GammaRay.desktop"));
+    QGuiApplication::setDesktopFileName(QStringLiteral("GammaRay"));
 #endif
 
     QApplication app(argc, argv);


### PR DESCRIPTION
This is not needed, and will now start generate warnings in Qt >6.5.

See https://codereview.qt-project.org/c/qt/qtbase/+/478287, and https://codereview.qt-project.org/c/qt/qtbase/+/477797