### PR TITLE
Fix GammaRay GUI not showing up on Windows

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 3.3.0
 -------------
  * Drop Qt 5 support, minimum is 6.5 now
  * Add support for LLVM MinGW on Windows
+ * Fix GammaRay UI not appearing sometimes on Windows
  * Update LZ4 to v1.10.0
 
 Version 3.2.1

--- a/core/probesettings.cpp
+++ b/core/probesettings.cpp
@@ -139,7 +139,7 @@ void ProbeSettingsReceiver::readyRead()
     }
 }
 
-inline void waitForBytesWritten(QLocalSocket &socket)
+static void waitForBytesWritten(QLocalSocket &socket)
 {
     while (socket.state() == QLocalSocket::ConnectedState && socket.bytesToWrite() > 0) {
         if (!socket.waitForBytesWritten()) {

--- a/core/probesettings.cpp
+++ b/core/probesettings.cpp
@@ -139,6 +139,16 @@ void ProbeSettingsReceiver::readyRead()
     }
 }
 
+inline void waitForBytesWritten(QLocalSocket &socket)
+{
+    while (socket.state() == QLocalSocket::ConnectedState && socket.bytesToWrite() > 0) {
+        if (!socket.waitForBytesWritten()) {
+            qWarning() << Q_FUNC_INFO << "Failed to wait for bytes written";
+            break;
+        }
+    }
+}
+
 void ProbeSettingsReceiver::sendServerAddress(const QUrl &address)
 {
     if (!m_socket || m_socket->state() != QLocalSocket::ConnectedState)
@@ -148,7 +158,7 @@ void ProbeSettingsReceiver::sendServerAddress(const QUrl &address)
     msg << address;
     msg.write(m_socket);
 
-    m_socket->waitForBytesWritten();
+    waitForBytesWritten(*m_socket);
     m_socket->close();
 
     deleteLater();
@@ -165,7 +175,7 @@ void ProbeSettingsReceiver::sendServerLaunchError(const QString &reason)
     msg << reason;
     msg.write(m_socket);
 
-    m_socket->waitForBytesWritten();
+    waitForBytesWritten(*m_socket);
     m_socket->close();
 
     deleteLater();

--- a/launcher/core/launcher.cpp
+++ b/launcher/core/launcher.cpp
@@ -355,25 +355,27 @@ void Launcher::newConnection()
 
 void Launcher::readyRead()
 {
-    while (Message::canReadMessage(d->socket)) {
-        const auto msg = Message::readMessage(d->socket);
-        switch (msg.type()) {
-        case Protocol::ServerAddress: {
-            msg >> d->serverAddress;
-            break;
-        }
-        case Protocol::ServerLaunchError: {
-            QString reason;
-            msg >> reason;
-            std::cerr << "Failed to start server: " << qPrintable(reason)
-                      << std::endl;
-            // TODO emit error signal to also notify qtcreator, etc
-            break;
-        }
-        default:
-            continue;
-        }
+    if (!Message::canReadMessage(d->socket)) {
+        // it's a partial write, wait for rest of message
+        return;
     }
+
+    const auto msg = Message::readMessage(d->socket);
+    switch (msg.type()) {
+    case Protocol::ServerAddress: {
+        msg >> d->serverAddress;
+        break;
+    }
+    case Protocol::ServerLaunchError: {
+        QString reason;
+        msg >> reason;
+        std::cerr << "Failed to start server: " << qPrintable(reason)
+                  << std::endl;
+        // TODO emit error signal to also notify qtcreator, etc
+        break;
+    }
+    }
+
 
     if (d->serverAddress.isEmpty())
         return;


### PR DESCRIPTION
The target sends the TCP address via a QLocalSocket, but Windows is very prone to partial writes.

Ensure all bytes are written before closing the socket.

Simplified the launcher code, no need to use a while, as the target only sends 1 message. Ignore the readyRead that contain partial writes.

Related to some comments in issue #959