### PR TITLE
Fix gcc-13 warnings about references to temporaries

### DIFF
--- a/plugins/network/networkinterfacemodel.cpp
+++ b/plugins/network/networkinterfacemodel.cpp
@@ -80,8 +80,8 @@ QVariant NetworkInterfaceModel::data(const QModelIndex &index, int role) const
                 return MetaEnum::flagsToString(iface.flags(), interface_flag_table);
             }
         } else if (index.column() == 0) {
-            const auto &iface = m_interfaces.at(index.internalId());
-            const auto &addr = iface.addressEntries().at(index.row());
+            const auto iface = m_interfaces.at(index.internalId());
+            const auto addr = iface.addressEntries().at(index.row());
             return QString(addr.ip().toString() + QLatin1Char('/') + addr.netmask().toString());
         }
     }

--- a/ui/clienttoolmodel.cpp
+++ b/ui/clienttoolmodel.cpp
@@ -39,7 +39,7 @@ QVariant ClientToolModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
         return QVariant();
 
-    const ToolInfo &tool = m_toolManager->tools().at(index.row());
+    const ToolInfo tool = m_toolManager->tools().at(index.row());
     switch (role) {
     case Qt::DisplayRole:
         return tool.name();
@@ -89,7 +89,7 @@ Qt::ItemFlags ClientToolModel::flags(const QModelIndex &index) const
     if (!index.isValid())
         return flags;
 
-    const auto &tool = m_toolManager->tools().at(index.row());
+    const auto tool = m_toolManager->tools().at(index.row());
     if (!tool.isEnabled() || (!tool.remotingSupported() && Endpoint::instance()->isRemoteClient()))
         flags &= ~(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
     return flags;


### PR DESCRIPTION
ui/clienttoolmodel.cpp:42:21: warning: possibly dangling reference to a temporary [-Wdangling-reference]
   42 |     const ToolInfo &tool = m_toolManager->tools().at(index.row());
      |                     ^~~~
ui/clienttoolmodel.cpp:42:53: note: the temporary was destroyed at the end of the full expression
‘GammaRay::ClientToolManager::tools() const().QList<GammaRay::ToolInfo>::at(((qsizetype)(& index)->QModelIndex::row()))’