### PR TITLE
Only pan when just the control modifier is pressed

### DIFF
--- a/ui/remoteviewwidget.cpp
+++ b/ui/remoteviewwidget.cpp
@@ -1013,7 +1013,7 @@ void RemoteViewWidget::mousePressEvent(QMouseEvent *event)
     if (m_interactionMode != NoInteraction
         && m_interactionMode != ViewInteraction
         && event->buttons() & Qt::LeftButton
-        && event->modifiers() & Qt::ControlModifier) {
+        && event->modifiers() == Qt::ControlModifier) {
 
         pan();
     } else {
@@ -1125,7 +1125,7 @@ void RemoteViewWidget::mouseMoveEvent(QMouseEvent *event)
 
     if (m_interactionMode != NoInteraction
         && event->buttons() & Qt::LeftButton
-        && event->modifiers() & Qt::ControlModifier) {
+        && event->modifiers() == Qt::ControlModifier) {
 
         pan();
     } else {


### PR DESCRIPTION
I.e. don't eat the event when ctrl+shift is clicked, at which point we want to bring up the extended "pick element" dialog instead.