### PR TITLE
CMake: gammaray_kitemmodels must respect GAMMARAY_LIBRARY_TYPE

### DIFF
--- a/3rdparty/kde/CMakeLists.txt
+++ b/3rdparty/kde/CMakeLists.txt
@@ -5,7 +5,7 @@ set(gammaray_kitemmodels_srcs
   kitemmodels_debug.cpp
 )
 
-add_library(gammaray_kitemmodels SHARED ${gammaray_kitemmodels_srcs})
+add_library(gammaray_kitemmodels ${GAMMARAY_LIBRARY_TYPE} ${gammaray_kitemmodels_srcs})
 
 target_link_libraries(gammaray_kitemmodels PUBLIC Qt::Core)
 


### PR DESCRIPTION
Otherwise static probe and plugins will end up depending on a shared library.