### PR TITLE
Fix (issue 1064: Build fails on macOS M1 Pro with Qt 6.5.2)

### DIFF
--- a/plugins/positioning/positioningwidget.cpp
+++ b/plugins/positioning/positioningwidget.cpp
@@ -29,6 +29,8 @@
 #include <QQuickWidget>
 #include <QQmlContext>
 
+#include <memory>
+
 using namespace GammaRay;
 
 static QObject *createPositioningClient(const QString &name, QObject *parent)
@@ -156,7 +158,8 @@ void PositioningWidget::loadNmeaFile()
     if (fileName.isEmpty())
         return;
 
-    QScopedPointer<QFile> file(new QFile(fileName, this));
+    //QScopedPointer<QFile> file(new QFile(fileName, this));
+    std::unique_ptr<QFile> file = std::make_unique<QFile>(fileName, this);
     if (!file->open(QFile::ReadOnly)) {
         QMessageBox::critical(this, tr("Failed to open NMEA file"), tr("Could not open '%1': %2.").arg(fileName, file->errorString()));
         return;
@@ -169,7 +172,8 @@ void PositioningWidget::loadNmeaFile()
     }
 
     m_replaySource = new QNmeaPositionInfoSource(QNmeaPositionInfoSource::SimulationMode, this);
-    m_replaySource->setDevice(file.take());
+    //m_replaySource->setDevice(file.take());           -----> the line that cause the issue
+    m_replaySource->setDevice(file.release()); 
     connect(m_replaySource, &QGeoPositionInfoSource::positionUpdated, this, &PositioningWidget::replayPosition);
     m_replaySource->startUpdates();
     connect(m_replaySource, &QGeoPositionInfoSource::errorOccurred, this, &PositioningWidget::nmeaError);


### PR DESCRIPTION
This pull request fixes the build failure on macOS M1 Pro when using Qt 6.5.2 by replacing the deprecated QScopedPointer::take() with std::unique_ptr and using release() instead.

This change ensures compatibility with Qt 6.5.2 and modern C++ standards, resolving the compilation errors and allowing the app to build successfully.

Tested the build on macOS M1 Pro with Qt 6.5.2, and it completes without errors.