### PR TITLE
Fixing Bug where a childs in child in a zero size element are not found.

### DIFF
--- a/plugins/quickinspector/quickinspector.h
+++ b/plugins/quickinspector/quickinspector.h
@@ -136,6 +136,7 @@ private:
     QString findSGNodeType(QSGNode *node) const;
     static void scanForProblems();
 
+    QRectF combinedChildrenRect(QQuickItem *object) const;
     GammaRay::ObjectIds recursiveItemsAt(QQuickItem *parent, const QPointF &pos,
                                          GammaRay::RemoteViewInterface::RequestMode mode,
                                          int &bestCandidate, bool parentIsGoodCandidate = true) const;


### PR DESCRIPTION
I have the Problem by using the Picker, they didn't find elements in elements in  a element which are zero size. 

For example:
```
import QtQuick 2.15
import QtQuick.Window 2.15

Window {
    width: 640
    height: 480
    visible: true
    title: qsTr("Minimal Pick Fail")

    Rectangle {
        id: zerosizereact1
        width: 0
        height: 0

        Rectangle {
            id: zerosizereact2
            width:0
            height: 0

            Rectangle {
                id: greenrectangle
                width: 100
                height: 100
                color: "green"
            }
        }
    }
}
```
When I click the green rectangle, the Picker chose the hole screen as Element.
![grafik](https://github.com/KDAB/GammaRay/assets/48125666/39d6db3a-f316-413f-8658-0ec4c6e764bb)
