### PR TITLE
cmake: Use RelWithDebInfo instead of Release for dev preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,7 @@
             "displayName": "dev",
             "cacheVariables": {
                 "QT_VERSION_MAJOR": "5",
-                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "GAMMARAY_USE_PCH": "ON"
             }
         },
@@ -28,7 +28,7 @@
             "inherits": "base",
             "cacheVariables": {
                 "QT_VERSION_MAJOR": "6",
-                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "GAMMARAY_USE_PCH": "ON"
             }
         },


### PR DESCRIPTION
Another option would be Debug, but seems CI depends on Release.
Would need refactoring, mayeb introduce ci-base