### PR TITLE
Modernize cmake usage a little bit

### DIFF
--- a/3rdparty/kde/CMakeLists.txt
+++ b/3rdparty/kde/CMakeLists.txt
@@ -8,7 +8,7 @@ set(gammaray_kitemmodels_srcs
 
 add_library(gammaray_kitemmodels SHARED ${gammaray_kitemmodels_srcs})
 
-target_link_libraries(gammaray_kitemmodels LINK_PUBLIC Qt::Core)
+target_link_libraries(gammaray_kitemmodels PUBLIC Qt::Core)
 
 set_target_properties(gammaray_kitemmodels PROPERTIES
   ${GAMMARAY_DEFAULT_LIBRARY_PROPERTIES}

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -52,15 +52,13 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_client
-  PUBLIC
-    Qt::Core
-  PRIVATE
-    gammaray_ui
-    gammaray_ui_internal
-    gammaray_common
-    Qt::Gui
-    Qt::Widgets
-    Qt::Network
+    PUBLIC Qt::Core
+    PRIVATE gammaray_ui
+            gammaray_ui_internal
+            gammaray_common
+            Qt::Gui
+            Qt::Widgets
+            Qt::Network
 )
 if(GAMMARAY_USE_PCH)
     target_precompile_headers(gammaray_client REUSE_FROM gammaray_pch_core_gui)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -52,9 +52,9 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_client
-    LINK_PUBLIC
+  PUBLIC
     Qt::Core
-    LINK_PRIVATE
+  PRIVATE
     gammaray_ui
     gammaray_ui_internal
     gammaray_common

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -73,19 +73,12 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_common
-  PUBLIC
-    Qt::Core
-  PRIVATE
-    Qt::Network
-    Qt::Gui
-    Qt::GuiPrivate
+    PUBLIC Qt::Core
+    PRIVATE Qt::Network Qt::Gui Qt::GuiPrivate
 )
 target_link_libraries(
     gammaray_common
-  PRIVATE
-    gammaray_lz4
-    gammaray_kitemmodels
-    ${CMAKE_DL_LIBS}
+    PRIVATE gammaray_lz4 gammaray_kitemmodels ${CMAKE_DL_LIBS}
 )
 gammaray_set_rpath(gammaray_common ${LIB_INSTALL_DIR})
 if(GAMMARAY_USE_PCH)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -73,16 +73,16 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_common
-    LINK_PUBLIC
+  PUBLIC
     Qt::Core
-    LINK_PRIVATE
+  PRIVATE
     Qt::Network
     Qt::Gui
     Qt::GuiPrivate
 )
 target_link_libraries(
     gammaray_common
-    LINK_PRIVATE
+  PRIVATE
     gammaray_lz4
     gammaray_kitemmodels
     ${CMAKE_DL_LIBS}

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -128,9 +128,9 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_core
-    LINK_PUBLIC
+  PUBLIC
     gammaray_common
-    LINK_PRIVATE
+  PRIVATE
     gammaray_common_internal
     gammaray_kitemmodels
     ${CMAKE_DL_LIBS}
@@ -149,14 +149,14 @@ gammaray_set_rpath(gammaray_core ${LIB_INSTALL_DIR})
 
 target_link_libraries(
     gammaray_core
-    LINK_PUBLIC
+  PUBLIC
     Qt::Core
-    LINK_PRIVATE
+  PRIVATE
     Qt::Gui
     Qt::GuiPrivate
 )
 if(TARGET Qt::AndroidExtras)
-    target_link_libraries(gammaray_core LINK_PRIVATE Qt::AndroidExtras)
+    target_link_libraries(gammaray_core PRIVATE Qt::AndroidExtras)
 endif()
 
 add_backward(gammaray_core)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -128,14 +128,12 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_core
-  PUBLIC
-    gammaray_common
-  PRIVATE
-    gammaray_common_internal
-    gammaray_kitemmodels
-    ${CMAKE_DL_LIBS}
-    Qt::CorePrivate
-    Qt::GuiPrivate
+    PUBLIC gammaray_common
+    PRIVATE gammaray_common_internal
+            gammaray_kitemmodels
+            ${CMAKE_DL_LIBS}
+            Qt::CorePrivate
+            Qt::GuiPrivate
 )
 if(GAMMARAY_USE_PCH)
     target_precompile_headers(gammaray_core REUSE_FROM gammaray_pch_core_gui)
@@ -149,11 +147,8 @@ gammaray_set_rpath(gammaray_core ${LIB_INSTALL_DIR})
 
 target_link_libraries(
     gammaray_core
-  PUBLIC
-    Qt::Core
-  PRIVATE
-    Qt::Gui
-    Qt::GuiPrivate
+    PUBLIC Qt::Core
+    PRIVATE Qt::Gui Qt::GuiPrivate
 )
 if(TARGET Qt::AndroidExtras)
     target_link_libraries(gammaray_core PRIVATE Qt::AndroidExtras)

--- a/launcher/core/CMakeLists.txt
+++ b/launcher/core/CMakeLists.txt
@@ -69,20 +69,20 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_launcher
-    LINK_PUBLIC
+  PUBLIC
     Qt::Core
