### PR TITLE
Show classnames next to objectNames, when different

### DIFF
--- a/core/objectdataprovider.cpp
+++ b/core/objectdataprovider.cpp
@@ -48,7 +48,7 @@ QString ObjectDataProvider::name(const QObject *obj)
     return name;
 }
 
-QString ObjectDataProvider::typeName(QObject *obj)
+QString ObjectDataProvider::typeName(const QObject *obj)
 {
     if (!obj)
         return QString();
@@ -61,7 +61,7 @@ QString ObjectDataProvider::typeName(QObject *obj)
     return obj->metaObject()->className();
 }
 
-QString ObjectDataProvider::shortTypeName(QObject *obj)
+QString ObjectDataProvider::shortTypeName(const QObject *obj)
 {
     if (!obj)
         return QString();
@@ -74,7 +74,7 @@ QString ObjectDataProvider::shortTypeName(QObject *obj)
     return obj->metaObject()->className();
 }
 
-SourceLocation ObjectDataProvider::creationLocation(QObject *obj)
+SourceLocation ObjectDataProvider::creationLocation(const QObject *obj)
 {
     SourceLocation loc;
     if (!obj)
@@ -90,7 +90,7 @@ SourceLocation ObjectDataProvider::creationLocation(QObject *obj)
     return loc;
 }
 
-SourceLocation ObjectDataProvider::declarationLocation(QObject *obj)
+SourceLocation ObjectDataProvider::declarationLocation(const QObject *obj)
 {
     SourceLocation loc;
     if (!obj)

--- a/core/objectdataprovider.h
+++ b/core/objectdataprovider.h
@@ -38,13 +38,13 @@ public:
     /*! Returns a name or identifier for @p obj. */
     virtual QString name(const QObject *obj) const = 0;
     /*! Returns the full name of the type of @p obj. */
-    virtual QString typeName(QObject *obj) const = 0;
+    virtual QString typeName(const QObject *obj) const = 0;
     /*! Returns a shortened type name (e.g. excluding namespaces) for @p obj. */
-    virtual QString shortTypeName(QObject *obj) const = 0;
+    virtual QString shortTypeName(const QObject *obj) const = 0;
     /*! Returns the source location where @p obj has been created. */
-    virtual SourceLocation creationLocation(QObject *obj) const = 0;
+    virtual SourceLocation creationLocation(const QObject *obj) const = 0;
     /*! Returns the source location where the type of @p obj has been declared. */
-    virtual SourceLocation declarationLocation(QObject *obj) const = 0;
+    virtual SourceLocation declarationLocation(const QObject *obj) const = 0;
 
 private:
     Q_DISABLE_COPY(AbstractObjectDataProvider)
@@ -61,16 +61,16 @@ GAMMARAY_CORE_EXPORT void registerProvider(AbstractObjectDataProvider *provider)
 GAMMARAY_CORE_EXPORT QString name(const QObject *obj);
 
 /*! Returns the type name of @p obj. */
-GAMMARAY_CORE_EXPORT QString typeName(QObject *obj);
+GAMMARAY_CORE_EXPORT QString typeName(const QObject *obj);
 
 /*! Returns the short type name of @p obj. */
-GAMMARAY_CORE_EXPORT QString shortTypeName(QObject *obj);
+GAMMARAY_CORE_EXPORT QString shortTypeName(const QObject *obj);
 
 /*! Returns the source location where this object was created, if known. */
-GAMMARAY_CORE_EXPORT SourceLocation creationLocation(QObject *obj);
+GAMMARAY_CORE_EXPORT SourceLocation creationLocation(const QObject *obj);
 
 /*! Returns the source location where the type of this object was declared, if known. */
-GAMMARAY_CORE_EXPORT SourceLocation declarationLocation(QObject *obj);
+GAMMARAY_CORE_EXPORT SourceLocation declarationLocation(const QObject *obj);
 }
 }
 

--- a/core/probe.cpp
+++ b/core/probe.cpp
@@ -1009,14 +1009,15 @@ void Probe::executeSignalCallback(const Func &func)
                   func);
 }
 
