### PR TITLE
Make link clickable in Yama security error window

### DIFF
--- a/launcher/cli/main.cpp
+++ b/launcher/cli/main.cpp
@@ -344,9 +344,9 @@ int main(int argc, char **argv)
         QMessageBox errorBox;
         errorBox.setWindowTitle("Launcher Error");
         errorBox.setIcon(QMessageBox::Icon::Critical);
-        // errorBox.setTextFormat(Qt::MarkdownText);
+        errorBox.setTextFormat(Qt::MarkdownText);
         errorBox.setTextInteractionFlags(Qt::TextBrowserInteraction);
-        errorBox.setText(launcher.errorMessage() + "\nSee https://github.com/KDAB/GammaRay/wiki/Known-Issues for troubleshooting");
+        errorBox.setText(launcher.errorMessage() + "\nSee https://github.com/KDAB/GammaRay/wiki/Known-Issues for troubleshooting.");
         errorBox.exec();
 #endif
         return launcher.exitCode();


### PR DESCRIPTION
It is inconvenient to copy the link manually every time and pasting it in browser. Better make it clickable in window.

Before:

![before](https://github.com/KDAB/GammaRay/assets/22634975/9e6c191e-0a5e-4b61-954a-f0037f4e80d1)

After:

![after](https://github.com/KDAB/GammaRay/assets/22634975/63a46d8d-f9d7-4477-95bb-c0ca5d0cd0ed)

---

Please check if I missed some other place to replace `\n` with `<br>`.

I did not used the `errorBox.setTextFormat(Qt::MarkdownText);`, because it was removed with [this](https://github.com/KDAB/GammaRay/commit/bd6863392db92dac6130f46d5fb1e6c6ac32c1a7) commit to support building with Qt < 5.14. I do not know if this version is still needed by anyone, so I decided to use `Qt::RichText`.