### PR TITLE
Avoid crash when m_costs is empty

### DIFF
--- a/core/paintbuffermodel.cpp
+++ b/core/paintbuffermodel.cpp
@@ -135,7 +135,7 @@ PaintBuffer PaintBufferModel::buffer() const
 void PaintBufferModel::setCosts(const QVector<double> &costs)
 {
     m_costs = costs;
-    if (rowCount() > 0) {
+    if (rowCount() > 0 && !m_costs.isEmpty()) {
         m_maxCost = *std::max_element(m_costs.constBegin(), m_costs.constEnd());
         emit dataChanged(index(0, 2, QModelIndex()), index(rowCount() - 1, 2, QModelIndex()));
     }


### PR DESCRIPTION
```
#0  0x00007f763131a048 in GammaRay::PaintBufferModel::setCosts(QList<double> const&) (this=this@entry=0x27a499f0, costs=QList<double> (size = 0)) 
    at /d/kdab/src/Legrand/gammaray/core/paintbuffermodel.cpp:139                                                                                 
#1  0x00007f76313164d3 in GammaRay::PaintAnalyzer::endAnalyzePainting() (this=<optimized out>) at /d/kdab/src/Legrand/gammaray/core/paintanalyzer.cpp:173
#2  0x00007f7630042e73 in GammaRay::PaintAnalyzerExtension::analyzePainting(QGraphicsItem*) (this=0x27ab1a70, item=0x286b9e60)                    
    at /d/kdab/src/Legrand/gammaray/plugins/sceneinspector/paintanalyzerextension.cpp:108                                                         
#3  0x00007f7631335791 in GammaRay::PropertyController::setObject(QObject*) (this=0x2729b3c0, object=0x286b9e50)                                  
    at /d/kdab/src/Legrand/gammaray/core/propertycontroller.cpp:81
#4  0x00007f7630047a8b in GammaRay::SceneInspector::sceneItemSelectionChanged(QItemSelection const&) (this=0x27a94520, selection=<optimized out>)
    at /d/kdab/src/Legrand/gammaray/plugins/sceneinspector/sceneinspector.cpp:197
```