### PR TITLE
Fix deserialization of graphicsitems due to shape being a QPainterPath

### DIFF
--- a/common/remoteviewinterface.cpp
+++ b/common/remoteviewinterface.cpp
@@ -21,6 +21,8 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <private/qeventpoint_p.h>
 #endif
+#include <QPainterPath>
+Q_DECLARE_METATYPE(QPainterPath) // needed for Qt5
 
 using namespace GammaRay;
 QT_BEGIN_NAMESPACE
@@ -206,6 +208,7 @@ RemoteViewInterface::RemoteViewInterface(const QString &name, QObject *parent)
 {
     ObjectBroker::registerObject(name, this);
 
+    qRegisterMetaType<QPainterPath>(); // for QGraphicsItem::shape
     qRegisterMetaType<QTouchEvent::TouchPoint>();
     qRegisterMetaType<QList<QTouchEvent::TouchPoint>>();
     qRegisterMetaType<RemoteViewInterface::TouchPointStates>();

--- a/plugins/sceneinspector/sceneinspector.cpp
+++ b/plugins/sceneinspector/sceneinspector.cpp
@@ -113,8 +113,6 @@ void SceneInspector::sceneSelected(const QItemSelection &selection)
 
     m_sceneModel->setScene(scene);
     connectToScene();
-    // TODO remote support when a different graphics scene was selected
-    // ui->graphicsSceneView->setGraphicsScene(scene);
 }
 
 void SceneInspector::connectToScene()


### PR DESCRIPTION
This fixes
`QVariant::load: unknown user type with name QPainterPath.`
warnings, and infinite Loading... in the scene inspector (when that property is the only problem...)

