### PR TITLE
Support Qt distributions that don't support QWheelEvent and QTabletEvent

### DIFF
--- a/core/remoteviewserver.cpp
+++ b/core/remoteviewserver.cpp
@@ -160,9 +160,13 @@ void RemoteViewServer::sendWheelEvent(const QPoint &localPos, QPoint pixelDelta,
     if (!m_eventReceiver)
         return;
 
+#if QT_CONFIG(wheelevent)
     auto event = new QWheelEvent(localPos, m_eventReceiver->mapToGlobal(localPos), pixelDelta, angleDelta, ( Qt::MouseButtons )buttons,
                                  ( Qt::KeyboardModifiers )modifiers, Qt::NoScrollPhase, false);
     QCoreApplication::postEvent(m_eventReceiver, event);
+#else
+    qWarning() << Q_FUNC_INFO << "QWheelEvent is not supported";
+#endif
 }
 
 void RemoteViewServer::sendTouchEvent(int type, int touchDeviceType, int deviceCaps, int touchDeviceMaxTouchPoints,

--- a/plugins/eventmonitor/eventmonitor.cpp
+++ b/plugins/eventmonitor/eventmonitor.cpp
@@ -62,12 +62,14 @@ static QString eventTypeToClassName(QEvent::Type type)
         return QStringLiteral("QScrollPrepareEvent");
     case QEvent::Scroll:
         return QStringLiteral("QScrollEvent");
+#if QT_CONFIG(tabletevent)
     case QEvent::TabletMove:
     case QEvent::TabletPress:
     case QEvent::TabletRelease:
     case QEvent::TabletEnterProximity:
     case QEvent::TabletLeaveProximity:
         return QStringLiteral("QTabletEvent");
+#endif
     case QEvent::NativeGesture:
         return QStringLiteral("QNativeGestureEvent");
     case QEvent::KeyPress:
@@ -100,8 +102,10 @@ static QString eventTypeToClassName(QEvent::Type type)
         return QStringLiteral("QPaintEvent");
     case QEvent::Enter:
         return QStringLiteral("QEnterEvent");
+#if QT_CONFIG(wheelevent)
     case QEvent::Wheel:
         return QStringLiteral("QWheelEvent");
+#endif
     case QEvent::HoverEnter:
     case QEvent::HoverMove:
     case QEvent::HoverLeave:

--- a/plugins/guisupport/guisupport.cpp
+++ b/plugins/guisupport/guisupport.cpp
@@ -488,42 +488,46 @@ void GuiSupport::registerMetaTypes()
 #endif
     MO_ADD_PROPERTY_RO(QHoverEvent, oldPosF);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    MO_ADD_METAOBJECT1(QWheelEvent, QInputEvent);
-    MO_ADD_PROPERTY_RO(QWheelEvent, buttons);
-    MO_ADD_PROPERTY_RO(QWheelEvent, delta);
-    MO_ADD_PROPERTY_RO(QWheelEvent, orientation);
-    MO_ADD_PROPERTY_RO(QWheelEvent, posF);
-    MO_ADD_PROPERTY_RO(QWheelEvent, globalPosF);
-#else
-    MO_ADD_METAOBJECT1(QWheelEvent, QSinglePointEvent);
+#if QT_CONFIG(wheelevent)
+    #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        MO_ADD_METAOBJECT1(QWheelEvent, QInputEvent);
+        MO_ADD_PROPERTY_RO(QWheelEvent, buttons);
+        MO_ADD_PROPERTY_RO(QWheelEvent, delta);
+        MO_ADD_PROPERTY_RO(QWheelEvent, orientation);
+        MO_ADD_PROPERTY_RO(QWheelEvent, posF);
+        MO_ADD_PROPERTY_RO(QWheelEvent, globalPosF);
+    #else
+        MO_ADD_METAOBJECT1(QWheelEvent, QSinglePointEvent);
+    #endif
+        MO_ADD_PROPERTY_RO(QWheelEvent, pixelDelta);
+        MO_ADD_PROPERTY_RO(QWheelEvent, angleDelta);
+        MO_ADD_PROPERTY_RO(QWheelEvent, phase);
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+        MO_ADD_PROPERTY_RO(QWheelEvent, inverted);
+    #endif
+        MO_ADD_PROPERTY_RO(QWheelEvent, source);
 #endif
-    MO_ADD_PROPERTY_RO(QWheelEvent, pixelDelta);
-    MO_ADD_PROPERTY_RO(QWheelEvent, angleDelta);
-    MO_ADD_PROPERTY_RO(QWheelEvent, phase);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
-    MO_ADD_PROPERTY_RO(QWheelEvent, inverted);
-#endif
-    MO_ADD_PROPERTY_RO(QWheelEvent, source);
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    MO_ADD_METAOBJECT1(QTabletEvent, QInputEvent);
-    MO_ADD_PROPERTY_RO(QTabletEvent, device);
-    MO_ADD_PROPERTY_RO(QTabletEvent, pointerType);
-    MO_ADD_PROPERTY_RO(QTabletEvent, posF);
-    MO_ADD_PROPERTY_RO(QTabletEvent, globalPosF);
-#else
-    MO_ADD_METAOBJECT1(QTabletEvent, QSinglePointEvent);
+#if QT_CONFIG(tabletevent)
+    #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        MO_ADD_METAOBJECT1(QTabletEvent, QInputEvent);
+        MO_ADD_PROPERTY_RO(QTabletEvent, device);
+        MO_ADD_PROPERTY_RO(QTabletEvent, pointerType);
+        MO_ADD_PROPERTY_RO(QTabletEvent, posF);
+        MO_ADD_PROPERTY_RO(QTabletEvent, globalPosF);
+    #else
+        MO_ADD_METAOBJECT1(QTabletEvent, QSinglePointEvent);
+    #endif
+        MO_ADD_PROPERTY_RO(QTabletEvent, uniqueId);
+        MO_ADD_PROPERTY_RO(QTabletEvent, pressure);
+        MO_ADD_PROPERTY_RO(QTabletEvent, z);
+        MO_ADD_PROPERTY_RO(QTabletEvent, tangentialPressure);
+        MO_ADD_PROPERTY_RO(QTabletEvent, rotation);
+        MO_ADD_PROPERTY_RO(QTabletEvent, xTilt);
+        MO_ADD_PROPERTY_RO(QTabletEvent, yTilt);
+        MO_ADD_PROPERTY_RO(QTabletEvent, button);
+        MO_ADD_PROPERTY_RO(QTabletEvent, buttons);
 #endif
-    MO_ADD_PROPERTY_RO(QTabletEvent, uniqueId);
-    MO_ADD_PROPERTY_RO(QTabletEvent, pressure);
-    MO_ADD_PROPERTY_RO(QTabletEvent, z);
-    MO_ADD_PROPERTY_RO(QTabletEvent, tangentialPressure);
-    MO_ADD_PROPERTY_RO(QTabletEvent, rotation);
-    MO_ADD_PROPERTY_RO(QTabletEvent, xTilt);
-    MO_ADD_PROPERTY_RO(QTabletEvent, yTilt);
-    MO_ADD_PROPERTY_RO(QTabletEvent, button);
-    MO_ADD_PROPERTY_RO(QTabletEvent, buttons);
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     MO_ADD_METAOBJECT1(QNativeGestureEvent, QInputEvent);


### PR DESCRIPTION
Both are optional and can be turned off for platforms that don't support the corresponding devices.