-    LINK_PRIVATE
+  PRIVATE
     gammaray_common
     Qt::Network
     ${CMAKE_DL_LIBS}
 )
 if(HAVE_QT_WIDGETS)
-    target_link_libraries(gammaray_launcher LINK_PRIVATE Qt::Gui Qt::Widgets)
+    target_link_libraries(gammaray_launcher PRIVATE Qt::Gui Qt::Widgets)
 endif()
 if(WIN32)
-    target_link_libraries(gammaray_launcher LINK_PRIVATE version)
+    target_link_libraries(gammaray_launcher PRIVATE version)
 elseif(APPLE)
-    target_link_libraries(gammaray_launcher LINK_PRIVATE "-framework CoreFoundation")
+    target_link_libraries(gammaray_launcher PRIVATE "-framework CoreFoundation")
 endif()
 
 install(

--- a/launcher/core/CMakeLists.txt
+++ b/launcher/core/CMakeLists.txt
@@ -69,12 +69,8 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_launcher
-  PUBLIC
-    Qt::Core
-  PRIVATE
-    gammaray_common
-    Qt::Network
-    ${CMAKE_DL_LIBS}
+    PUBLIC Qt::Core
+    PRIVATE gammaray_common Qt::Network ${CMAKE_DL_LIBS}
 )
 if(HAVE_QT_WIDGETS)
     target_link_libraries(gammaray_launcher PRIVATE Qt::Gui Qt::Widgets)

--- a/launcher/ui/CMakeLists.txt
+++ b/launcher/ui/CMakeLists.txt
@@ -40,9 +40,9 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_launcher_ui
-    LINK_PUBLIC
+  PUBLIC
     gammaray_launcher
-    LINK_PRIVATE
+  PRIVATE
     Qt::Core
     Qt::Concurrent
     Qt::Gui

--- a/launcher/ui/CMakeLists.txt
+++ b/launcher/ui/CMakeLists.txt
@@ -40,15 +40,13 @@ target_include_directories(
 )
 target_link_libraries(
     gammaray_launcher_ui
-  PUBLIC
-    gammaray_launcher
-  PRIVATE
-    Qt::Core
-    Qt::Concurrent
-    Qt::Gui
-    Qt::Widgets
-    Qt::Network
-    gammaray_ui
+    PUBLIC gammaray_launcher
+    PRIVATE Qt::Core
+            Qt::Concurrent
+            Qt::Gui
+            Qt::Widgets
+            Qt::Network
+            gammaray_ui
 )
 
 install(

--- a/plugins/signalmonitor/CMakeLists.txt
+++ b/plugins/signalmonitor/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(
     ${gammaray_signalmonitor_shared_srcs}
 )
 target_link_libraries(
-    gammaray_signalmonitor_shared LINK_PRIVATE gammaray_common
+    gammaray_signalmonitor_shared PRIVATE gammaray_common
 )
 set_target_properties(gammaray_signalmonitor_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_features(gammaray_signalmonitor_shared PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})

--- a/plugins/signalmonitor/CMakeLists.txt
+++ b/plugins/signalmonitor/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(
     ${gammaray_signalmonitor_shared_srcs}
 )
 target_link_libraries(
-    gammaray_signalmonitor_shared PRIVATE gammaray_common
+    gammaray_signalmonitor_shared
+    PRIVATE gammaray_common
 )
 set_target_properties(gammaray_signalmonitor_shared PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_features(gammaray_signalmonitor_shared PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -113,15 +113,8 @@ target_include_directories(
 
 target_link_libraries(
     gammaray_ui
-  PUBLIC
-    Qt::Core
-    Qt::Gui
-    Qt::Widgets
-    gammaray_common
-  PRIVATE
-    gammaray_common_internal
-    gammaray_kitemmodels
-    Qt::WidgetsPrivate
+    PUBLIC Qt::Core Qt::Gui Qt::Widgets gammaray_common
+    PRIVATE gammaray_common_internal gammaray_kitemmodels Qt::WidgetsPrivate
 )
 if(TARGET KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
     target_link_libraries(gammaray_ui PRIVATE KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -113,18 +113,18 @@ target_include_directories(
 
 target_link_libraries(
     gammaray_ui
-    LINK_PUBLIC
+  PUBLIC
     Qt::Core
     Qt::Gui
     Qt::Widgets
     gammaray_common
-    LINK_PRIVATE
+  PRIVATE
     gammaray_common_internal
     gammaray_kitemmodels
     Qt::WidgetsPrivate
 )
 if(TARGET KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
-    target_link_libraries(gammaray_ui LINK_PRIVATE KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
+    target_link_libraries(gammaray_ui PRIVATE KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
 endif()
 
 set(gammaray_ui_internal_srcs


### PR DESCRIPTION
I haven't seen LINK_PRIVATE/LINK_PUBLIC in ages, they're deprecated in favour of PRIVATE/PUBLIC, which exist since CMake 3.0 if I see correctly. Also improve indentation.