-SourceLocation Probe::objectCreationSourceLocation(QObject *object)
+SourceLocation Probe::objectCreationSourceLocation(const QObject *object)
 {
-    if (!s_listener()->constructionBacktracesForObjects.contains(object)) {
+    QObject *key = const_cast<QObject *>(object);
+    if (!s_listener()->constructionBacktracesForObjects.contains(key)) {
         IF_DEBUG(std::cout << "No backtrace for object available" << object << "." << std::endl;)
         return SourceLocation();
     }
 
-    const auto &st = s_listener()->constructionBacktracesForObjects.value(object);
+    const auto &st = s_listener()->constructionBacktracesForObjects.value(key);
     int distanceToQObject = 0;
 
     const QMetaObject *metaObject = object->metaObject();

--- a/core/probe.h
+++ b/core/probe.h
@@ -182,7 +182,7 @@ public:
     void registerSignalSpyCallbackSet(const SignalSpyCallbackSet &callbacks);
 
     /*! Returns the source code location @p object was created at. */
-    static SourceLocation objectCreationSourceLocation(QObject *object);
+    static SourceLocation objectCreationSourceLocation(const QObject *object);
     /*! Returns the entire stack trace for the creation of @p object. */
     static Execution::Trace objectCreationStackTrace(QObject *object);
 

--- a/core/util.cpp
+++ b/core/util.cpp
@@ -42,11 +42,14 @@ using namespace std;
 QString Util::displayString(const QObject *object)
 {
     if (!object)
-        return QStringLiteral("QObject(0x0)");
+        return QStringLiteral("0x0 (QObject)");
     const auto name = ObjectDataProvider::name(object);
     if (name.isEmpty())
-        return QStringLiteral("%1[this=%2]").arg(object->metaObject()->className(), addressToString(object));
-    return name;
+        return QStringLiteral("%1 (%2)").arg(addressToString(object), object->metaObject()->className());
+    const auto typeName = ObjectDataProvider::typeName(object);
+    if (name == typeName)
+        return name;
+    return QStringLiteral("%1 (%2)").arg(ObjectDataProvider::typeName(object), name);
 }
 
 QString Util::shortDisplayString(const QObject *object)

--- a/plugins/qmlsupport/qmlsupport.cpp
+++ b/plugins/qmlsupport/qmlsupport.cpp
@@ -186,10 +186,10 @@ class QmlObjectDataProvider : public AbstractObjectDataProvider
 {
 public:
     QString name(const QObject *obj) const override;
-    QString typeName(QObject *obj) const override;
-    QString shortTypeName(QObject *obj) const override;
-    SourceLocation creationLocation(QObject *obj) const override;
-    SourceLocation declarationLocation(QObject *obj) const override;
+    QString typeName(const QObject *obj) const override;
+    QString shortTypeName(const QObject *obj) const override;
+    SourceLocation creationLocation(const QObject *obj) const override;
+    SourceLocation declarationLocation(const QObject *obj) const override;
 };
 }
 
@@ -202,7 +202,7 @@ QString QmlObjectDataProvider::name(const QObject *obj) const
     return ctx->nameForObject(const_cast<QObject *>(obj));
 }
 
-QString QmlObjectDataProvider::typeName(QObject *obj) const
+QString QmlObjectDataProvider::typeName(const QObject *obj) const
 {
     Q_ASSERT(obj);
 
@@ -234,7 +234,7 @@ QString QmlObjectDataProvider::typeName(QObject *obj) const
     return QString();
 }
 
-QString QmlObjectDataProvider::shortTypeName(QObject *obj) const
+QString QmlObjectDataProvider::shortTypeName(const QObject *obj) const
 {
     auto n = typeName(obj);
     const auto isQmlType = !n.isEmpty();
@@ -255,13 +255,13 @@ QString QmlObjectDataProvider::shortTypeName(QObject *obj) const
     return isQmlType ? n : QString(); // let somebody else handle shortening of non-QML names
 }
 
-SourceLocation QmlObjectDataProvider::creationLocation(QObject *obj) const
+SourceLocation QmlObjectDataProvider::creationLocation(const QObject *obj) const
 {
     SourceLocation loc;
 
     auto objectData = QQmlData::get(obj);
     if (!objectData) {
-        if (auto context = qobject_cast<QQmlContext *>(obj)) {
+        if (auto context = qobject_cast<const QQmlContext *>(obj)) {
             loc.setUrl(context->baseUrl());
         }
         return loc;
@@ -277,7 +277,7 @@ SourceLocation QmlObjectDataProvider::creationLocation(QObject *obj) const
     return loc;
 }
 
-SourceLocation QmlObjectDataProvider::declarationLocation(QObject *obj) const
+SourceLocation QmlObjectDataProvider::declarationLocation(const QObject *obj) const
 {
     Q_ASSERT(obj);
 


### PR DESCRIPTION
  Property     | Value                        | Type     | Class
Before:
  parent       | m_loadingWidget              | QObject* | QObject
After:
  parent       | m_loadingWidget (QSvgWidget) | QObject* | QObject

Should this be QSvgWidget* with a star?
Or something more consistent with the case where there's no objectName, which shows "QFrame[this=0xdcd22e0]" ?

The change propagated to other classes to fix const [in]correctness (the const_cast is only because of QHash API, it shouldn't be necessary for the caller of those methods).