### PR TITLE
Fix the OpenGLScreenGrabber for QQuickWidgetOffscreenWindow in Qt6.8+

### DIFF
--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -633,14 +633,19 @@ void OpenGLScreenGrabber::windowAfterRendering()
             const auto viewportHeight = viewport[3];
             yOff = viewportHeight - windowBottom;
 #else
-            const auto windowBottom = m_renderInfo.windowSize.height();
             const auto rc = QQuickWindowPrivate::get(m_window)->renderControl;
             QPoint offset;
             rc->renderWindow(&offset);
 
-            const auto viewportHeight = viewport[3];
-            yOff = viewportHeight - windowBottom - offset.y();
             xOff = offset.x();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+            yOff = 0;
+            xOff = static_cast<int>(std::floor(xOff * m_renderInfo.dpr));
+#else
+            const auto viewportHeight = viewport[3];
+            const auto windowBottom = m_renderInfo.windowSize.height();
+            yOff = viewportHeight - windowBottom - offset.y();
+#endif
 #endif
         }
 #endif


### PR DESCRIPTION
For me at least, the y offset has to be 0, otherwise we grab an offset part of the image. Furthermore, the x offset has to be hidpi adapted too.

I cannot test the other Qt versions, so I'll assume this code used to work fine there and only touch this for Qt 6.8+