### PR TITLE
Revert "Don't use a recursive sort/filter proxy when a QIdentityProxyModel is enough"

### DIFF
--- a/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
+++ b/core/tools/metaobjectbrowser/metaobjectbrowser.cpp
@@ -24,10 +24,10 @@
 #include <common/objectbroker.h>
 #include <common/metatypedeclarations.h>
 #include <common/tools/metaobjectbrowser/qmetaobjectmodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
-#include <QIdentityProxyModel>
 
 using namespace GammaRay;
 
@@ -37,7 +37,7 @@ MetaObjectBrowser::MetaObjectBrowser(Probe *probe, QObject *parent)
     , m_motm(new MetaObjectTreeModel(this))
     , m_model(nullptr)
 {
-    auto model = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto model = new ServerProxyModel<RecursiveProxyModelBase>(this);
     model->addRole(QMetaObjectModel::MetaObjectIssues);
     model->addRole(QMetaObjectModel::MetaObjectInvalid);
     model->setSourceModel(m_motm);

--- a/core/tools/objectinspector/objectinspector.cpp
+++ b/core/tools/objectinspector/objectinspector.cpp
@@ -32,10 +32,10 @@
 #include <core/problemcollector.h>
 #include <core/util.h>
 #include <remote/serverproxymodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QCoreApplication>
 #include <QItemSelectionModel>
-#include <QIdentityProxyModel>
 #include <QMetaMethod>
 
 #include <QMutexLocker>
@@ -52,7 +52,7 @@ ObjectInspector::ObjectInspector(Probe *probe, QObject *parent)
                                                       "com.kdab.GammaRay.ObjectInspector"),
                                                   this);
 
-    auto proxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto proxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     proxy->setSourceModel(probe->objectTreeModel());
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ObjectInspectorTree"), proxy);
 

--- a/plugins/mimetypes/mimetypes.cpp
+++ b/plugins/mimetypes/mimetypes.cpp
@@ -13,8 +13,8 @@
 
 #include "mimetypes.h"
 #include "mimetypesmodel.h"
-#include <core/remote/serverproxymodel.h>
-#include <QIdentityProxyModel>
+
+#include <common/recursiveproxymodelbase.h>
 
 using namespace GammaRay;
 
@@ -22,7 +22,7 @@ MimeTypes::MimeTypes(Probe *probe, QObject *parent)
     : QObject(parent)
 {
     auto model = new MimeTypesModel(this);
-    auto proxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto proxy = new RecursiveProxyModelBase(this);
     proxy->setSourceModel(model);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.MimeTypeModel"), proxy);
 }

--- a/plugins/modelinspector/modelinspector.cpp
+++ b/plugins/modelinspector/modelinspector.cpp
@@ -20,10 +20,10 @@
 
 #include <core/remote/serverproxymodel.h>
 #include <common/objectbroker.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QDebug>
 #include <QItemSelectionModel>
-#include <QIdentityProxyModel>
 
 using namespace GammaRay;
 
@@ -40,7 +40,7 @@ ModelInspector::ModelInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, modelModelSource, &ModelModel::objectAdded);
     connect(probe, &Probe::objectDestroyed, modelModelSource, &ModelModel::objectRemoved);
 
-    auto modelModelProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto modelModelProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     modelModelProxy->setSourceModel(modelModelSource);
     m_modelModel = modelModelProxy;
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.ModelModel"), m_modelModel);

--- a/plugins/qt3dinspector/3dinspector.cpp
+++ b/plugins/qt3dinspector/3dinspector.cpp
@@ -27,6 +27,7 @@
 
 #include <common/modelevent.h>
 #include <common/objectbroker.h>
+#include <common/recursiveproxymodelbase.h>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <Qt3DCore/QAttribute>
@@ -68,7 +69,6 @@ namespace Qt3DGeometry = Qt3DRender;
 #include <Qt3DCore/QEntity>
 
 #include <QDebug>
-#include <QIdentityProxyModel>
 #include <QItemSelection>
 #include <QItemSelectionModel>
 
