### PR TITLE
Match exact Qt versions for QtScxml and QtStateMachine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,9 +480,21 @@ endif()
 find_package(Qt${QT_VERSION_MAJOR}IviCore 1.1 NO_MODULE QUIET) # 1.1 is based on 5.8
 find_package(Qt${QT_VERSION_MAJOR}IviVehicleFunctions 1.1 NO_MODULE QUIET)
 find_package(Qt${QT_VERSION_MAJOR}IviMedia 1.1 NO_MODULE QUIET)
-find_package(Qt${QT_VERSION_MAJOR}Scxml ${Qt${QT_VERSION_MAJOR}_VERSION} EXACT NO_MODULE QUIET)
+find_package(
+    Qt${QT_VERSION_MAJOR}Scxml
+    ${Qt${QT_VERSION_MAJOR}_VERSION}
+    EXACT
+    NO_MODULE
+    QUIET
+)
 if(QT_VERSION_MAJOR GREATER_EQUAL 6)
-    find_package(Qt${QT_VERSION_MAJOR}StateMachine ${Qt${QT_VERSION_MAJOR}_VERSION} EXACT NO_MODULE QUIET)
+    find_package(
+        Qt${QT_VERSION_MAJOR}StateMachine
+        ${Qt${QT_VERSION_MAJOR}_VERSION}
+        EXACT
+        NO_MODULE
+        QUIET
+    )
 endif()
 
 # if translation/doc host tools are missing, the Qt5 cmake config files throw errors...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,9 +480,9 @@ endif()
 find_package(Qt${QT_VERSION_MAJOR}IviCore 1.1 NO_MODULE QUIET) # 1.1 is based on 5.8
 find_package(Qt${QT_VERSION_MAJOR}IviVehicleFunctions 1.1 NO_MODULE QUIET)
 find_package(Qt${QT_VERSION_MAJOR}IviMedia 1.1 NO_MODULE QUIET)
-find_package(Qt${QT_VERSION_MAJOR}Scxml 5.8 NO_MODULE QUIET)
+find_package(Qt${QT_VERSION_MAJOR}Scxml ${Qt${QT_VERSION_MAJOR}_VERSION} EXACT NO_MODULE QUIET)
 if(QT_VERSION_MAJOR GREATER_EQUAL 6)
-    find_package(Qt${QT_VERSION_MAJOR}StateMachine NO_MODULE QUIET)
+    find_package(Qt${QT_VERSION_MAJOR}StateMachine ${Qt${QT_VERSION_MAJOR}_VERSION} EXACT NO_MODULE QUIET)
 endif()
 
 # if translation/doc host tools are missing, the Qt5 cmake config files throw errors...


### PR DESCRIPTION
If pointed towards a different prefix for Qt, it's possible to have QtScxml and QtStateMachine fall back to the system Qt which may be a completely different version. This prevents an issues where you could be building with Qt 6.5, and it falls back to system Qt 6.6 for example.

An easy way to test this is to download a binary Qt distribution that's different from system Qt, and then delete the QtScxml folder if it exists. Poke CMake and you'll see that it gladly uses the binary Qt for most modules, and then falls back to system Qt paths when trying to find these two modules.

Fixes #893