### PR TITLE
Expose list of ToolInfos in ClientToolManager as a const reference

### DIFF
--- a/ui/clienttoolmanager.h
+++ b/ui/clienttoolmanager.h
@@ -84,7 +84,7 @@ public:
     int toolIndexForToolId(const QString &toolId) const;
     ToolInfo toolForToolId(const QString &toolId) const;
 
-    inline QVector<ToolInfo> tools() const
+    inline QVector<ToolInfo> const& tools() const
     {
         return m_tools;
     }

--- a/ui/clienttoolmanager.h
+++ b/ui/clienttoolmanager.h
@@ -84,7 +84,7 @@ public:
     int toolIndexForToolId(const QString &toolId) const;
     ToolInfo toolForToolId(const QString &toolId) const;
 
-    inline QVector<ToolInfo> const& tools() const
+    inline QVector<ToolInfo> const &tools() const
     {
         return m_tools;
     }


### PR DESCRIPTION
Although unlikely to actually happen due to compiler optimization shenanigans, this will quiet a warning about dangling references. This is because call sites take a const reference to a specific tool, but it's from a "temporary" container created via this function.