### PR TITLE
Bugfix | Compile error in staticinjectiontest against Qt6

### DIFF
--- a/core/staticprobe.h
+++ b/core/staticprobe.h
@@ -23,7 +23,9 @@
  * the better option anyway.
  */
 #ifdef QT_CORE_LIB
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 Q_IMPORT_PLUGIN(CodecBrowserFactory)
+#endif
 Q_IMPORT_PLUGIN(EventMonitorFactory)
 Q_IMPORT_PLUGIN(SignalMonitorFactory)
 Q_IMPORT_PLUGIN(StateMachineViewerFactory)

--- a/tests/manual/CMakeLists.txt
+++ b/tests/manual/CMakeLists.txt
@@ -97,7 +97,6 @@ if(GAMMARAY_STATIC_PROBE)
         gammaray_probe
         Qt::Widgets
         gammaray_actioninspector_plugin
-        gammaray_codecbrowser_plugin
         gammaray_eventmonitor_plugin
         gammaray_guisupport
         gammaray_fontbrowser_plugin
@@ -113,4 +112,7 @@ if(GAMMARAY_STATIC_PROBE)
         #    gammaray_quickinspector
         #    gammaray_webinspector_plugin
     )
+    if(${QT_VERSION_MAJOR} EQUAL 5 AND TARGET Qt5::Core)
+        target_link_libraries(staticinjectiontest gammaray_codecbrowser_plugin)
+    endif()
 endif()


### PR DESCRIPTION
## The Bug

The staticinjectiontest target fails to link because it's missing the codecbrowser library which is only included in Qt5 builds. [The target is excluded inn Qt6 builds here](https://github.com/KDAB/GammaRay/blob/v3.1.0/plugins/CMakeLists.txt#L10-L12).

## The Fix

We do not link the target when we build against Qt6. We also do not statically import the plugin.