### PR TITLE
.clang-format - add StatementAttributeLikeMacros: [emit]

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -78,4 +78,5 @@ SpaceInEmptyParentheses: false
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: true
 SpacesInParentheses: false
+StatementAttributeLikeMacros: [emit]
 ...


### PR DESCRIPTION
"Macros which are ignored in front of a statement, as if they
were an attribute. So that they are not parsed as identifier,
for example for Qts emit."

As recommended in https://github.com/llvm/llvm-project/issues/99758

to fix the spaces around the arrow operator problem
