### PR TITLE
Fix probe not picking up PySide2 applications on some corner cases

### DIFF
--- a/launcher/core/probeabidetector.cpp
+++ b/launcher/core/probeabidetector.cpp
@@ -151,6 +151,14 @@ static bool checkQtCoreSuffix(const QByteArray &line, int index)
         return false;
     }
 
+    // Sometimes when using PySide2 on Windows we end up loading QtCore.pyd, which doesn't
+    // have information about the corresponding Qt version among its file details.
+    // We can safely skip it since that will in turn load a QtCore dll file with the right
+    // information, and that will be picked up by this function.
+    if (line.endsWith(".pyd")) {
+        return false;
+    }
+
     return true;
 }
 

--- a/tests/probeabidetectortest.cpp
+++ b/tests/probeabidetectortest.cpp
@@ -83,6 +83,8 @@ private slots:
 
         // pyside
         QTest::newRow("QtCore.abi3.so") << "QtCore.abi3.so" << false;
+        QTest::newRow("QtCore.pyd") << "QtCore.pyd" << false;
+        QTest::newRow("QtGui.pyd") << "QtGui.pyd" << false;
     }
 
     static void testContainsQtCore()


### PR DESCRIPTION
Fixes issue #954

As per comment in patch, sometimes GammaRay doesn't pick up PySide2 applications on Windows.
This seems to happen when QtCore is imported before other Qt modules.

The reason for that is that in that case QtCore.pyd will appear before the QtCore DLL in the list of loaded modules, and so it will be picked up instead of the DLL for the version check.

As the pyd file doesn't have any information about the Qt version among its file details, the version lookup will fail.

Also, since all pyd files will in turn load a corresponding DLL we can safely skip all pyd modules when navigating through loaded modules.