### PR TITLE
Fix inspection of graphics scenes with nested items

### DIFF
--- a/plugins/sceneinspector/scenemodel.h
+++ b/plugins/sceneinspector/scenemodel.h
@@ -45,6 +45,8 @@ public:
 
 private:
     QList<QGraphicsItem *> topLevelItems() const;
+    int rowForItem(QGraphicsItem *item) const;
+
     /// Returns a string type name for the given QGV item type id
     QString typeName(int itemType) const;
 


### PR DESCRIPTION
The SceneModel had a broken parent() implementation, it always returned row = 0 for toplevel items, instead of looking up the position in the topLevelItems() list.

While at it, make this model more robust against the fact that the order of QGraphicsItem::childItems() can change due to stackBefore() or changing the Z order, so sort that list (by pointer address) to make it stable.

There's still one way to break that model:
QGraphicsItem::setParentItem(). But that's for another day.