### PR TITLE
Fix build for Qt >= 6.9

### DIFF
--- a/core/remoteviewserver.cpp
+++ b/core/remoteviewserver.cpp
@@ -188,8 +188,12 @@ void RemoteViewServer::sendTouchEvent(int type, int touchDeviceType, int deviceC
     const QEventPoint::States states(touchPointStates);
     QTouchEvent event(QEvent::Type(type), m_touchDevice.get(), Qt::KeyboardModifiers(modifiers), states, touchPoints);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 9, 0))
+    QMutableTouchEvent::setTarget(&event, m_eventReceiver);
+#else
     auto *mut = QMutableTouchEvent::from(&event);
     mut->setTarget(m_eventReceiver);
+#endif
 #else
     if (!m_touchDevice) {
         // create our own touch device, the system may not have one already, or it may not have


### PR DESCRIPTION
QMutableTouchEvent::from was removed in qtbase commit [1]

    commit e9cabe22c1e7ae64e48690b7dada2b83161e6340
    Author: Allan Sandfeld Jensen <allan.jensen@qt.io>
    Date:   Tue Nov 12 16:25:28 2024 +0100

        QMutable{Touch,SinglePoint}Event: Remove unsafe from() getters

        The getters were used to convert types in an undefined manner.
        No usage of the methods outside of qtbase (Qt and KDE searched)
        has been found, and qtbase is already fixed.

        Change-Id: I9fe77de842a2e0023b011e6eee257d6c6a28a3f5
        Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>

For Qt >= 6.9, use the API introduced in [2]

    commit acc3ef6653c710b509e9321663986910f88ac3b4
    Author: Allan Sandfeld Jensen <allan.jensen@qt.io>
    Date:   Tue Nov 12 12:34:15 2024 +0100

        Fix ubsan warning of illegal cast and illegal method call

        Avoid casting an event to a type it does not have. Instead use a static accessor class.

        Pick-to: 6.8
        Task-number: QTBUG-99563
        Change-Id: Ideb11779b1510cd10a27fb8bc40bcc8e4849bf15
        Reviewed-by: Marc Mutz <marc.mutz@qt.io>

instead.

[1] https://code.qt.io/cgit/qt/qtbase.git/commit/?id=e9cabe22c1e7ae64e48690b7dada2b83161e6340
[2] https://code.qt.io/cgit/qt/qtbase.git/commit/?id=acc3ef6653c710b509e9321663986910f88ac3b4