### PR TITLE
Repair lack of classnames in "Graphics Scenes" or "Styles" combobox

### DIFF
--- a/core/singlecolumnobjectproxymodel.cpp
+++ b/core/singlecolumnobjectproxymodel.cpp
@@ -38,3 +38,11 @@ QVariant SingleColumnObjectProxyModel::data(const QModelIndex &proxyIndex, int r
 
     return QIdentityProxyModel::data(proxyIndex, role);
 }
+
+QMap<int, QVariant> SingleColumnObjectProxyModel::itemData(const QModelIndex &proxyIndex) const
+{
+    QMap<int, QVariant> map = QIdentityProxyModel::itemData(proxyIndex);
+    map[Qt::DisplayRole] = data(proxyIndex);
+    return map;
+}
+

--- a/core/singlecolumnobjectproxymodel.cpp
+++ b/core/singlecolumnobjectproxymodel.cpp
@@ -45,4 +45,3 @@ QMap<int, QVariant> SingleColumnObjectProxyModel::itemData(const QModelIndex &pr
     map[Qt::DisplayRole] = data(proxyIndex);
     return map;
 }
-

--- a/core/singlecolumnobjectproxymodel.h
+++ b/core/singlecolumnobjectproxymodel.h
@@ -52,6 +52,8 @@ public:
      *         QVariant() if some anamoly occurs.
      */
     QVariant data(const QModelIndex &proxyIndex, int role = Qt::DisplayRole) const override;
+
+    QMap<int, QVariant> itemData(const QModelIndex &proxyIndex) const override;
 };
 }
 


### PR DESCRIPTION
Since Qt 6.3, QAbstractProxyModel::itemData() no longer calls data() but calls into the source model. So we need to reimplement it in order to use our data() reimplementation.

Should I target master or something else?