### PR TITLE
Revive the RenderModeRequest::apply for Qt6

### DIFF
--- a/plugins/quickinspector/quickinspector.cpp
+++ b/plugins/quickinspector/quickinspector.cpp
@@ -301,11 +301,6 @@ void RenderModeRequest::apply()
     if (connection)
         disconnect(connection);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // crashes in qrhigles2..bindShaderResources sometimes
-    return;
-#endif
-
     if (window && window->rendererInterface()->graphicsApi() != QSGRendererInterface::OpenGL)
         return;
 


### PR DESCRIPTION
This was disabled in the original port in patch b1e8e7fd5b. In my own testing, it works fine nowadays, so let's re-enable it instead of silently disabling the code in a non-obvious way.