### PR TITLE
quickinspector: Use QT_VERSION_MAJOR

### DIFF
--- a/plugins/quickinspector/CMakeLists.txt
+++ b/plugins/quickinspector/CMakeLists.txt
@@ -73,7 +73,7 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
         ${gammaray_quickinspector_srcs}
     )
 
-    if(TARGET Qt${QT_MAJOR_VERSION}::Quick)
+    if(TARGET Qt${QT_VERSION_MAJOR}::Quick)
         target_sources(
             gammaray_quickinspector PUBLIC ${CMAKE_CURRENT_LIST_DIR}/quickimplicitbindingdependencyprovider.cpp
         )


### PR DESCRIPTION
In ac8ed0c73 I fixed this in `plugins/qmlsupport/CMakeLists.txt`, but I somehow missed the exact same issue in `plugins/quickinspector/CMakeLists.txt`.

Qt target names should be constructed using `Qt${QT_VERSION_MAJOR}::target`, not `Qt${QT_MAJOR_VERSION}::target`, to conform with the rest of the build. (`QT_MAJOR_VERSION` is an ECM thing, and <s>is only found</s> should only be found in the files in `cmake/ECM/modules/`.)