### PR TITLE
Allow inspector window to fit in low resolution displays using high DPI

### DIFF
--- a/plugins/fontbrowser/fontbrowserwidget.ui
+++ b/plugins/fontbrowser/fontbrowserwidget.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="QSplitter" name="mainSplitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <widget class="QWidget" name="widget" native="true">
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -88,7 +88,10 @@
           <item>
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Point Size:</string>
+             <string>Point size:</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -97,29 +100,47 @@
           </item>
           <item>
            <widget class="QCheckBox" name="boldBox">
+            <property name="minimumSize">
+             <size>
+              <width>28</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="text">
-             <string>Bold</string>
+             <string>&amp;Bold</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="italicBox">
+            <property name="minimumSize">
+             <size>
+              <width>28</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="text">
-             <string>Italic</string>
+             <string>&amp;Italic</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="underlineBox">
+            <property name="minimumSize">
+             <size>
+              <width>28</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="text">
-             <string>Underline</string>
+             <string>&amp;Underline</string>
             </property>
            </widget>
           </item>
           <item>
            <spacer name="horizontalSpacer">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>

--- a/plugins/modelinspector/modelinspectorwidget.cpp
+++ b/plugins/modelinspector/modelinspectorwidget.cpp
@@ -123,12 +123,13 @@ static const MetaEnum::Value<Qt::ItemFlag> item_flag_table[] = {
 void ModelInspectorWidget::cellDataChanged()
 {
     const auto cellData = m_interface->currentCellData();
-    ui->indexLabel->setText(cellData.row != -1
-                                ? tr("Row: %1 Column: %2").arg(cellData.row).arg(cellData.column)
-                                : tr("Invalid"));
-    ui->internalIdLabel->setText(cellData.internalId);
-    ui->internalPtrLabel->setText(cellData.internalPtr);
-    ui->flagsLabel->setText(MetaEnum::flagsToString(cellData.flags, item_flag_table));
+    ui->indexLineEdit->setText(cellData.row != -1
+                                   ? tr("Row: %1 Column: %2").arg(cellData.row).arg(cellData.column)
+                                   : tr("Invalid"));
+    ui->internalIdLineEdit->setText(cellData.internalId);
+    ui->internalPtrLineEdit->setText(cellData.internalPtr);
+    ui->flagsPlainTextEdit->selectAll();
+    ui->flagsPlainTextEdit->insertPlainText(MetaEnum::flagsToString(cellData.flags, item_flag_table));
 }
 
 void ModelInspectorWidget::objectRegistered(const QString &objectName)

--- a/plugins/modelinspector/modelinspectorwidget.ui
+++ b/plugins/modelinspector/modelinspectorwidget.ui
@@ -14,11 +14,11 @@
    <item>
     <widget class="QSplitter" name="mainSplitter">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <widget class="QSplitter" name="modelSplitter">
       <property name="orientation">
-       <enum>Qt::Vertical</enum>
+       <enum>Qt::Orientation::Vertical</enum>
       </property>
       <widget class="QWidget" name="layoutWidget_3">
        <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -28,7 +28,7 @@
            <string>Models</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -38,7 +38,7 @@
         <item>
          <widget class="GammaRay::DeferredTreeView" name="modelView">
           <property name="contextMenuPolicy">
-           <enum>Qt::CustomContextMenu</enum>
+           <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
           </property>
           <property name="uniformRowHeights">
            <bool>true</bool>
@@ -47,7 +47,7 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="">
+      <widget class="QWidget" name="layoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
          <widget class="QLabel" name="label_6">
@@ -55,14 +55,14 @@
            <string>Selection Models</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
         <item>
          <widget class="GammaRay::DeferredTreeView" name="selectionModelsView">
           <property name="contextMenuPolicy">
-           <enum>Qt::CustomContextMenu</enum>
+           <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
           </property>
           <property name="rootIsDecorated">
            <bool>false</bool>
@@ -75,7 +75,7 @@
        </layout>
       </widget>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QLabel" name="label">
@@ -83,20 +83,20 @@
           <string>Model Content</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
        <item>
         <widget class="GammaRay::DeferredTreeView" name="modelContentView">
          <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectItems</enum>
+          <enum>QAbstractItemView::SelectionBehavior::SelectItems</enum>
          </property>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QLabel" name="label_2">
@@ -104,7 +104,7 @@
           <string>Cell Content</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -112,55 +112,137 @@
         <layout class="QFormLayout" name="formLayout_2">
          <item row="0" column="0">
           <widget class="QLabel" name="label_8">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
-            <string>Model Index:</string>
+            <string>Model index:</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QLabel" name="indexLabel">
+          <widget class="QLineEdit" name="indexLineEdit">
+           <property name="minimumSize">
+            <size>
+             <width>72</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Invalid</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
           <widget class="QLabel" name="label_4">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
-            <string>Internal Id:</string>
+            <string>Internal id:</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLabel" name="internalIdLabel">
-           <property name="text">
-            <string/>
+          <widget class="QLineEdit" name="internalIdLineEdit">
+           <property name="minimumSize">
+            <size>
+             <width>72</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="2" column="0">
           <widget class="QLabel" name="label_5">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
-            <string>Internal Pointer:</string>
+            <string>Internal pointer:</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QLabel" name="internalPtrLabel">
-           <property name="text">
-            <string/>
+          <widget class="QLineEdit" name="internalPtrLineEdit">
+           <property name="minimumSize">
+            <size>
+             <width>72</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item row="3" column="0">
           <widget class="QLabel" name="label_7">
+           <property name="minimumSize">
+            <size>
+             <width>55</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Flags:</string>
            </property>
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QLabel" name="flagsLabel"/>
+          <widget class="QPlainTextEdit" name="flagsPlainTextEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>72</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="acceptDrops">
+            <bool>false</bool>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+           </property>
+           <property name="undoRedoEnabled">
+            <bool>false</bool>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+           <property name="plainText">
+            <string notr="true"/>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/ui/propertyeditor/propertyeditorfactory.cpp
+++ b/ui/propertyeditor/propertyeditorfactory.cpp
@@ -79,6 +79,7 @@ QWidget *PropertyEditorFactory::createEditor(TypeId type, QWidget *parent) const
 
     // the read-only view is still in the background usually, so transparency is not a good choice here
     w->setAutoFillBackground(true);
+    w->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     return w;
 }
 

