### PR TITLE
ci: Fix tests on Windows

### DIFF
--- a/tests/launcheruiprocesslisttest.cpp
+++ b/tests/launcheruiprocesslisttest.cpp
@@ -32,10 +32,14 @@ private slots:
         QVERIFY(!newList.isEmpty());
 
         const auto &proc = newList[0];
+
+#ifndef Q_OS_WIN
         QVERIFY(proc.ppid != 0);
-        QVERIFY(!proc.name.isEmpty());
         QVERIFY(!proc.state.isEmpty());
         QVERIFY(!proc.user.isEmpty());
+#endif
+
+        QVERIFY(!proc.name.isEmpty());
     }
 };
 


### PR DESCRIPTION
This test was added recently but didn't pass CI on Windows.
Relax it on Windows, as processList() can return processes without user, state and even with pid 0 (system process)