### PR TITLE
Docs: Remove contentspage commands

### DIFF
--- a/docs/manual/gammaray-action-inspector.qdoc
+++ b/docs/manual/gammaray-action-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Models}
     \previouspage {Object Browser}
     \page gammaray-action-inspector.html

--- a/docs/manual/gammaray-advanced-usage.qdoc
+++ b/docs/manual/gammaray-advanced-usage.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Examples}
     \nextpage {Licenses and Attributions}
     \page gammaray-advanced-usage.html

--- a/docs/manual/gammaray-application-attributes.qdoc
+++ b/docs/manual/gammaray-application-attributes.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Qt3D Geometry Inspector}
     \nextpage {HTTP Cookies}
     \page gammaray-application-attributes.html

--- a/docs/manual/gammaray-basic-operations.qdoc
+++ b/docs/manual/gammaray-basic-operations.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Getting Started}
     \nextpage {Graphical Launcher}
     \previouspage {Installation}
     \page gammaray-basic-operations.html

--- a/docs/manual/gammaray-classinfo.qdoc
+++ b/docs/manual/gammaray-classinfo.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Enums and Flags}
     \nextpage {Stack Trace}
     \page gammaray-classinfo.html

--- a/docs/manual/gammaray-client.qdoc
+++ b/docs/manual/gammaray-client.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Getting Started}
     \nextpage {Qt Creator Integration}
     \previouspage {Graphical Launcher}
     \page gammaray-client.html

--- a/docs/manual/gammaray-codec-browser.qdoc
+++ b/docs/manual/gammaray-codec-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \previouspage {Network}
     \nextpage {System Information}
     \page gammaray-codec-browser.html

--- a/docs/manual/gammaray-command-line.qdoc
+++ b/docs/manual/gammaray-command-line.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Gettings Started}
     \nextpage {Tools}
     \previouspage {Qt Creator Integration}
     \page gammaray-command-line.html

--- a/docs/manual/gammaray-connections.qdoc
+++ b/docs/manual/gammaray-connections.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Methods}
     \nextpage {Enums and Flags}
     \page gammaray-connections.html

--- a/docs/manual/gammaray-enums.qdoc
+++ b/docs/manual/gammaray-enums.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Connections}
     \nextpage {Class Info}
     \page gammaray-enums.html

--- a/docs/manual/gammaray-event-monitor.qdoc
+++ b/docs/manual/gammaray-event-monitor.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Wayland Compositors}
     \previouspage {Timers}
     \page gammaray-event-monitor.html

--- a/docs/manual/gammaray-examples.qdoc
+++ b/docs/manual/gammaray-examples.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage{GammaRay User Manual}
     \previouspage {Problem Reporter}
     \nextpage {Advanced Usage}
     \group examples-gammaray

--- a/docs/manual/gammaray-font-browser.qdoc
+++ b/docs/manual/gammaray-font-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Locales}
     \previouspage {Geo Positioning}
     \page gammaray-font-browser.html

--- a/docs/manual/gammaray-geo-positioning.qdoc
+++ b/docs/manual/gammaray-geo-positioning.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Geo Positioning}
     \nextpage {Font Browser}
     \previouspage {Meta Type Browser}
     \page gammaray-geo-positioning.html

--- a/docs/manual/gammaray-getting-started.qdoc
+++ b/docs/manual/gammaray-getting-started.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage {Installation}
     \previouspage {Gammaray User Manual}
     \page gammaray-getting-started.html

--- a/docs/manual/gammaray-graphicsscene.qdoc
+++ b/docs/manual/gammaray-graphicsscene.qdoc
@@ -12,8 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
-    \contentspage {Graphics Scene Inspector}
     \nextpage {Qt3D Inspector}
     \previouspage {Widget Inspector}
     \page gammaray-graphicsscene-inspector.html

--- a/docs/manual/gammaray-http-cookies.qdoc
+++ b/docs/manual/gammaray-http-cookies.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage{Problem Reporter}
     \previouspage{Application Attributes}
     \page gammaray-http-cookies.html

--- a/docs/manual/gammaray-install.qdoc
+++ b/docs/manual/gammaray-install.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Getting Started}
     \nextpage {Basic Operations}
     \previouspage {Getting Started}
     \page gammaray-install.html

--- a/docs/manual/gammaray-launcher-gui.qdoc
+++ b/docs/manual/gammaray-launcher-gui.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Getting Started}
     \nextpage {GammaRay Client}
     \previouspage {Basic Operations}
     \page gammaray-launcher-gui.html