--- a/ui/tools/messagehandler/messagehandlerwidget.ui
+++ b/ui/tools/messagehandler/messagehandlerwidget.ui
@@ -10,7 +10,7 @@
     <height>426</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -24,7 +24,7 @@
        <item>
         <widget class="QSplitter" name="mainSplitter">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <widget class="QWidget" name="layoutWidget">
           <layout class="QVBoxLayout" name="verticalLayout">
@@ -34,7 +34,7 @@
            <item>
             <widget class="GammaRay::DeferredTreeView" name="messageView">
              <property name="contextMenuPolicy">
-              <enum>Qt::CustomContextMenu</enum>
+              <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
              </property>
              <property name="rootIsDecorated">
               <bool>false</bool>
@@ -45,7 +45,7 @@
          </widget>
          <widget class="GammaRay::DeferredTreeView" name="backtraceView">
           <property name="contextMenuPolicy">
-           <enum>Qt::CustomContextMenu</enum>
+           <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
           </property>
           <property name="rootIsDecorated">
            <bool>false</bool>
@@ -62,48 +62,82 @@
       <attribute name="title">
        <string>Categories</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="2" column="0" colspan="4">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Sunken</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents_3">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>730</width>
+            <height>68</height>
+           </rect>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QPushButton" name="saveAllConf">
+             <property name="text">
+              <string>Save All Logging Config</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="saveModConf">
+             <property name="text">
+              <string>Save Modified Logging Config</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="copyModConf">
+             <property name="text">
+              <string>Copy Modified Config for Env Var</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>328</width>
+               <height>14</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+       <item>
         <widget class="GammaRay::DeferredTreeView" name="categoriesView">
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+         </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
          <property name="uniformRowHeights">
           <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QPushButton" name="saveAllConf">
-         <property name="text">
-          <string>Save All Logging Config</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="0">
-        <widget class="QPushButton" name="saveModConf">
-         <property name="text">
-          <string>Save Modified Logging Config</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="copyModConf">
-         <property name="text">
-          <string>Copy Modified Config for Env Var</string>
          </property>
         </widget>
        </item>

--- a/ui/tools/objectinspector/propertiestab.cpp
+++ b/ui/tools/objectinspector/propertiestab.cpp
@@ -104,7 +104,7 @@ void PropertiesTab::updateNewPropertyValueEditor()
     const PropertyEditorFactory::TypeId type = selectedTypeId(m_ui->newPropertyType);
 
     m_newPropertyValue = PropertyEditorFactory::instance()->createEditor(type, this);
-    static_cast<QHBoxLayout *>(m_ui->newPropertyBar->layout())->insertWidget(5, m_newPropertyValue);
+    static_cast<QHBoxLayout *>(m_ui->newPropertyBar->layout())->insertWidget(3, m_newPropertyValue);
     m_ui->newPropertyValueLabel->setBuddy(m_newPropertyValue);
 }
 

--- a/ui/tools/objectinspector/propertiestab.ui
+++ b/ui/tools/objectinspector/propertiestab.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="GammaRay::DeferredTreeView" name="propertyView">
      <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
+      <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
      </property>
      <property name="rootIsDecorated">
       <bool>false</bool>
@@ -25,15 +25,15 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="newPropertyBar" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
-       <number>0</number>
-      </property>
+    <widget class="QWidget" name="horizontalWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
          <string>&amp;New Dynamic Property:</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
         <property name="buddy">
          <cstring>newPropertyName</cstring>
@@ -47,8 +47,23 @@
         </property>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="newPropertyBar" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="margin" stdset="0">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QLabel" name="label_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>&amp;Type:</string>
         </property>
@@ -58,23 +73,36 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="newPropertyType"/>
+       <widget class="QComboBox" name="newPropertyType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QLabel" name="newPropertyValueLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
          <string>&amp;Value:</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QPushButton" name="newPropertyButton">
-        <property name="text">
-         <string>Add</string>
-        </property>
-       </widget>
-      </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="newPropertyButton">
+     <property name="text">
+      <string>Add</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Allows the following sections to shrink better:
- Object tab (PropertiesTab)
- Messages tab (MessageHandlerWidget)
- Font browser (FontBrowserWidget)
- Models tab (ModelInspectorWidget)

Fixes `value` field in PropertiesTab not being accessible at small pane widths.

Improves Models tab by allowing data that was previously drawn on labels to be copied.

Solves #358