@@ -106,7 +106,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_entityModel, &Qt3DEntityTreeModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_entityModel, &Qt3DEntityTreeModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_entityModel, &Qt3DEntityTreeModel::objectReparented);
-    auto entityProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto entityProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     entityProxy->setSourceModel(m_entityModel);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.Qt3DInspector.sceneModel"), entityProxy);
     m_entitySelectionModel = ObjectBroker::selectionModel(entityProxy);
@@ -116,7 +116,7 @@ Qt3DInspector::Qt3DInspector(Probe *probe, QObject *parent)
     connect(probe, &Probe::objectCreated, m_frameGraphModel, &FrameGraphModel::objectCreated);
     connect(probe, &Probe::objectDestroyed, m_frameGraphModel, &FrameGraphModel::objectDestroyed);
     connect(probe, &Probe::objectReparented, m_frameGraphModel, &FrameGraphModel::objectReparented);
-    auto frameGraphProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto frameGraphProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     frameGraphProxy->setSourceModel(m_frameGraphModel);
     probe->registerModel(QStringLiteral(
                              "com.kdab.GammaRay.Qt3DInspector.frameGraphModel"),

--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -34,6 +34,7 @@
 #include <common/probecontrollerinterface.h>
 #include <common/problem.h>
 #include <common/remoteviewframe.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <core/enumrepositoryserver.h>
 #include <core/metaenum.h>

--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -31,6 +31,7 @@
 #include <common/endpoint.h>
 #include <common/metatypedeclarations.h>
 #include <common/objectmodel.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QGraphicsEffect>
 #include <QGraphicsItem>
@@ -39,7 +40,6 @@
 #include <QGraphicsProxyWidget>
 #include <QGraphicsWidget>
 #include <QGraphicsView>
-#include <QIdentityProxyModel>
 #include <QItemSelectionModel>
 #include <QTextDocument>
 
@@ -90,7 +90,7 @@ SceneInspector::SceneInspector(Probe *probe, QObject *parent)
             this, &SceneInspector::sceneSelected);
 
     m_sceneModel = new SceneModel(this);
-    auto sceneProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto sceneProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     sceneProxy->setSourceModel(m_sceneModel);
     sceneProxy->addRole(ObjectModel::ObjectIdRole);
     probe->registerModel(QStringLiteral("com.kdab.GammaRay.SceneGraphModel"), sceneProxy);

--- a/plugins/widgetinspector/widgetinspectorserver.cpp
+++ b/plugins/widgetinspector/widgetinspectorserver.cpp
@@ -41,6 +41,7 @@
 #include "common/paths.h"
 #include <common/probecontrollerinterface.h>
 #include <common/remoteviewframe.h>
+#include <common/recursiveproxymodelbase.h>
 
 #include <QAction>
 #include <QAbstractItemView>
@@ -70,7 +71,6 @@
 #include <QStyle>
 #include <QToolButton>
 #include <QWindow>
-#include <QIdentityProxyModel>
 
 #include <iostream>
 
@@ -111,7 +111,7 @@ WidgetInspectorServer::WidgetInspectorServer(Probe *probe, QObject *parent)
     auto *widgetFilterProxy = new WidgetTreeModel(this);
     widgetFilterProxy->setSourceModel(probe->objectTreeModel());
 
-    auto widgetSearchProxy = new ServerProxyModel<QIdentityProxyModel>(this);
+    auto widgetSearchProxy = new ServerProxyModel<RecursiveProxyModelBase>(this);
     widgetSearchProxy->setSourceModel(widgetFilterProxy);
     widgetSearchProxy->addRole(ObjectModel::ObjectIdRole);
 


### PR DESCRIPTION
The QSFPMs are actually used for the filter lineedits (despite being on the server side, so I didn't expect that).

This reverts commit c2edaf5c5a1e073628a72843f8b94b29b61f0bc0 (and a bit of 3783c1724802fa2bab702f1fd4711be0404b5b27).