### PR TITLE
Fix infinite in loop QuickSceneGraphModel::itemForSgNode()

### DIFF
--- a/plugins/quickinspector/quickscenegraphmodel.cpp
+++ b/plugins/quickinspector/quickscenegraphmodel.cpp
@@ -416,7 +416,11 @@ QQuickItem *QuickSceneGraphModel::itemForSgNode(QSGNode *node) const
     while (node && !contains(m_itemNodeItemMap, node)) {
         // If there's no entry for node, take its parent
         auto it = m_childParentMap.find(node);
-        if (it != m_childParentMap.end()) {
+        if (it == m_childParentMap.end()) {
+            // Can happen if the node belongs to another window and itemForSgNode() gets
+            // called during window selection change
+            return nullptr;
+        } else {
             node = it->second;
         }
     }


### PR DESCRIPTION
Window selection triggers lots of model and selection updates, which are not atomic. It can happen that itemForSgNode() is called with the old selected node from the old window, since it wasn't updated yet.

We could also attempt to prevent it from being called with old sg node, but it's benign, since SG selection is processed right after.

For issue #1070