### PR TITLE
Add using of a build folder in the INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,7 +35,8 @@ Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
 Adapt the instructions to suit your cmake generator and operating system.
 
 ```bash
-    cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/path/where/to/install ../path/to/gammaray
+    mkdir build && cd build/
+    cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/path/where/to/install ..
     cmake --build .
     cmake --build . --target install
 ```


### PR DESCRIPTION
I know the PR look weird. But I build GammaRay three times without a build folder because of these docs.
So It would be nice to add this to the `INSTALL.md`.