### PR TITLE
Fix pyside abi detection

### DIFF
--- a/launcher/core/probeabidetector.cpp
+++ b/launcher/core/probeabidetector.cpp
@@ -146,6 +146,11 @@ static bool checkQtCoreSuffix(const QByteArray &line, int index)
     if (index < line.size() && ((line.at(index) >= 'a' && line.at(index) <= 'z') || (line.at(index) >= 'A' && line.at(index) <= 'Z')))
         return false;
 
+    // must not be followed by .abi3, (pyside)
+    if (line.lastIndexOf(".abi3", index) == index) {
+        return false;
+    }
+
     return true;
 }
 

--- a/tests/probeabidetectortest.cpp
+++ b/tests/probeabidetectortest.cpp
@@ -80,6 +80,9 @@ private slots:
         QTest::newRow("QT") << "QTCore" << false;
         QTest::newRow("prefix") << "libFooQtCore.so" << false;
         QTest::newRow("libQt") << "libQt.dylib" << false;
+
+        // pyside
+        QTest::newRow("QtCore.abi3.so") << "QtCore.abi3.so" << false;
     }
 
     static void testContainsQtCore()


### PR DESCRIPTION
Python app with pyside has a dll libQtCore.abi3.so due to which abi detection failed

 #954