### PR TITLE
Disable GAMMARAY_WITH_KDSME on Qt 6 Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Configure project
         run: >
           cmake -S . -G Ninja --preset ${{ matrix.config.preset }}
-          -DGAMMARAY_WITH_KDSME=${{ runner.os == 'Linux' }}
+          -DGAMMARAY_WITH_KDSME=${{ runner.os == 'Linux' && matrix.config.qt_version == "5.15" }}
           -DGAMMARAY_BUILD_DOCS=${{ runner.os == 'Linux' }}
 
       - name: Build Project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         # quickmaterialtest|quicktexturetest fails because of QT_QUICK_BACKEND=software AND QT_QPA_PLATFORM=offscreen
         # quickinspectortest|quickinspectortest2 fails at CI, local with 6.2.4 passes
       - name: Run tests on Linux Qt6 (offscreen)
-        if: ${{ runner.os == 'Linux' && matrix.config.qt_version == "5.15" }}
+        if: ${{ runner.os == 'Linux' && matrix.config.tests_with == 'qt6' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "quickmaterialtest|quicktexturetest|quickinspectortest|quickinspectortest2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
 
           - preset: ci-dev-client-and-ui-qt6
             qt_version: "6.5.*"
+            qt_modules: qtscxml
             tests_with: qt6
 
           - preset: ci-dev-probe-only-qt5
@@ -46,6 +47,7 @@ jobs:
 
           - preset: ci-dev-probe-only-qt6
             qt_version: "6.5.*"
+            qt_modules: qtscxml
 
     steps:
       - name: Install Qt with options and default aqtversion
@@ -102,7 +104,7 @@ jobs:
         # quickmaterialtest|quicktexturetest fails because of QT_QUICK_BACKEND=software AND QT_QPA_PLATFORM=offscreen
         # quickinspectortest|quickinspectortest2 fails at CI, local with 6.2.4 passes
       - name: Run tests on Linux Qt6 (offscreen)
-        if: ${{ runner.os == 'Linux' && matrix.config.tests_with == 'qt6' }}
+        if: ${{ runner.os == 'Linux' }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "quickmaterialtest|quicktexturetest|quickinspectortest|quickinspectortest2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Configure project
         run: >
           cmake -S . -G Ninja --preset ${{ matrix.config.preset }}
-          -DGAMMARAY_WITH_KDSME=${{ runner.os == 'Linux' && matrix.config.qt_version == "5.15" }}
+          -DGAMMARAY_WITH_KDSME=${{ runner.os == 'Linux' }}
           -DGAMMARAY_BUILD_DOCS=${{ runner.os == 'Linux' }}
 
       - name: Build Project
@@ -104,7 +104,7 @@ jobs:
         # quickmaterialtest|quicktexturetest fails because of QT_QUICK_BACKEND=software AND QT_QPA_PLATFORM=offscreen
         # quickinspectortest|quickinspectortest2 fails at CI, local with 6.2.4 passes
       - name: Run tests on Linux Qt6 (offscreen)
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && matrix.config.qt_version == "5.15" }}
         run: >
           ctest --test-dir ./build-${{ matrix.config.preset }} --output-on-failure
           --exclude-regex "quickmaterialtest|quicktexturetest|quickinspectortest|quickinspectortest2"

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -12,7 +12,7 @@ if(GAMMARAY_WITH_KDSME)
         # Function creates extra scope to keep these variables local
         set(BUILD_DOCS OFF)
         set(BUILD_EXAMPLES OFF)
-        set(BUILD_TESTS ON)
+        set(BUILD_TESTS OFF)
 
         set(KDSME_PACKAGE_NAME KDSME)
         if(QT_VERSION_MAJOR GREATER_EQUAL 6)

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -12,7 +12,7 @@ if(GAMMARAY_WITH_KDSME)
         # Function creates extra scope to keep these variables local
         set(BUILD_DOCS OFF)
         set(BUILD_EXAMPLES OFF)
-        set(BUILD_TESTS OFF)
+        set(BUILD_TESTS ON)
 
         set(KDSME_PACKAGE_NAME KDSME)
         if(QT_VERSION_MAJOR GREATER_EQUAL 6)


### PR DESCRIPTION
This works around the fact that Qt6StateMachine is missing from some of the Qt 6 Linux workers, causing CI to fail.