### PR TITLE
Test probe only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,15 +26,25 @@ jobs:
         config:
           - preset: ci-dev-client-only-qt5
             qt_version: "5.15"
+            tests_with: qt5
 
           - preset: ci-dev-client-only-qt6
             qt_version: "6.5.*"
             qt_modules: qtshadertools qtscxml
+            tests_with: qt6
 
           - preset: ci-dev-client-and-ui-qt5
             qt_version: "5.15"
+            tests_with: qt5
 
           - preset: ci-dev-client-and-ui-qt6
+            qt_version: "6.5.*"
+            tests_with: qt6
+
+          - preset: ci-dev-probe-only-qt5
+            qt_version: "5.15"
+
+          - preset: ci-dev-probe-only-qt6
             qt_version: "6.5.*"
 
     steps:
@@ -74,13 +84,13 @@ jobs:
         run: cmake --build ./build-${{ matrix.config.preset }}
 
       - name: Enable gdb attaching
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && matrix.config.tests_with != '' }}
         run: echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 
         # Exclude
         # quickmaterialtest|quicktexturetest fails because of QT_QUICK_BACKEND=software
       - name: Run tests on Linux Qt5 (offscreen)
-        if: ${{ runner.os == 'Linux' && startsWith(matrix.config.qt_version, '5.') }}
+        if: ${{ runner.os == 'Linux' && matrix.config.tests_with == 'qt5' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "quickmaterialtest|quicktexturetest"
@@ -92,7 +102,7 @@ jobs:
         # quickmaterialtest|quicktexturetest fails because of QT_QUICK_BACKEND=software AND QT_QPA_PLATFORM=offscreen
         # quickinspectortest|quickinspectortest2 fails at CI, local with 6.2.4 passes
       - name: Run tests on Linux Qt6 (offscreen)
-        if: ${{ runner.os == 'Linux' && startsWith(matrix.config.qt_version, '6.') }}
+        if: ${{ runner.os == 'Linux' && matrix.config.tests_with == 'qt6' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "quickmaterialtest|quicktexturetest|quickinspectortest|quickinspectortest2"
@@ -105,7 +115,7 @@ jobs:
         #26 - launchertest (Failed)
         #37 - quickinspectortest2 (Failed)
       - name: Run tests Qt5 on macOS
-        if: ${{ runner.os == 'macOS' && startsWith(matrix.config.qt_version, '5.') }}
+        if: ${{ runner.os == 'macOS' && matrix.config.tests_with == 'qt5' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "probeabidetectortest|launchertest|quickinspectortest2"
@@ -116,7 +126,7 @@ jobs:
         #32 - clientconnectiontest (Failed)
         # quickinspectortest2
       - name: Run tests Qt6 on macOS
-        if: ${{ runner.os == 'macOS' && startsWith(matrix.config.qt_version, '6.') }}
+        if: ${{ runner.os == 'macOS' && matrix.config.tests_with == 'qt6' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex
@@ -126,7 +136,7 @@ jobs:
         # quicktexturetest
         # bindinginspectortest
       - name: Qt5 Run tests on Windows
-        if: ${{ runner.os == 'Windows' && startsWith(matrix.config.qt_version, '5.') }}
+        if: ${{ runner.os == 'Windows' && matrix.config.tests_with == 'qt5' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} -C 'Release' --output-on-failure
           --exclude-regex "quicktexturetest|bindinginspectortest"
@@ -134,7 +144,7 @@ jobs:
         # Exclude
         # quicktexturetest
       - name: Qt6 Run tests on Windows
-        if: ${{ runner.os == 'Windows' && startsWith(matrix.config.qt_version, '6.') }}
+        if: ${{ runner.os == 'Windows' && matrix.config.tests_with == 'qt6' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} -C 'Release' --output-on-failure
           --exclude-regex "quicktexturetest|launchertest|probesettingstest"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,6 +5,7 @@
             "name": "base",
             "generator": "Ninja",
             "hidden": true,
+            "binaryDir": "${sourceDir}/build-${presetName}",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
             },
@@ -14,29 +15,22 @@
         },
         {
             "name": "dev",
+            "inherits": "base",
             "displayName": "dev",
-            "binaryDir": "${sourceDir}/build-dev",
             "cacheVariables": {
                 "QT_VERSION_MAJOR": "5",
                 "CMAKE_BUILD_TYPE": "Release",
                 "GAMMARAY_USE_PCH": "ON"
-            },
-            "inherits": [
-                "base"
-            ]
+            }
         },
         {
-            "name": "dev6",
-            "displayName": "dev qt6",
-            "binaryDir": "${sourceDir}/build-dev-qt6",
+            "name": "dev-qt6",
+            "inherits": "base",
             "cacheVariables": {
                 "QT_VERSION_MAJOR": "6",
                 "CMAKE_BUILD_TYPE": "Release",
                 "GAMMARAY_USE_PCH": "ON"
-            },
-            "inherits": [
-                "base"
-            ]
+            }
         },
         {
             "name": "dev-asan",
@@ -143,6 +137,7 @@
         },
         {
             "name": "ci-dev-client-only-qt5",
+            "inherits": "dev",
             "displayName": "ci-dev-client-only-qt5",
             "description": "Qt5 client-only build",
             "binaryDir": "${sourceDir}/build-ci-dev-client-only-qt5",
@@ -152,58 +147,70 @@
                 "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
                 "GAMMARAY_MULTI_BUILD": "OFF",
                 "WARNINGS_ARE_ERRORS": "ON"
-            },
-            "inherits": [
-                "dev"
-            ]
+            }
         },
         {
             "name": "ci-dev-client-only-qt6",
+            "inherits": "dev-qt6",
             "displayName": "ci-dev-client-only-qt6",
             "description": "Qt6 client-only build",
-            "binaryDir": "${sourceDir}/build-ci-dev-client-only-qt6",
-            "generator": "Ninja",
             "cacheVariables": {
                 "GAMMARAY_CLIENT_ONLY_BUILD": "ON",
                 "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
                 "GAMMARAY_MULTI_BUILD": "OFF",
                 "WARNINGS_ARE_ERRORS": "ON"
-            },
-            "inherits": [
-                "dev6"
-            ]
+            }
         },
         {
             "name": "ci-dev-client-and-ui-qt5",
+            "inherits": "dev",
             "displayName": "ci-dev-client-and-ui-qt5",
             "description": "Qt5 client and ui build",
-            "binaryDir": "${sourceDir}/build-ci-dev-client-and-ui-qt5",
-            "generator": "Ninja",
             "cacheVariables": {
                 "GAMMARAY_CLIENT_ONLY_BUILD": "OFF",
                 "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
                 "GAMMARAY_MULTI_BUILD": "OFF",
                 "WARNINGS_ARE_ERRORS": "ON"
-            },
-            "inherits": [
-                "dev"
-            ]
+            }
         },
         {
             "name": "ci-dev-client-and-ui-qt6",
+            "inherits": "dev-qt6",
             "displayName": "ci-dev-client-and-ui-qt6",
             "description": "Qt6 client and ui build",
-            "binaryDir": "${sourceDir}/build-ci-dev-client-and-ui-qt6",
-            "generator": "Ninja",
             "cacheVariables": {
                 "GAMMARAY_CLIENT_ONLY_BUILD": "OFF",
                 "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
                 "GAMMARAY_MULTI_BUILD": "OFF",
                 "WARNINGS_ARE_ERRORS": "ON"
-            },
-            "inherits": [
-                "dev6"
-            ]
+            }
+        },
+        {
+            "name": "ci-dev-probe-only-qt5",
+            "inherits": "dev",
+            "description": "Qt5 PROBE_ONLY build",
+            "cacheVariables": {
+                "GAMMARAY_PROBE_ONLY_BUILD": "ON",
+                "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
+                "GAMMARAY_BUILD_UI": "OFF",
+                "GAMMARAY_BUILD_DOCS": "OFF",
+                "GAMMARAY_MULTI_BUILD": "OFF",
+                "WARNINGS_ARE_ERRORS": "ON"
+            }
+        },
+        {
+            "name": "ci-dev-probe-only-qt6",
+            "inherits": "dev-qt6",
+            "description": "Qt6 PROBE_ONLY build",
+            "cacheVariables": {
+                "GAMMARAY_PROBE_ONLY_BUILD": "ON",
+                "GAMMARAY_INSTALL_QT_LAYOUT": "ON",
+                "GAMMARAY_BUILD_UI": "OFF",
+                "GAMMARAY_BUILD_DOCS": "OFF",
+                "GAMMARAY_MULTI_BUILD": "OFF",
+                "WARNINGS_ARE_ERRORS": "ON"
+
+            }
         },
         {
             "name": "ci-dev-clang-tidy-qt6",
@@ -220,7 +227,7 @@
                 "GAMMARAY_USE_PCH": "OFF"
             },
             "inherits": [
-                "dev6"
+                "dev-qt6"
             ]
         },
         {
@@ -238,7 +245,7 @@
                 "GAMMARAY_USE_PCH": "OFF"
             },
             "inherits": [
-                "dev6"
+                "dev-qt6"
             ]
         }
     ],


