### PR TITLE
Add build*/ dirs to gitignore due reuse-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ perf.data*
 
 # ts generation
 translations/plugin_meta_data.cpp
+build*/


### PR DESCRIPTION
reuse-tool doesn't use pre-commit exclude,
it uses .gitignore instead.