### PR TITLE
fix: resolve root path via symlink targets

### DIFF
--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -60,7 +60,8 @@ void setRootPath(const QString &rootPath)
 void setRelativeRootPath(const char *relativeRootPath)
 {
     Q_ASSERT(relativeRootPath);
-    setRootPath(QCoreApplication::applicationDirPath() + QDir::separator()
+    setRootPath(QFileInfo(QCoreApplication::applicationFilePath()).canonicalPath()
+                + QDir::separator()
                 + QLatin1String(relativeRootPath));
 }
 


### PR DESCRIPTION
When GammaRay is invoked through a symlinked executable, `QCoreApplication::applicationDirPath()` points at the symlink directory. Resolve the executable path first so relative root paths are based on the real executable location.

This helps downstream package layouts that link the executable from a separate prefix while keeping the Qt plugin/root layout beside the real binary.

AI-assisted contribution by OpenAI Codex. Codex just opened the pr. The 3 lines were done by my brain.