### PR TITLE
CMake: Add the INSTALL_DIR argument to gammaray_add_plugin

### DIFF
--- a/cmake/GammaRayMacros.cmake
+++ b/cmake/GammaRayMacros.cmake
@@ -14,10 +14,11 @@ include(CMakeParseArguments)
 # GAMMARAY_ADD_PLUGIN: create a gammaray plugin, install at the right place, etc
 # arguments:
 # - JSON <file> - the plugin .json file
+# - INSTALL_DIR <dir> - plugin installation subdirectory
 # - SOURCES <files> - the plugin sources
 #
-macro(gammaray_add_plugin _target_name)
-    set(oneValueArgs JSON)
+function(gammaray_add_plugin _target_name)
+    set(oneValueArgs JSON INSTALL_DIR)
     set(multiValueArgs SOURCES)
     cmake_parse_arguments(
         _gammaray_add_plugin
@@ -27,10 +28,15 @@ macro(gammaray_add_plugin _target_name)
         ${ARGN}
     )
 
-    if(NOT PROBE_PLUGIN_INSTALL_DIR) # HACK for external plugins that don't set PLUGIN_INSTALL_DIR
-        set(PROBE_PLUGIN_INSTALL_DIR ${GAMMARAY_PROBE_PLUGIN_INSTALL_DIR})
+    # HACK for external plugins that don't set PLUGIN_INSTALL_DIR
+    set(_install_target_dir "${GAMMARAY_PROBE_PLUGIN_INSTALL_DIR}")
+    if(PROBE_PLUGIN_INSTALL_DIR)
+        set(_install_target_dir "${PROBE_PLUGIN_INSTALL_DIR}")
     endif()
-    set(_build_target_dir "${GAMMARAY_OUTPUT_PREFIX}/${PROBE_PLUGIN_INSTALL_DIR}")
+    if(DEFINED _gammaray_add_plugin_INSTALL_DIR)
+        set(_install_target_dir "${_install_target_dir}/${_gammaray_add_plugin_INSTALL_DIR}")
+    endif()
+    set(_build_target_dir "${GAMMARAY_OUTPUT_PREFIX}/${_install_target_dir}")
 
     add_library(${_target_name} ${GAMMARAY_PLUGIN_TYPE} ${_gammaray_add_plugin_SOURCES})
     set_target_properties(${_target_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${_build_target_dir})
@@ -42,13 +48,13 @@ macro(gammaray_add_plugin _target_name)
     if(GAMMARAY_INSTALL_QT_LAYOUT)
         set_target_properties(${_target_name} PROPERTIES OUTPUT_NAME ${_target_name}-${GAMMARAY_PROBE_ABI})
     endif()
-    gammaray_set_rpath(${_target_name} ${PROBE_PLUGIN_INSTALL_DIR})
+    gammaray_set_rpath(${_target_name} ${_install_target_dir})
 
-    install(TARGETS ${_target_name} DESTINATION ${PROBE_PLUGIN_INSTALL_DIR})
+    install(TARGETS ${_target_name} DESTINATION ${_install_target_dir})
     if(MSVC)
         install(
             FILES "$<TARGET_PDB_FILE_DIR:${_target_name}>/$<TARGET_PDB_FILE_NAME:${_target_name}>"
-            DESTINATION ${PROBE_PLUGIN_INSTALL_DIR}
+            DESTINATION ${_install_target_dir}
             CONFIGURATIONS Debug RelWithDebInfo
         )
     endif()
@@ -56,7 +62,7 @@ macro(gammaray_add_plugin _target_name)
     if(GAMMARAY_USE_PCH)
         target_precompile_headers(${_target_name} REUSE_FROM gammaray_pch_core_gui)
     endif()
-endmacro()
+endfunction()
 
 # Common RPATH setup
 # @internal

--- a/plugins/positioning/CMakeLists.txt
+++ b/plugins/positioning/CMakeLists.txt
@@ -42,11 +42,17 @@ if(NOT GAMMARAY_CLIENT_ONLY_BUILD)
         positioninginterface.cpp
         positioninginterface.h
     )
-
-    add_library(gammaray_geopositioninfosource MODULE ${gammaray_geopositioninfosource_srcs})
+    gammaray_add_plugin(
+        gammaray_geopositioninfosource
+        JSON
+        geopositioninfosourcefactory.json
+        SOURCES
+        ${gammaray_positioning_srcs}
+        INSTALL_DIR
+        position
+    )
     target_compile_features(gammaray_geopositioninfosource PUBLIC ${GAMMARAY_REQUIRED_CXX_FEATURES})
     target_link_libraries(gammaray_geopositioninfosource gammaray_common Qt::Positioning Qt::CorePrivate)
-    install(TARGETS gammaray_geopositioninfosource DESTINATION ${TARGET_PLUGIN_INSTALL_DIR}/position)
 endif()
 
 # ui plugin


### PR DESCRIPTION
Use this new feature to define the gammaray_geopositioninfosource plugin via the gammaray_add_plugin rather than custom add_library.