### PR TITLE
Fix uninitialized field

### DIFF
--- a/launcher/ui/processlist.h
+++ b/launcher/ui/processlist.h
@@ -42,7 +42,7 @@
 
 struct ProcData
 {
-    qint64 ppid;
+    qint64 ppid = 0;
     QString name;
     QString image;
     QString state;


### PR DESCRIPTION
We must initialize it for obvious reasons and so that the bad values can actually get filtered out.