--- a/docs/manual/gammaray-licenses-and-attribtions.qdoc
+++ b/docs/manual/gammaray-licenses-and-attribtions.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage{GammaRay User Manual}
     \page gammaray-licenses-and-attributions.html
 
     \title Licenses and Attributions

--- a/docs/manual/gammaray-locales.qdoc
+++ b/docs/manual/gammaray-locales.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Mime Types}
     \previouspage {Font Browser}
     \page gammaray-locales.html

--- a/docs/manual/gammaray-messages.qdoc
+++ b/docs/manual/gammaray-messages.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Signal Plotter}
     \previouspage {State Machine Debugger}
     \page gammaray-messages.html

--- a/docs/manual/gammaray-metaobject-browser.qdoc
+++ b/docs/manual/gammaray-metaobject-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage{Meta Type Browser}
     \previouspage {Translations}
     \page gammaray-metaobject-browser.html

--- a/docs/manual/gammaray-metatype-browser.qdoc
+++ b/docs/manual/gammaray-metatype-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Meta Type Browser}
     \nextpage{Geo Positioning}
     \previouspage {Meta Object Browser}
     \page gammaray-metatype-browser.html

--- a/docs/manual/gammaray-methods.qdoc
+++ b/docs/manual/gammaray-methods.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Properties}
     \nextpage {Connections}
     \page gammaray-methods.html

--- a/docs/manual/gammaray-mime-types.qdoc
+++ b/docs/manual/gammaray-mime-types.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Network}
     \previouspage {Locales}
     \page gammaray-mime-types.html

--- a/docs/manual/gammaray-model-inspector.qdoc
+++ b/docs/manual/gammaray-model-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Text Documents}
     \previouspage {Actions}
     \page gammaray-model-inspector.html

--- a/docs/manual/gammaray-network.qdoc
+++ b/docs/manual/gammaray-network.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \previouspage {Mime Types}
     \nextpage {Text Codecs}
     \page gammaray-network.html

--- a/docs/manual/gammaray-object-inspection.qdoc
+++ b/docs/manual/gammaray-object-inspection.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {System Information}
     \nextpage {Properties}
     \page gammaray-object-inspection.html

--- a/docs/manual/gammaray-paint-analyzer.qdoc
+++ b/docs/manual/gammaray-paint-analyzer.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage{Scene Graph Texture}
     \nextpage{Widget Attributes}
     \page gammaray-paint-analyzer.html

--- a/docs/manual/gammaray-problem-reporter.qdoc
+++ b/docs/manual/gammaray-problem-reporter.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Object Inspection}
     \nextpage {Examples}
     \page gammaray-problem-reporter.html

--- a/docs/manual/gammaray-properties.qdoc
+++ b/docs/manual/gammaray-properties.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Object Inspection}
     \nextpage {Methods}
     \page gammaray-properties.html

--- a/docs/manual/gammaray-qmlbindings.qdoc
+++ b/docs/manual/gammaray-qmlbindings.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage {QML Context}
     \previouspage {Stack Trace}
     \page gammaray-qmlbindings.html

--- a/docs/manual/gammaray-qmlcontext.qdoc
+++ b/docs/manual/gammaray-qmlcontext.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage{Bindings}
     \nextpage{QML Type}
     \page gammaray-qmlcontext.html

--- a/docs/manual/gammaray-qmltype.qdoc
+++ b/docs/manual/gammaray-qmltype.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage{Scene Graph Material}
     \previouspage{QML Context}
     \page gammaray-qmltype.html

--- a/docs/manual/gammaray-qobject-browser.qdoc
+++ b/docs/manual/gammaray-qobject-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Actions}
     \previouspage {Timers}
     \page gammaray-qobject-browser.html

--- a/docs/manual/gammaray-qresource-browser.qdoc
+++ b/docs/manual/gammaray-qresource-browser.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Translations}
     \previouspage {Text Documents}
     \page gammaray-qresource-browser.html

--- a/docs/manual/gammaray-qsggeometry.qdoc
+++ b/docs/manual/gammaray-qsggeometry.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage{Scene Graph Material}
     \nextpage{Scene Graph Texture}
     \page gammaray-qsggeometry.html

--- a/docs/manual/gammaray-qsgmaterial.qdoc
+++ b/docs/manual/gammaray-qsgmaterial.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage{QML Type}
     \nextpage{Scene Graph Geometry}
     \page gammaray-qsgmaterial.html

--- a/docs/manual/gammaray-qsgtexture.qdoc
+++ b/docs/manual/gammaray-qsgtexture.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage{Paint Analyzer}
     \previouspage {Scene Graph Geometry}
     \page gammaray-qsgtexture.html

