### PR TITLE
Simplify proxy usage

### DIFF
--- a/core/objecttypefilterproxymodel.cpp
+++ b/core/objecttypefilterproxymodel.cpp
@@ -18,7 +18,6 @@ using namespace GammaRay;
 ObjectFilterProxyModelBase::ObjectFilterProxyModelBase(QObject *parent)
     : QSortFilterProxyModel(parent)
 {
-    setDynamicSortFilter(true);
 }
 
 QMap<int, QVariant> ObjectFilterProxyModelBase::itemData(const QModelIndex &index) const

--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -24,10 +24,10 @@
 #include <common/objectbroker.h>
 #include <common/metatypedeclarations.h>
 #include <common/tools/metaobjectbrowser/qmetaobjectmodel.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
+#include <QIdentityProxyModel>
 
 using namespace GammaRay;
 
@@ -37,7 +37,7 @@ MetaObjectBrowser::MetaObjectBrowser(Probe *probe, QObject *parent)
     , m_motm(new MetaObjectTreeModel(this))
     , m_model(nullptr)
 {
-    auto model = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto model = new ServerProxyModel<QIdentityProxyModel>(this);
     model->addRole(QMetaObjectModel::MetaObjectIssues);
     model->addRole(QMetaObjectModel::MetaObjectInvalid);
     model->setSourceModel(m_motm);

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -32,10 +32,10 @@
 #include <core/problemcollector.h>
 #include <core/util.h>
 #include <remote/serverproxymodel.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <QCoreApplication>
 #include <QItemSelectionModel>
+#include <QIdentityProxyModel>
 #include <QMetaMethod>
 
 #include <QMutexLocker>
@@ -52,7 +52,7 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
                                                       "com.kdab.GammaRay.ObjectInspector"),
                                                   this);
 
-    auto proxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto proxy = new ServerProxyModel<QIdentityProxyModel>(this);
     proxy->setSourceModel(probe->objectTreeModel());
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ObjectInspectorTree"), proxy);
 

--- a/launcher/ui/attachdialog.cpp
+++ b/launcher/ui/attachdialog.cpp
@@ -53,7 +53,6 @@ AttachDialog::AttachDialog(QWidget *parent, Qt::WindowFlags f)
 
     m_proxyModel = new ProcessFilterModel(this);
     m_proxyModel->setSourceModel(m_model);
-    m_proxyModel->setDynamicSortFilter(true);
 
     ui->view->setModel(m_proxyModel);
     // hide state

--- a/plugins/mimetypes/mimetypes.cpp
+++ b/plugins/mimetypes/mimetypes.cpp
@@ -13,8 +13,8 @@
 
 #include "mimetypes.h"
 #include "mimetypesmodel.h"
-
-#include <common/recursiveproxymodelbase.h>
+#include <core/remote/serverproxymodel.h>
+#include <QIdentityProxyModel>
 
 using namespace GammaRay;
 
@@ -22,7 +22,7 @@ MimeTypes::MimeTypes(Probe *probe, QObject *parent)
     : QObject(parent)
 {
     auto model = new MimeTypesModel(this);
-    auto proxy = new RecursiveProxyModelBase(this);
+    auto proxy = new ServerProxyModel<QIdentityProxyModel>(this);
     proxy->setSourceModel(model);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.MimeTypeModel"), proxy);
 }

--- a/plugins/modelinspector/modelinspector.cpp
+++ b/plugins/modelinspector/modelinspector.cpp
@@ -20,10 +20,10 @@
 
 #include <core/remote/serverproxymodel.h>
 #include <common/objectbroker.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
+#include <QIdentityProxyModel>
 
 using namespace GammaRay;
 
@@ -40,7 +40,7 @@ ModelInspector::ModelInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, modelModelSource, &ModelModel::objectAdded);
     connect(probe, &Probe::objectDestroyed, modelModelSource, &ModelModel::objectRemoved);
 
-    auto modelModelProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto modelModelProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     modelModelProxy->setSourceModel(modelModelSource);
     m_modelModel = modelModelProxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ModelModel"), m_modelModel);

--- a/plugins/qt3dinspector/3dinspector.cpp
+++ b/plugins/qt3dinspector/3dinspector.cpp
@@ -27,7 +27,6 @@
 
 #include <common/modelevent.h>
 #include <common/objectbroker.h>
-#include <common/recursiveproxymodelbase.h>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <Qt3DCore/QAttribute>
@@ -69,6 +68,7 @@ namespace Qt3DGeometry = Qt3DRender;
 #include <Qt3DCore/QEntity>
 
 #include <QDebug>
