### PR TITLE
Require Qt5.15 or above

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ Release Highlights
 
 Version 3.1.0 (unreleased)
 --------------------------
- *
+ * Qt5 versions less than 5.15 are no longer supported
 
 Version 3.0.1 (unreleased)
 --------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ if(NOT DEFINED QT_VERSION_MAJOR)
     #
     find_package(
         QT
-        5.5
+        5.15
         NAMES
         Qt6
         Qt5

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,8 @@ To build GammaRay you will need *at least*:
 
 - CMake 3.16.0
 - a C++ compiler with C++11 support
-- Qt 5.5 or higher, or Qt 6
+- Qt 5.15 or higher, or Qt 6
+  (GammaRay v3.0.1 was the last release to support Qt versions less than 5.15)
 
 Please be aware that GammaRay heavily relies on Qt private headers which can
 be changed at will by The Qt Company between releases and may need to be

--- a/docs/manual/gammaray-install.qdoc
+++ b/docs/manual/gammaray-install.qdoc
@@ -60,7 +60,7 @@
     You can obtain the source code of GammaRay on \l{https://github.com/KDAB/GammaRay}{Github}. To build it you need
     the following requirements:
     \list
-        \li Qt 5.5 or newer
+        \li Qt 5.15 or newer
         \li CMake 3.4 or newer
         \li a C++11 compatible compiler
     \endlist
@@ -158,6 +158,6 @@
         export PATH=<toolchain>:$PATH
 
         cd <builddir>
-        cmake -DCMAKE_TOOLCHAIN_FILE=<srcdir>/cmake/Toolchain-RPI.cmake  -DCMAKE_PREFIX_PATH=$SYSROOT/usr/local/Qt-5.5.1 -DCMAKE_INSTALL_PREFIX=$SYSROOT/usr/ -DGAMMARAY_BUILD_UI=OFF
+        cmake -DCMAKE_TOOLCHAIN_FILE=<srcdir>/cmake/Toolchain-RPI.cmake  -DCMAKE_PREFIX_PATH=$SYSROOT/usr/local/Qt-5.15.1 -DCMAKE_INSTALL_PREFIX=$SYSROOT/usr/ -DGAMMARAY_BUILD_UI=OFF
     \endcode
 */


### PR DESCRIPTION
i.e no longer support Qt5 versions < 5.15

Future patches will remove code specific for Qt versions less than 5.15.