### PR TITLE
ci: Don't require awkward msvc 2008 dependency with MinGW

### DIFF
--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -17,6 +17,14 @@ on:
         branches:
             - master
 
+    workflow_dispatch:
+        inputs:
+            debug_enabled:
+                type: boolean
+                description: "Enable ssh for debugging purposes"
+                required: false
+                default: false
+
 jobs:
     build:
         runs-on: windows-latest
@@ -36,6 +44,12 @@ jobs:
                       runs_tests: false
 
         steps:
+            - name: Setup tmate session
+              if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+              uses: mxschmitt/action-tmate@v3
+              with:
+                  detached: true
+
             - name: Install Qt with options and default aqtversion
               uses: jurplel/install-qt-action@v4
               with:

--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -27,12 +27,13 @@ jobs:
                     - "6.9.0"
                 preset:
                     - name: ci-dev-client-only-qt6
-                      tests_with: qt6
+                      runs_tests: true
 
                     - name: ci-dev-client-and-ui-qt6
-                      tests_with: qt6
+                      runs_tests: true
 
                     - name: ci-dev-probe-only-qt6
+                      runs_tests: false
 
         steps:
             - name: Install Qt with options and default aqtversion
@@ -74,14 +75,11 @@ jobs:
             - name: Build Project
               run: cmake --build ./build-${{ matrix.preset.name }}
 
-            # Exclude
-            # quicktexturetest
-            # TODO: We don't support running tests yet
-            # - name: Qt6 Run tests on Windows
-            #   if: ${{ runner.os == 'Windows' && matrix.preset.tests_with == 'qt6' }}
-            #   run: >
-            #       ctest --test-dir ./build-${{ matrix.preset.name }} -C 'Release' --output-on-failure
-            #       --exclude-regex "quicktexturetest|launchertest|probesettingstest"
+            - name: Run tests
+              if: ${{ matrix.preset.runs_tests }}
+              run: >
+                  ctest --test-dir ./build-${{ matrix.preset.name }} -C 'Release' --output-on-failure
+                  --exclude-regex "^(quicktexturetest|probeabidetectortest|launchertest|clientconnectiontest|probesettingstest)$"
 
             - name: Read tests log when it fails
               uses: andstor/file-reader-action@v1

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -244,7 +244,9 @@ if(TARGET Qt::AndroidExtras)
     target_link_libraries(gammaray_core PRIVATE Qt::AndroidExtras)
 endif()
 
-add_backward(gammaray_core)
+if(NOT (WIN32 AND NOT MSVC)) # not working in MinGW
+    add_backward(gammaray_core)
+endif()
 
 if(NOT GAMMARAY_PROBE_ONLY_BUILD)
     install(


### PR DESCRIPTION
Most MinGW tests now pass, so enable them.

For #959 and #1074