### PR TITLE
Fix two issues in  ObjectEnumModel, found by QAbstractItemModelTester

### DIFF
--- a/core/objectenummodel.cpp
+++ b/core/objectenummodel.cpp
@@ -33,7 +33,7 @@ int ObjectEnumModel::rowCount(const QModelIndex &parent) const
 {
     if (!parent.isValid())
         return SuperClass::rowCount(parent);
-    if (parent.parent().isValid())
+    if (parent.parent().isValid() || parent.column() > 0)
         return 0;
     const QMetaEnum e = m_metaObject->enumerator(parent.row());
     return e.keyCount();
@@ -93,8 +93,9 @@ QModelIndex GammaRay::ObjectEnumModel::index(int row, int column, const QModelIn
 
 QModelIndex GammaRay::ObjectEnumModel::parent(const QModelIndex &child) const
 {
-    // note: Qt4 doesn't have qintptr
-    if (static_cast<qptrdiff>(child.internalId()) == -1)
+    if (!child.isValid())
+        return {};
+    if (static_cast<qintptr>(child.internalId()) == -1)
         return SuperClass::parent(child);
     return SuperClass::index(child.internalId(), 0, QModelIndex());
 }


### PR DESCRIPTION
- only column 0 has children
- parent(invalid index) should be invalid index