--- a/docs/manual/gammaray-qt3d-inspector.qdoc
+++ b/docs/manual/gammaray-qt3d-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Qt3D Inspector}
     \nextpage {Styles}
     \previouspage {Graphics Scene Inspector}
     \page gammaray-qt3d-inspector.html

--- a/docs/manual/gammaray-qt3dgeometry.qdoc
+++ b/docs/manual/gammaray-qt3dgeometry.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage{Widget Attributes}
     \nextpage{Application Attributes}
     \page gammaray-qt3dgeometry-inspector.html

--- a/docs/manual/gammaray-qtcreator.qdoc
+++ b/docs/manual/gammaray-qtcreator.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Command Line Interface}
     \previouspage {GammaRay Client}
     \page gammaray-qtcreator.html

--- a/docs/manual/gammaray-qtquick2-inspector.qdoc
+++ b/docs/manual/gammaray-qtquick2-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Widget Inspector}
     \previouspage {Tools}
     \page gammaray-qtquick2-inspector.html

--- a/docs/manual/gammaray-signal-plotter.qdoc
+++ b/docs/manual/gammaray-signal-plotter.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Timers}
     \previouspage {Messages}
     \page gammaray-signal-plotter.html

--- a/docs/manual/gammaray-stack-trace.qdoc
+++ b/docs/manual/gammaray-stack-trace.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Class Info}
     \nextpage {Bindings}
     \page gammaray-stack-trace.html

--- a/docs/manual/gammaray-standard-paths.qdoc
+++ b/docs/manual/gammaray-standard-paths.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {System Information}
     \previouspage {Text Codecs}
     \nextpage {Object Inspection}
     \page gammaray-standard-paths.html

--- a/docs/manual/gammaray-state-machine-debugger.qdoc
+++ b/docs/manual/gammaray-state-machine-debugger.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Messages}
     \previouspage {Web Inspector}
     \page gammaray-state-machine-debugger.html

--- a/docs/manual/gammaray-styles.qdoc
+++ b/docs/manual/gammaray-styles.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Web Inspector}
     \previouspage {Qt3D Inspector}
     \page gammaray-styles.html

--- a/docs/manual/gammaray-text-documents.qdoc
+++ b/docs/manual/gammaray-text-documents.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Resources}
     \previouspage {Models}
     \page gammaray-text-documents.html

--- a/docs/manual/gammaray-timertop.qdoc
+++ b/docs/manual/gammaray-timertop.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Events}
     \previouspage {Signal Plotter}
     \page gammaray-timertop.html

--- a/docs/manual/gammaray-tools.qdoc
+++ b/docs/manual/gammaray-tools.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \nextpage {Qt Quick 2 Inspector}
     \previouspage {Command Line Interface}
     \page gammaray-tools.html

--- a/docs/manual/gammaray-translator-inspector.qdoc
+++ b/docs/manual/gammaray-translator-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Translations}
     \nextpage {Meta Object Browser}
     \previouspage {Resources}
     \page gammaray-translator-inspector.html

--- a/docs/manual/gammaray-wayland-compositors.qdoc
+++ b/docs/manual/gammaray-wayland-compositors.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Wayland Compositors}
     \nextpage {Object Browser}
     \previouspage {Events}
     \page gammaray-wayland-compositors.html

--- a/docs/manual/gammaray-web-inspector.qdoc
+++ b/docs/manual/gammaray-web-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {State Machine Debugger}
     \previouspage {Styles}
     \page gammaray-web-Inspector.html

--- a/docs/manual/gammaray-widget-attributes.qdoc
+++ b/docs/manual/gammaray-widget-attributes.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {GammaRay User Manual}
     \previouspage {Paint Analyzer}
     \nextpage {Qt3D Geometry Inspector}
     \page gammaray-widget-attributes.html

--- a/docs/manual/gammaray-widget-inspector.qdoc
+++ b/docs/manual/gammaray-widget-inspector.qdoc
@@ -12,7 +12,6 @@
 */
 
 /*!
-    \contentspage {Tools}
     \nextpage {Graphics Scene Inspector}
     \previouspage {Qt Quick 2 Inspector}
     \page gammaray-widget-Inspector.html


### PR DESCRIPTION
According to commits in the qttools repository, contentspage has done nothing since Qt 5.3, so its documentation was removed in Qt 5.15, and the command itself was removed from Qt 6.

(Indeed, when building the documentation using Qt6 `qdoc`, the commands end up appearing in the rendered docs:)

![image](https://github.com/KDAB/GammaRay/assets/538020/cc1e13f1-0027-416c-90fe-0a79ad7a8cf1)
