### PR TITLE
FindQmlLint: Prefer to use the Qt::qmllint target

### DIFF
--- a/cmake/FindQmlLint.cmake
+++ b/cmake/FindQmlLint.cmake
@@ -8,49 +8,65 @@
 # Contact KDAB at <info@kdab.com> for commercial licensing options.
 #
 
-find_program(QMLLINT_EXECUTABLE qmllint)
-if(QMLLINT_EXECUTABLE)
-    if(NOT QMLLINT_IS_WORKING)
-        # Try to fix common problems on Debian-based distros -- they provide /usr/bin/qmllint,
-        # which is a symlink to /usr/lib/x86_64-linux-gnu/qt4/bin/qmllint (or the Qt5 version of it).
-        # The actual executable is part of different package, so might not even be installed =>
-        # double-check whether qmllint is working by executing it
-        execute_process(
-            COMMAND ${QMLLINT_EXECUTABLE} --version
-            RESULT_VARIABLE _qmllint_result
-            OUTPUT_QUIET ERROR_QUIET
-        )
-        if(_qmllint_result EQUAL 0)
-            set(QMLLINT_IS_WORKING
-                TRUE
-                CACHE BOOL "Whether the found qmllint executable is actually usable" FORCE
+set(QmlLint_EXECUTABLE)
+set(QmlLint_FOUND FALSE)
+
+# First check for a target (Qt6)
+if(TARGET Qt${QT_VERSION_MAJOR}::qmllint)
+    set(QmlLint_FOUND TRUE)
+    set(QmlLint_EXECUTABLE Qt${QT_VERSION_MAJOR}::qmllint)
+else()
+    # See if it's on the PATH
+    find_program(QmlLint_EXECUTABLE qmllint)
+    if(QmlLint_EXECUTABLE)
+        if(NOT QMLLINT_IS_WORKING)
+            # Try to fix common problems on Debian-based distros -- they provide /usr/bin/qmllint,
+            # which is a symlink to /usr/lib/x86_64-linux-gnu/qt4/bin/qmllint (or the Qt5 version of it).
+            # The actual executable is part of different package, so might not even be installed =>
+            # double-check whether qmllint is working by executing it
+            execute_process(
+                COMMAND ${QmlLint_EXECUTABLE} --version
+                RESULT_VARIABLE _qmllint_result
+                OUTPUT_QUIET ERROR_QUIET
             )
+            if(_qmllint_result EQUAL 0)
+                set(QMLLINT_IS_WORKING
+                    TRUE
+                    CACHE BOOL "Whether the found qmllint executable is actually usable" FORCE
+                )
+            endif()
         endif()
-    endif()
-    if(QMLLINT_IS_WORKING)
-        set(QmlLint_FOUND TRUE)
+        if(QMLLINT_IS_WORKING)
+            set(QmlLint_FOUND TRUE)
+        endif()
     endif()
 endif()
 
 # validate a list of qml files
 function(qml_lint)
-    if(NOT QMLLINT_EXECUTABLE OR NOT QmlLint_FOUND)
+    if(NOT QmlLint_EXECUTABLE OR NOT QmlLint_FOUND)
         return()
+    endif()
+
+    if(NOT TARGET qmllint_all)
+        add_custom_target(qmllint_all ALL COMMENT "Scan all .qml files with qmllint")
     endif()
 
     foreach(_file ${ARGN})
         get_filename_component(_file_abs ${_file} ABSOLUTE)
         add_custom_command(
-            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.qmllint
-            COMMAND ${QMLLINT_EXECUTABLE} ${_file_abs}
-            COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${_file}.qmllint
+            OUTPUT ${_file}.lint
+            COMMAND ${QmlLint_EXECUTABLE} ${_file_abs}
+            COMMAND ${CMAKE_COMMAND} -E touch ${_file}.lint
             MAIN_DEPENDENCY ${_file_abs}
-            COMMENT "Run qmlint on the specified files and create the associated timestamp semaphore"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Run qmllint on ${_file}"
         )
         add_custom_target(
-            ${_file}_qmllint ALL
-            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_file}.qmllint
-            COMMENT "Target to run qmllint on the specified file"
+            ${_file}_qmllint
+            DEPENDS ${_file}.lint
+            COMMENT "Ensure qmllint is run on ${_file}"
         )
+        add_dependencies(qmllint_all ${_file}_qmllint)
     endforeach()
 endfunction()


### PR DESCRIPTION
If a target exists `Qt${QT_MAJOR_VERSION}::qmllint`, we can simply use that as our qmllint executable instead of searching around the path for one.

We have to keep the path-based discovery for Qt5, which doesn't have a target.

I also added a `qmllint_all`, to be the parent target of all of the linting targets. (Which are themselves backed by `add_custom_command(OUTPUT..` targets. It's targets all the way down.

Fixes #894 