### PR TITLE
ci: Ask aqtinstall for 'latest' instead of we bumping manually

### DIFF
--- a/.github/workflows/build-qt6.yml
+++ b/.github/workflows/build-qt6.yml
@@ -26,7 +26,7 @@ jobs:
           - macos-latest
         qt_version:
           - "6.5.*"
-          - "6.10.0" # bump to latest Qt freely
+          - "6" # this is always the latest Qt6
         preset:
           - name: ci-dev-client-only
             tests_with: qt6


### PR DESCRIPTION
We have a fixed Qt (6.5) and a floating one which we bump whenever a new Qt is released. But 'latest' should work and avoid us manual work.