### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: https://www.github.com/KDAB/GammaRay
 
 #misc source code
 Files: *.ui *.qrc *.json CMakePresets.json GammaRay.desktop app/Info.plist.in client/Info.plist.in launcher/app/Info.plist.in launcher/cli/Info.plist.in com.kdab.GammaRay.metainfo.xml resources/gammaray/authors docs/collection/about.txt *.frag *.geom *.vert *.ts *.qm *.map cmake/gammaray.rc.cmake
-Copyright: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: GPL-2.0-or-later
 
 #misc documentation
 Files: CHANGES CONTRIBUTORS.txt INSTALL.md README.md docs/manual/style/* ui/resources/gammaray/ui/icons/classes/*/* docs/api/*.dox docs/api/*.html docs/man/*.pod docs/*.pdf
-Copyright: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: GPL-2.0-or-later
 
 #misc config files
 Files: 3rdparty/*/qt_attribution.json .clang-format .clang-tidy .clangd .clazy .cmake-format.py .codespellrc .emacs-dirvars .git-blame-ignore-revs .gitattributes .gitignore .kateconfig .krazy .mdlrc .mdlrc.rb .pep8 .pre-commit-config.yaml .pylintrc .qmake.conf .tag .travis.yml appveyor.ini appveyor.yml distro/* format.config.uncrustify.4_spaces *.qdocconf format_sources docs/collection/gammaray.qhcp.cmake examples/yocto/gammaray_git*.bb probe/gammaray_probe-android-dependencies.xml docs/api/Doxyfile.cmake .github/*
-Copyright: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 
 #artwork
 Files: ui/resources/gammaray/*.png plugins/guisupport/images/*.png ui/resources/gammaray/ui/icons/classes/*/*.png  ui/resources/gammaray/ui/*/*/*.png docs/manual/*/*.png docs/api/*.png tests/manual/*.png plugins/positioning/*.png plugins/quickinspector/textureextension/resources/*.png launcher/ui/resources/launcher/*.png ui/resources/svg/*.svg ui/resources/svg/*.svgz plugins/positioning/direction_marker.svg ui/resources/gammaray/GammaRay.icns ui/resources/gammaray/GammaRay.ico
-Copyright: 2010 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: GPL-2.0-or-later
 
 #3rdparty from Qt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 License
 =======
-The GammaRay Software is (C) 2010-2024 Klarälvdalens Datakonsult AB (KDAB),
-and is available under the terms of the GPL version 2 (or any later version,
+The GammaRay Software is © Klarälvdalens Datakonsult AB (KDAB), and is
+available under the terms of the GPL version 2 (or any later version,
 at your option).
 
 Note that this software relies on 3rd party MIT-licensed projects

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Thanks to our [contributors](CONTRIBUTORS.txt).
 
 ## License
 
-The GammaRay Software is (C) 2010-2024 Klarälvdalens Datakonsult AB (KDAB),
-and is available under the terms of the GPL version 2 (or any later version,
+The GammaRay Software is © Klarälvdalens Datakonsult AB (KDAB), and is
+available under the terms of the GPL version 2 (or any later version,
 at your option).  See [GPL-2.0-or-later.txt](LICENSES/GPL-2.0-or-later.txt)
 for license details.
 

--- a/docs/api/Mainpage.dox
+++ b/docs/api/Mainpage.dox
@@ -87,8 +87,8 @@ The key elements for embedding the client UI are:
 
 @section license License
 
-The GammaRay Software is (C) 2010-2024 Klarälvdalens Datakonsult AB (KDAB),
-and is available under the terms of the GPL version 2 (or any later version,
+The GammaRay Software is © Klarälvdalens Datakonsult AB (KDAB), and is
+available under the terms of the GPL version 2 (or any later version,
 at your option).
 See <a href="LICENSES/GPL-2.0-or-later.txt">GPL-2.0-or-later.txt</a> for
 license details.

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-16x16.png">
-      <font style="font-weight: bold;">&copy; 2010-2024 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
           "The Qt, C++ and OpenGL Experts"<br>
           <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/docs/manual/gammaray-manual-offline.qdocconf
+++ b/docs/manual/gammaray-manual-offline.qdocconf
@@ -11,7 +11,7 @@ HTML.footer = \
     "</div>\n" \
     "<div class=\"footer\">\n" \
     "   <p>\n" \
-    "   <acronym title=\"Copyright\">&copy;</acronym> 2016-2024 <a href=\"https://www.kdab.com/\">Klar&auml;lvdalens Datakonsult AB (KDAB)</a>.\n" \
+    "   <acronym title=\"Copyright\">&copy;</acronym> <a href=\"https://www.kdab.com/\">Klar&auml;lvdalens Datakonsult AB (KDAB)</a>.\n" \
     "   Documentation contributions included herein are the copyrights of\n" \
     "   their respective owners.<br/>" \
     "   This work is licensed under a <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Creative Commons Attribution-ShareAlike 4.0 International License</a>." \

--- a/docs/manual/gammaray-manual-online.qdocconf
+++ b/docs/manual/gammaray-manual-online.qdocconf
@@ -3,7 +3,7 @@ include(gammaray-manual.qdocconf)
 HTML.footer = \
     "   </div>\n" \
     "   <p class=\"copy-notice\">\n" \
-    "   <acronym title=\"Copyright\">&copy;</acronym> 2016-2024 <a href=\"https://www.kdab.com/\">Klar&auml;lvdalens Datakonsult AB (KDAB)</a>.\n" \
+    "   <acronym title=\"Copyright\">&copy;</acronym> <a href=\"https://www.kdab.com/\">Klar&auml;lvdalens Datakonsult AB (KDAB)</a>.\n" \
     "   Documentation contributions included herein are the copyrights of\n" \
     "   their respective owners.<br/>" \
     "   This work is licensed under a <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Creative Commons Attribution-ShareAlike 4.0 International License</a>." \

--- a/launcher/cli/main.cpp
+++ b/launcher/cli/main.cpp
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
         }
         if (arg == QLatin1String("-v") || arg == QLatin1String("--version")) {
             out() << "GammaRay version " << GAMMARAY_VERSION_STRING << endl;
-            out() << "Copyright (C) 2010-2024 Klaralvdalens Datakonsult AB, "
+            out() << "© Klaralvdalens Datakonsult AB, "
                   << "a KDAB Group company, info@kdab.com" << endl;
             out() << "Protocol version " << Protocol::version() << endl;
             out() << "Broadcast version " << Protocol::broadcastFormatVersion() << endl;

--- a/translations/gammaray_de.ts
+++ b/translations/gammaray_de.ts
@@ -15,7 +15,7 @@
     </message>
     <message>
         <location line="+5"/>
-        <source>&lt;p&gt;The Qt application inspection and manipulation tool.Learn more at &lt;a href=&quot;https://www.kdab.com/gammaray&quot;&gt;https://www.kdab.com/gammaray/&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Copyright (C) 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company, &lt;a href=&quot;mailto:info@kdab.com&quot;&gt;info@kdab.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;StackWalker code Copyright (c) 2005-2019, Jochen Kalmbach, All rights reserved&lt;br&gt;lz4 fast LZ compression code Copyright (C) 2011-2015, Yann Collet, All rights reserved&lt;br&gt;backward-cpp code Copyright 2013-2017 Google Inc. All rights reserved.&lt;/p&gt;</source>
+        <source>&lt;p&gt;The Qt application inspection and manipulation tool.Learn more at &lt;a href=&quot;https://www.kdab.com/gammaray&quot;&gt;https://www.kdab.com/gammaray/&lt;/a&gt;.&lt;/p&gt;&lt;p&gt; (C) Klarälvdalens Datakonsult AB, a KDAB Group company, &lt;a href=&quot;mailto:info@kdab.com&quot;&gt;info@kdab.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;StackWalker code Copyright (c) 2005-2019, Jochen Kalmbach, All rights reserved&lt;br&gt;lz4 fast LZ compression code Copyright (C) 2011-2015, Yann Collet, All rights reserved&lt;br&gt;backward-cpp code Copyright 2013-2017 Google Inc. All rights reserved.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/gammaray_en.ts
+++ b/translations/gammaray_en.ts
@@ -15,7 +15,7 @@
     </message>
     <message>
         <location line="+5"/>
-        <source>&lt;p&gt;The Qt application inspection and manipulation tool.Learn more at &lt;a href=&quot;https://www.kdab.com/gammaray&quot;&gt;https://www.kdab.com/gammaray/&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Copyright (C) 2010-2024 Klarälvdalens Datakonsult AB, a KDAB Group company, &lt;a href=&quot;mailto:info@kdab.com&quot;&gt;info@kdab.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;StackWalker code Copyright (c) 2005-2019, Jochen Kalmbach, All rights reserved&lt;br&gt;lz4 fast LZ compression code Copyright (C) 2011-2015, Yann Collet, All rights reserved&lt;br&gt;backward-cpp code Copyright 2013-2017 Google Inc. All rights reserved.&lt;/p&gt;</source>
+        <source>&lt;p&gt;The Qt application inspection and manipulation tool.Learn more at &lt;a href=&quot;https://www.kdab.com/gammaray&quot;&gt;https://www.kdab.com/gammaray/&lt;/a&gt;.&lt;/p&gt;&lt;p&gt; (C) Klarälvdalens Datakonsult AB, a KDAB Group company, &lt;a href=&quot;mailto:info@kdab.com&quot;&gt;info@kdab.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;StackWalker code Copyright (c) 2005-2019, Jochen Kalmbach, All rights reserved&lt;br&gt;lz4 fast LZ compression code Copyright (C) 2011-2015, Yann Collet, All rights reserved&lt;br&gt;backward-cpp code Copyright 2013-2017 Google Inc. All rights reserved.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/aboutdata.cpp
+++ b/ui/aboutdata.cpp
@@ -61,7 +61,7 @@ QString AboutData::aboutHeader()
     return AboutDataContext::tr(
         "<p>The Qt application inspection and manipulation tool. "
         "Learn more at <a href=\"https://www.kdab.com/gammaray\">https://www.kdab.com/gammaray/</a>.</p>"
-        "<p>Copyright (C) 2010-2024 Klarälvdalens Datakonsult AB, "
+        "<p>&copy; Klarälvdalens Datakonsult AB, "
         "a KDAB Group company, <a href=\"mailto:info@kdab.com\">info@kdab.com</a></p>"
         "<p>StackWalker code Copyright (c) 2005-2019, Jochen Kalmbach, All rights reserved<br>"
         "lz4 fast LZ compression code Copyright (C) 2011-2020, Yann Collet, All rights reserved<br>"


### PR DESCRIPTION
For entire project: remove year from the statement Use the © where feasible

reference:
 https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code