### PR TITLE
Add special check for libqtqmlcoreplugin when detecting Qt6 ABI

### DIFF
--- a/launcher/core/probeabidetector.cpp
+++ b/launcher/core/probeabidetector.cpp
@@ -156,6 +156,10 @@ bool ProbeABIDetector::containsQtCore(const QByteArray &line)
     // Windows Qt[X]Core[d].dll
 
     for (int index = 0; (index = line.indexOf("Qt", index)) >= 0; ++index) {
+        // Path must not be something like "libqtqmlcoreplugin" which is not what we're looking for
+        if (line.contains(QByteArrayLiteral("qml")))
+            return false;
+
         if (!checkQtCorePrefix(line, index))
             continue;
 


### PR DESCRIPTION
Qt6 has added a new QtCore import, which trips up our previous detection of valid injectable processes. The QML plugin is called "libqtqmlcoreplugin" and will take the place of a genuine QtCore library we're looking for in a process.

This library isn't versioned though, so it's impossible to determine the Qt version from the filename. This prevents it from being selected which makes the process detection much more reliable for Qt6 QtQuick applications.