### PR TITLE
CMake: Build gammaray_common_internal and gammaray_lz4 as OBJECTs

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -23,7 +23,7 @@ configure_file(
 )
 
 add_library(
-    gammaray_lz4 STATIC
+    gammaray_lz4 OBJECT
     ${CMAKE_SOURCE_DIR}/3rdparty/lz4/lz4.c
 )
 set_target_properties(gammaray_lz4 PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -101,7 +101,7 @@ target_link_libraries(
 )
 target_link_libraries(
     gammaray_common
-    PRIVATE gammaray_lz4 gammaray_kitemmodels ${CMAKE_DL_LIBS}
+    PRIVATE $<BUILD_INTERFACE:gammaray_lz4> gammaray_kitemmodels ${CMAKE_DL_LIBS}
 )
 gammaray_set_rpath(gammaray_common ${LIB_INSTALL_DIR})
 if(GAMMARAY_USE_PCH)
@@ -144,7 +144,7 @@ set(gammaray_common_internal_srcs
 )
 
 add_library(
-    gammaray_common_internal STATIC
+    gammaray_common_internal OBJECT
     ${gammaray_common_internal_srcs}
 )
 set_target_properties(gammaray_common_internal PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -219,7 +219,7 @@ target_include_directories(
 target_link_libraries(
     gammaray_core
     PUBLIC gammaray_common
-    PRIVATE gammaray_common_internal
+    PRIVATE $<BUILD_INTERFACE:gammaray_common_internal>
             gammaray_kitemmodels
             ${CMAKE_DL_LIBS}
             Qt::CorePrivate

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -195,7 +195,7 @@ target_include_directories(
 target_link_libraries(
     gammaray_ui
     PUBLIC Qt::Core Qt::Gui Qt::Widgets gammaray_common
-    PRIVATE gammaray_common_internal gammaray_kitemmodels Qt::WidgetsPrivate
+    PRIVATE $<BUILD_INTERFACE:gammaray_common_internal> gammaray_kitemmodels Qt::WidgetsPrivate
 )
 if(TARGET KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
     target_link_libraries(gammaray_ui PRIVATE KF${QtCore_VERSION_MAJOR}::SyntaxHighlighting)
@@ -226,7 +226,7 @@ target_link_libraries(
     Qt::Gui
     Qt::Widgets
     Qt::GuiPrivate
-    gammaray_common_internal
+    $<BUILD_INTERFACE:gammaray_common_internal>
     gammaray_ui
     gammaray_kitemmodels
 )


### PR DESCRIPTION
This allows avoid installation and export of these intermediate libraries when building the STATIC probe.