### PR TITLE
pre-commit-config manual update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
-    skip: [clang-format]
     autoupdate_schedule: monthly
 
 exclude: ^(3rdparty/|cmake/ECM/|cmake/KDAB/|launcher/ui/processlist.*|compat/qasconst.h|docs/api/doxygen-awesome.css|launcher/cli/completions/gammaray.zsh|ui/resources/gammaray/update_icon_sets.sh)
@@ -26,7 +25,7 @@ repos:
   hooks:
   - id: clang-format
 - repo: https://github.com/PyCQA/pylint
-  rev: v3.2.4
+  rev: v3.2.7
   hooks:
   - id: pylint
     exclude: ^(.cmake-format.py|conan/.*/conanfile.py)
@@ -54,12 +53,12 @@ repos:
     language: ruby
     files: \.(md|mdown|markdown)$
 - repo: https://github.com/fsfe/reuse-tool
-  rev: v3.1.0a1
+  rev: v4.0.3
   hooks:
   - id: reuse
     args: [--suppress-deprecation]
 - repo: https://github.com/scop/pre-commit-shfmt
-  rev: v3.8.0-1
+  rev: v3.9.0-1
   hooks:
   - id: shfmt
 - repo: https://github.com/shellcheck-py/shellcheck-py


### PR DESCRIPTION
reenable pre-commit.ci running clang-format,
manually update components but clang-format
because v18 is broken for us