### PR TITLE
Fix infinite in loop QuickSceneGraphModel::itemForSgNode()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Release Highlights
 ==================
 
+Version 3.2.1
+-------------
+ * Fix infinite in loop QuickSceneGraphModel::itemForSgNode() (#1070)
+
 Version 3.2.0
 -------------
  * Source tarballs no longer ship 60MB of KDStateMachineEditor/Graphviz Windows dll binaries

--- a/plugins/quickinspector/quickscenegraphmodel.cpp
+++ b/plugins/quickinspector/quickscenegraphmodel.cpp
@@ -416,7 +416,11 @@ QQuickItem *QuickSceneGraphModel::itemForSgNode(QSGNode *node) const
     while (node && !contains(m_itemNodeItemMap, node)) {
         // If there's no entry for node, take its parent
         auto it = m_childParentMap.find(node);
-        if (it != m_childParentMap.end()) {
+        if (it == m_childParentMap.end()) {
+            // Can happen if the node belongs to another window and itemForSgNode() gets
+            // called during window selection change
+            return nullptr;
+        } else {
             node = it->second;
         }
     }


### PR DESCRIPTION
cherry-picking for the 3.2.1 release