### PR TITLE
Fix remote decoration drawing on OpenGL

### DIFF
--- a/plugins/quickinspector/quickscreengrabber.cpp
+++ b/plugins/quickinspector/quickscreengrabber.cpp
@@ -577,8 +577,7 @@ OpenGLScreenGrabber::OpenGLScreenGrabber(QQuickWindow *window)
 #endif
         this,
         &OpenGLScreenGrabber::windowAfterRendering,
-        Qt::DirectConnection
-    );
+        Qt::DirectConnection);
 }
 
 OpenGLScreenGrabber::~OpenGLScreenGrabber() = default;


### PR DESCRIPTION
On Qt 6.8 enabling the "decorate target" button doesn't do anything. If we have to inject custom GL commands, we have to inform QtQuick that we're doing so, so wrap our after-rendering screengrab and overlay drawing in the appropriate calls.
Also, apparently can only be done while a pass is being recorded, so switch the connect() from afterRendering (pass has been recorded and finished, but not submitted) to afterRenderPassRecording (QQ2 has drawn itself but the pass is still active).