### PR DESCRIPTION
Way back in #765, I submitted some patches to fix the `GAMMARAY_CLIENT_ONLY_BUILD`, which had stealth-broken because it wasn't being tested in CI.

The same is now true of `GAMMARAY_PROBE_ONLY_BUILD`, so to avoid the possibility of similar stealth breakage, this PR adds test runs for probe-only builds to the standard CI, by first adding configurations for them to the `CMakePresets.json`.

Along the way, it makes some adjustments to the existing configuration(s), to facilitate adding additional CI build configurations

### Presets file `CMakePresets.json`
1. The presets file is adjusted to make better use of inheritance, removing duplicate manual settings of `"generator"` or `"binaryDir"` when those can simply be inherited.
2. To keep the file more streamlined, the new configs (and any they depend on) take advantage of a CMake feature that permits a string value for `"inherits"`, rather than a list value, when only one configuration is being inherited from.

(Not all configurations were adjusted, mostly just the ones I was touching anyway. But in both cases, they all _could_ be changed the same way.)

### CI configuration `build.yml`
1. To control whether (and which type) of unit tests are run, a new `matrix.config.tests_with` value is _optionally_ added to matrix members, set to either `qt5` or `qt6`. 
    This allows the complicated version checks:
    ```yml
    startsWith(matrix.config.qt_version, '6.')
    ```
    to be replaced with a simple:
    ```yml
    matrix.config.tests_with == 'qt6'
    ````
    and (along with `runner.os`) not only controls _which_ tests are run, but its _absence_ will **prevent** tests from being run at all. (Mostly because unit tests on a `PROBE_ONLY` build are simultaneously both pointless and redundant.)