### PR TITLE
Select first index in attach process list

### DIFF
--- a/launcher/ui/attachdialog.cpp
+++ b/launcher/ui/attachdialog.cpp
@@ -159,8 +159,12 @@ void AttachDialog::updateProcessesFinished()
     }
     const int oldPid = pid();
     m_model->mergeProcesses(watcher->result());
-    if (oldPid != pid())
+    if (oldPid == 0) {
+        ui->view->setCurrentIndex(m_proxyModel->index(0, 0));
+    } else if (oldPid != pid()) {
         ui->view->setCurrentIndex(QModelIndex());
+    }
+
     watcher->deleteLater();
 
     QTimer::singleShot(1000, this, &AttachDialog::updateProcesses);


### PR DESCRIPTION
This selects the first index by default when there's no old PID.