+#include <QIdentityProxyModel>
 #include <QItemSelection>
 #include <QItemSelectionModel>
 
@@ -106,7 +106,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_entityModel, &Qt3DEntityTreeModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_entityModel, &Qt3DEntityTreeModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_entityModel, &Qt3DEntityTreeModel::objectReparented);
-    auto entityProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto entityProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     entityProxy->setSourceModel(m_entityModel);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.Qt3DInspector.sceneModel"), entityProxy);
     m_entitySelectionModel = ObjectBroker::selectionModel(entityProxy);
@@ -116,7 +116,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_frameGraphModel, &FrameGraphModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_frameGraphModel, &FrameGraphModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_frameGraphModel, &FrameGraphModel::objectReparented);
-    auto frameGraphProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto frameGraphProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     frameGraphProxy->setSourceModel(m_frameGraphModel);
     probe->registerModel(QStringLiteral(
                              "com.kdab.GammaRay.Qt3DInspector.frameGraphModel"),

--- a/plugins/quickinspector/geometryextension/sggeometrytab.cpp
+++ b/plugins/quickinspector/geometryextension/sggeometrytab.cpp
@@ -40,7 +40,6 @@ void SGGeometryTab::setObjectBaseName(const QString &baseName)
     m_adjacencyModel = ObjectBroker::model(baseName + '.' + "sgGeometryAdjacencyModel");
 
     auto *proxy = new QSortFilterProxyModel(this);
-    proxy->setDynamicSortFilter(true);
     proxy->setSourceModel(m_vertexModel);
     m_ui->tableView->setModel(proxy);
     auto *selectionModel = new QItemSelectionModel(proxy);

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -34,7 +34,6 @@
 #include <common/probecontrollerinterface.h>
 #include <common/problem.h>
 #include <common/remoteviewframe.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <core/enumrepositoryserver.h>
 #include <core/metaenum.h>

--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -31,7 +31,6 @@
 #include <common/endpoint.h>
 #include <common/metatypedeclarations.h>
 #include <common/objectmodel.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <QGraphicsEffect>
 #include <QGraphicsItem>
@@ -40,6 +39,7 @@
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
 #include <QGraphicsView>
+#include <QIdentityProxyModel>
 #include <QItemSelectionModel>
 #include <QTextDocument>
 
@@ -90,7 +90,7 @@ SceneInspector::SceneInspector(Probe *probe, QObject *parent)
             this, &SceneInspector::sceneSelected);
 
     m_sceneModel = new SceneModel(this);
-    auto sceneProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto sceneProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     sceneProxy->setSourceModel(m_sceneModel);
     sceneProxy->addRole(ObjectModel::ObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.SceneGraphModel"), sceneProxy);

--- a/plugins/signalmonitor/signalmonitor.cpp
+++ b/plugins/signalmonitor/signalmonitor.cpp
@@ -33,7 +33,6 @@ SignalMonitor::SignalMonitor(Probe *probe, QObject *parent)
 
     auto *model = new SignalHistoryModel(probe, this);
     auto proxy = new ServerProxyModel<QSortFilterProxyModel>(this);
-    proxy->setDynamicSortFilter(true);
     proxy->setSourceModel(model);
     m_objModel = proxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.SignalHistoryModel"), proxy);

--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -41,7 +41,6 @@
 #include "common/paths.h"
 #include <common/probecontrollerinterface.h>
 #include <common/remoteviewframe.h>
-#include <common/recursiveproxymodelbase.h>
 
 #include <QAction>
 #include <QAbstractItemView>
@@ -71,6 +70,7 @@
 #include <QStyle>
 #include <QToolButton>
 #include <QWindow>
+#include <QIdentityProxyModel>
 
 #include <iostream>
 
@@ -111,7 +111,7 @@ WidgetInspectorServer::WidgetInspectorServer(Probe *probe, QObject *parent)
     auto *widgetFilterProxy = new WidgetTreeModel(this);
     widgetFilterProxy->setSourceModel(probe->objectTreeModel());
 
-    auto widgetSearchProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
+    auto widgetSearchProxy = new ServerProxyModel<QIdentityProxyModel>(this);
     widgetSearchProxy->setSourceModel(widgetFilterProxy);
     widgetSearchProxy->addRole(ObjectModel::ObjectIdRole);
 


### PR DESCRIPTION
- Don't use a recursive sort/filter proxy when a QIdentityProxyModel is enough
- dynamicSortFilter is on by default since Qt 5.0
