### PR TITLE
quickinspector: minor cleanups

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -384,7 +384,7 @@ QuickInspector::QuickInspector(Probe *probe, QObject *parent)
     m_windowModel = proxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickWindowModel"), m_windowModel);
 
-    auto filterProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto filterProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     filterProxy->setSourceModel(m_itemModel);
     filterProxy->addRole(ObjectModel::ObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickItemModel"), filterProxy);
@@ -404,11 +404,11 @@ QuickInspector::QuickInspector(Probe *probe, QObject *parent)
     connect(m_itemSelectionModel, &QItemSelectionModel::selectionChanged,
             this, &QuickInspector::itemSelectionChanged);
 
-    filterProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
-    filterProxy->setSourceModel(m_sgModel);
-    probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickSceneGraphModel"), filterProxy);
+    auto sgFilterProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    sgFilterProxy->setSourceModel(m_sgModel);
+    probe->registerModel(QStringLiteral("com.kdab.GammaRay.QuickSceneGraphModel"), sgFilterProxy);
 
-    m_sgSelectionModel = ObjectBroker::selectionModel(filterProxy);
+    m_sgSelectionModel = ObjectBroker::selectionModel(sgFilterProxy);
     connect(m_sgSelectionModel, &QItemSelectionModel::selectionChanged,
             this, &QuickInspector::sgSelectionChanged);
     connect(m_sgModel, &QuickSceneGraphModel::nodeDeleted, this, &QuickInspector::sgNodeDeleted);

--- a/plugins/quickinspector/quickscenegraphmodel.cpp
+++ b/plugins/quickinspector/quickscenegraphmodel.cpp
@@ -318,8 +318,8 @@ void QuickSceneGraphModel::populateFromNode(QSGNode *node, bool emitSignals)
 
                 auto it = m_childParentMap.find(*j);
                 if (it != m_childParentMap.end()) {
-                    QSGNode *node = it->second;
-                    m_parentChildMap[node].remove(sourceIdx.row());
+                    QSGNode *childNode = it->second;
+                    m_parentChildMap[childNode].remove(sourceIdx.row());
                     m_childParentMap.erase(*j);
                 }
 
@@ -413,8 +413,6 @@ QSGNode *QuickSceneGraphModel::sgNodeForItem(QQuickItem *item) const
 
 QQuickItem *QuickSceneGraphModel::itemForSgNode(QSGNode *node) const
 {
-    m_itemNodeItemMap.find(node);
-
     while (node && !contains(m_itemNodeItemMap, node)) {
         // If there's no entry for node, take its parent
         auto it = m_childParentMap.find(node);
@@ -460,10 +458,9 @@ void QuickSceneGraphModel::pruneSubTree(QSGNode *node)
     auto it = m_parentChildMap.find(node);
     if (it != m_parentChildMap.end()) {
         const QVector<QSGNode *> children = it->second;
-
-        foreach (auto child, children)
+        for (auto child : children)
             pruneSubTree(child);
+        m_parentChildMap.erase(node);
     }
-    m_parentChildMap.erase(node);
     m_childParentMap.erase(node);
 }


### PR DESCRIPTION
- don't reuse a local variable, it got confusing
- don't shadow a parameter, either
- remove unused find() call
- port one foreach to range-for
- only call erase(node) if find(node) found it, since we find() first anyway
- we don't need QSortFilterProxyModels here, there's no sorting or
  filtering happening. QIdentityProxyModel is enough. I bet this code
  predates QIPM....