### PR TITLE
Resolve "unregistered datatype 'QHeaderView*'"

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -24,6 +24,8 @@
 #include <QApplication>
 #include <QStringList>
 
+#include <QHeaderView>
+
 using namespace GammaRay;
 
 int main(int argc, char **argv)
@@ -42,6 +44,8 @@ int main(int argc, char **argv)
     Paths::setRelativeRootPath(GAMMARAY_INVERSE_LIBEXEC_DIR);
     Translator::loadStandAloneTranslations();
     ClientConnectionManager::init();
+
+    qRegisterMetaType<QHeaderView *>("QHeaderView*");
 
     QUrl serverUrl;
     if (app.arguments().size() == 2) {

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -24,8 +24,6 @@
 #include <QApplication>
 #include <QStringList>
 
-#include <QHeaderView>
-
 using namespace GammaRay;
 
 int main(int argc, char **argv)
@@ -44,8 +42,6 @@ int main(int argc, char **argv)
     Paths::setRelativeRootPath(GAMMARAY_INVERSE_LIBEXEC_DIR);
     Translator::loadStandAloneTranslations();
     ClientConnectionManager::init();
-
-    qRegisterMetaType<QHeaderView *>("QHeaderView*");
 
     QUrl serverUrl;
     if (app.arguments().size() == 2) {

--- a/ui/uistatemanager.cpp
+++ b/ui/uistatemanager.cpp
@@ -24,7 +24,6 @@
 #endif
 #include <QMainWindow>
 #include <QSplitter>
-#include <QHeaderView>
 #include <QSettings>
 #include <QEvent>
 #include <QScreen>

--- a/ui/uistatemanager.h
+++ b/ui/uistatemanager.h
@@ -22,12 +22,12 @@
 #include <QVector>
 #include <QHash>
 #include <QMetaMethod>
+#include <QHeaderView>
 
 QT_BEGIN_NAMESPACE
 class QWidget;
 class QSplitter;
 class QSettings;
-class QHeaderView;
 QT_END_NAMESPACE
 
 namespace GammaRay {


### PR DESCRIPTION
Fix #949
When running GR from command line we get:
```
QMetaMethod::invoke: Unable to handle unregistered
datatype 'QHeaderView*'
```
on tab loading. Register the type to fix.